### PR TITLE
[codex] Tone down docs and credit origin

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,13 +1,13 @@
 # DESIGN — The Architect Loop v2
 
-**A research-backed design for a Claude Code harness skill in which Claude Fable 5
+**A source-backed design for a Claude Code harness skill in which Claude Fable 5
 (high effort) acts as architect/orchestrator and GPT-5.5 via Codex CLI (xhigh
 reasoning) acts as builder, with the repo as the only memory.**
 
 Researched June 2026 from Anthropic engineering posts, the official Fable 5 and
-Codex CLI documentation, and the most-used community harness skills. Every
-prescription below cites its source. This document is the "why"; the skill files
-in `skills/architect/` are the "how".
+Codex CLI documentation, and widely used community harness skills. Prescriptive
+claims below cite their sources. This document is the "why"; the skill files in
+`skills/architect/` are the "how".
 
 ---
 
@@ -28,27 +28,28 @@ Single-agent coding sessions degrade in three predictable ways:
 3. **Goalpost drift** — acceptance criteria written (or edited) after results
    exist always pass.
 
-The fix that every serious source converged on independently — Anthropic's
+The sources surveyed point to the same basic shape — Anthropic's
 [harness design post](https://www.anthropic.com/engineering/harness-design-long-running-apps),
-obra/superpowers' subagent-driven development, the Ralph loop, GitHub Spec Kit —
-is the same shape:
+obra/superpowers' subagent-driven development, the Ralph loop, and GitHub Spec
+Kit:
 
 > **Separate planning context from execution context. Persist state in the repo,
 > not the conversation. Dispatch fresh-context workers per task. Verify with an
 > agent that didn't write the code.**
 
 This loop adds one more separation on top: **cross-vendor judgment**. The builder
-and the judge are different models from different labs, which removes same-model
-sycophancy bias from review ([OpenAI's own pitch for the Codex↔Claude
-bridge](https://www.mindstudio.ai/blog/openai-codex-plugin-claude-code-cross-provider-review))
-and lets each model do what it measurably does best: GPT-5.5 leads Terminal-Bench
-2.0 (82.7%) for hands-on building; Fable 5 is Anthropic's strongest long-horizon
-judgment model, with ~3× gains on complex tasks when paired with persistent
-file-based memory ([Fable 5 announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)).
+and the judge are different models from different labs, which reduces
+same-model review bias ([OpenAI's own pitch for the Codex↔Claude
+bridge](https://www.mindstudio.ai/blog/openai-codex-plugin-claude-code-cross-provider-review)).
+The split also lines up with available benchmark claims: GPT-5.5 leads
+Terminal-Bench 2.0 (82.7%) for hands-on terminal work, while Anthropic positions
+Fable 5 for long-horizon judgment and persistent file-based memory
+([Fable 5 announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)).
 
-The economics also work: judgment minutes on the expensive model, typing hours on
-the flat-rate one. Community measurements of orchestrator/worker splits report
-58–74% cost savings versus running the top model end-to-end
+The economics are another reason for the split: judgment minutes on the expensive
+model, typing hours on the flat-rate one. Community measurements of
+orchestrator/worker splits report 58–74% lower cost versus running the top model
+end-to-end
 ([Fable 5 Orchestrator Playbook](https://www.developersdigest.tech/blog/fable-5-orchestrator-model-playbook)).
 
 ---
@@ -83,7 +84,7 @@ the spec records explicitly.
 
 ## 3. The twelve design rules
 
-Each rule below is enforced mechanically by the skill, not left to vibes.
+Each rule below is enforced mechanically by the skill, not left as advice.
 
 ### R1. Repo docs are the memory; not in `HANDOFF.md` = didn't happen
 Anthropic's long-running-agent harnesses use a progress file + git history as
@@ -170,7 +171,7 @@ git worktree per agent, and a practical ceiling of 2–4 lanes before coordinati
 overhead dominates ([Intility engineering](https://engineering.intility.com/article/agent-teams-or-how-i-learned-to-stop-worrying-about-merge-conflicts-and-love-git-worktrees),
 [MindStudio worktrees](https://www.mindstudio.ai/blog/git-worktrees-parallel-ai-coding-agents)).
 **The architect — not Codex — owns the fan-out.** The spec splits the slice
-into 1–4 lanes with provably disjoint file sets; each lane is an isolated
+into 1–4 lanes whose file sets are checked for overlap; each lane is an isolated
 worktree running its own `codex exec` process, writing its own lane report
 (`docs/lanes/`); the architect runs per-lane boundary checks (`git status`
 must show only declared files), commits each passing lane, and merges
@@ -349,8 +350,8 @@ so it must be deliberately invoked, never a side-effect. The loop's step 3
 routes: discovery scale → `/architect-research`; narrow slice facts → the
 inline fan-out above.
 
-`/architect-research` encodes the methodology the best deep-research systems
-converged on. As of v2.3 the decomposition is **scout-first and
+`/architect-research` encodes the methodology found across the surveyed
+deep-research systems. As of v2.3 the decomposition is **scout-first and
 topic-designed, not a fixed lane taxonomy** — a 2026-06 evidence review found
 all five production deep-research systems (OpenAI DR, Anthropic, Gemini,
 Perplexity, Kimi) use adaptive planner-driven decomposition and none uses
@@ -365,7 +366,7 @@ became a tactics library the orchestrator draws from when designing lanes:
   codex scout (~10 searches) maps terminology, load-bearing
   systems, named people, and the topic's natural fault lines; the architect
   then designs 3–6 topic-specific lanes from that map. Source-derived
-  perspective discovery is STORM's biggest measured lever (unique references
+  perspective discovery was STORM's largest measured lever (unique references
   99.83 vs 54.36 without it); Anthropic's lead agent and OpenAI/Gemini's
   user-visible research plans are the production analogs. Comparisons and
   fact-finds skip the scout — recon that tells you nothing is pure latency.
@@ -449,10 +450,10 @@ became a tactics library the orchestrator draws from when designing lanes:
   multi-block runs, the dispatch step composes with `claude -p` / scheduled
   jobs, but that's an extension, not the default (and note `claude -p` draws on
   separate Agent SDK credits from June 15, 2026).
-- **Not Goal-Mode-in-a-trenchcoat.** Codex's Goal Mode already loops
-  plan→act→test→review against a stopping condition. This design's value-add is
-  everything Goal Mode can't do: cross-model judgment, frozen external gates,
-  arbitration, and repo-resident memory across runs.
+- **Not just Goal Mode.** Codex's Goal Mode already loops
+  plan→act→test→review against a stopping condition. This design adds extra
+  separation around Goal Mode: cross-model judgment, frozen external
+  gates, arbitration, and repo-resident memory across runs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # architect-loop
 
-**Claude Fable is the architect — it designs every slice, freezes the
-acceptance gates, and judges the results. GPT-5.5 Codex is the builder and
-researcher — it does all the engineering and all the web research, in
-parallel, unattended, for hours.** Two Claude Code skills that run this
-cross-vendor loop on the flat-rate subscriptions you already have — no API
-keys, no token bills.
+**Claude Fable handles planning and review; GPT-5.5 Codex handles
+implementation and research.** Two Claude Code skills wire that split into a
+repo-centered loop: specs and gates are written first, Codex works in fresh
+contexts, and Fable reviews the evidence before anything is integrated. It runs
+on the subscriptions you already have — no API keys required by default.
 
 ## Install (30 seconds)
 
@@ -37,19 +36,18 @@ dispatch builders. `/architect-research` is for when you're still deciding
 One short Fable session per work block — judgment only, it never writes code:
 
 - **Spec + gates first.** Fable specs a one-PR slice, splits it into 1–4
-  lanes with provably disjoint file sets, and commits the acceptance gates to
+  lanes whose file sets are checked for overlap, and commits the acceptance gates to
   `docs/gates/` *before* any builder starts. Gates are read-only; a builder
   edit to a gate file fails the slice automatically.
 - **Parallel isolated builders.** One fresh `codex exec` (xhigh) per lane,
   each in its own git worktree. Builders must argue with the spec before
   building (silent compliance = defect), build only their declared files,
-  and report raw results — they physically can't commit (the sandbox
-  protects `.git`).
+  and report raw results — they do not have commit access in the sandbox.
 - **Fable judges and integrates.** It runs the gate commands itself (builder
   claims are hearsay), reads the diff against the spec's intent (passing
   tests ≠ mergeable work), then commits and merges passing lanes. Judgment
-  happens in a fresh session — cross-context review measurably beats
-  same-session review.
+  happens in a fresh session because the cited evidence favors fresh-context
+  review.
 - **The repo is the only memory.** `docs/HANDOFF.md` (a short table of
   contents, pruned every session), `docs/gates/`, `docs/lanes/`, git
   history. Not in the repo = didn't happen.
@@ -83,12 +81,12 @@ taxonomy:
 
 ## Why this shape
 
-Each piece is there because evidence put it there (full citations in
+Each design choice is source-backed (full citations in
 [DESIGN.md](DESIGN.md)):
 
-- Weak planners hurt more than weak executors — so the strongest model does
-  the design, and builders get exhaustive specs.
-- Manager + worktree-isolated workers is the measured-best topology for
+- Weak planners hurt more than weak executors — so the architect model does
+  the design, and builders get explicit specs.
+- Manager + worktree-isolated workers is a well-supported topology for
   shared-artifact software work; naive shared-file coordination collapses
   throughput.
 - Frozen external gates beat trusting the agent — but agents game visible
@@ -96,9 +94,9 @@ Each piece is there because evidence put it there (full citations in
   also reads the diff.
 - Memory files rot — so the handoff stays a short map, and detail lives in
   linked gate/lane files.
-- Every production deep-research system uses planner-designed decomposition,
-  none uses fixed lanes — so research lanes are designed per topic, after a
-  scout pass.
+- The surveyed production deep-research systems use planner-designed
+  decomposition rather than fixed lanes — so research lanes are designed per
+  topic, after a scout pass.
 
 ## What's in the box
 
@@ -131,6 +129,14 @@ can paste it into an interactive `codex` session with `/goal` instead.
 
 **Why two skills?** Research-grade fan-out costs ~15× chat-level tokens — it
 should be a deliberate act, not a side-effect of the build loop.
+
+## Origin
+
+The original idea came from [this X post by @jumperz](https://x.com/jumperz/status/2065454404623384859)
+about using Fable with Opus subagents. I built architect-loop because I couldn't
+find an easy way to run that pattern, and because it seemed useful to add a few
+extra operational best practices on top of what Fable can already do when calling
+Opus subagents.
 
 ## License
 

--- a/skills/architect-research/SKILL.md
+++ b/skills/architect-research/SKILL.md
@@ -40,16 +40,16 @@ the final report so the reader can audit scope drift.
 
 ### 2. Scout, then design the lanes
 
-Every production deep-research system and 4/5 leading OSS frameworks use
-LLM-designed, topic-specific decomposition — none uses a fixed lane taxonomy.
-Lanes are designed per topic, not taken from a template.
+The surveyed production deep-research systems and 4/5 leading OSS frameworks
+use LLM-designed, topic-specific decomposition rather than a fixed lane
+taxonomy. Lanes are designed per topic, not taken from a template.
 
 **Scout (brainstorm scale only):** dispatch ONE cheap researcher (~10
 searches, same codex command as step 3) to map the terrain: canonical
 terminology, the 5–10 load-bearing systems/papers/repos, the named people,
 which source classes look rich vs empty, and the topic's natural fault lines.
 The scout returns a map, not findings — discovering the topic's actual
-perspectives from sources is what nearly doubled source diversity in STORM's
+perspectives from sources substantially increased source diversity in STORM's
 ablations. Skip the scout when you already know the terrain (comparisons,
 fact-finds) — an upfront pass that tells you nothing new is pure latency.
 

--- a/skills/architect-research/lanes.md
+++ b/skills/architect-research/lanes.md
@@ -41,7 +41,7 @@ classes look rich vs empty for this topic (papers? repos? vendor blogs?
 forums?); (5) the topic's natural fault lines — the 3–6 sub-questions an
 expert would split it into. Budget ~10 searches; breadth over depth; snippet
 over page. Output is a MAP for the orchestrator to design lanes from —
-structure beats completeness.
+structure matters more than completeness.
 
 ## Lane 1 — Academic (latest papers)
 
@@ -61,7 +61,7 @@ Pipeline: **survey first → frontier sweep → snowball → score.**
   Community signal: `https://huggingface.co/api/daily_papers?limit=20` and
   `https://huggingface.co/papers/trending`. **Papers With Code is dead**
   (shut down July 2025; HF Papers is the successor) — never cite it.
-- Snowball from the 2-3 best seeds — the most reliable "latest papers" method:
+- Snowball from the 2-3 most relevant seeds — a reliable "latest papers" method:
   forward citations
   `https://api.semanticscholar.org/graph/v1/paper/arXiv:<id>/citations?fields=title,year,isInfluential&limit=100`
   and semantic neighbors
@@ -114,7 +114,7 @@ are actually adopting — and which hyped repos are already abandoned.
 
 ## Lane 4 — Production-grade design patterns
 
-Objective: how the 2-3 best production libraries adjacent to <topic> design
+Objective: how 2-3 production libraries adjacent to <topic> design
 the thing we're about to build — API ergonomics, error handling, extension
 points, testing patterns — and where they differ.
 

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -126,8 +126,8 @@ One-PR-sized. The spec is the full delegation contract, self-contained:
 - **Boundaries** — files it may touch, files it must not, explicit
   out-of-scope list, "no placeholders; search before implementing",
   no refactors beyond the task.
-- **Lane plan** — split the slice into 1–4 parallel lanes with **provably
-  disjoint file-touch sets**: list every file each lane may touch; any overlap
+- **Lane plan** — split the slice into 1–4 parallel lanes with **file-touch
+  sets checked for overlap**: list every file each lane may touch; any overlap
   means those lanes run as one. Each lane gets its own objective, output
   format, and boundaries. Most slices are one lane — fan out only when the
   work is genuinely parallel.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -31,7 +31,7 @@ codex exec -C <repo-root> --sandbox workspace-write \
 ## Worktree fan-out (2–4 lanes — the architect owns the parallelism)
 
 One isolated worktree + one fresh `codex exec` per lane, all launched in
-parallel in the background. Lanes have provably disjoint file-touch sets from
+parallel in the background. Lanes have file-touch sets checked for overlap from
 the spec; each writes raw results to its own `docs/lanes/<slice>-<lane>.md`,
 so nothing collides.
 
@@ -73,7 +73,8 @@ conflicting lane and re-spec; don't hand-resolve builder conflicts.
   `.architect/last-run.md` and the repo state afterwards.
 - Pin the model explicitly — automations have been reported silently falling
   back to older models.
-- Effort: `xhigh` default (best review-survival for unattended work);
+- Effort: `xhigh` default (based on the cited review-survival data for
+  unattended work);
   architect downgrades routine, tightly-specified slices to `"high"`.
 - Same-slice follow-up (e.g. answering PHASE 0 disagreements after the human
   rules): `codex exec resume --last "<rulings + proceed>"`. Never resume
@@ -86,8 +87,8 @@ conflicting lane and re-spec; don't hand-resolve builder conflicts.
 - **Builders never commit — the architect does.** workspace-write protects
   `.git` as read-only (verified on Windows, Codex 0.139 — no config toggle;
   `writable_roots` does not bypass it; worktree pointer files are resolved and
-  protected too). This is load-bearing for the loop: lanes can't touch shared
-  history, so nothing reaches a branch until the architect's tamper, boundary,
+  protected too). This is load-bearing for the loop: lanes do not have commit
+  access, so nothing reaches a branch until the architect's tamper, boundary,
   and gate checks pass.
 
 ## Stall detection and rescue (verified live: Windows, Codex 0.139)


### PR DESCRIPTION
## Summary
- tone down README, DESIGN, and skill prose that read as self-aggrandizing
- preserve the operational guardrails in the architect skills, including overlap checks before lane fan-out
- add README origin credit to @jumperz's X post for the Fable + Opus subagent idea

## Checks
- `tests/validate_skills.py`
- `git diff --check --cached` before commit