### PR TITLE
architect v5.1: hardening from the first factory run

### DIFF
--- a/.claude/agents/architect-builder.md
+++ b/.claude/agents/architect-builder.md
@@ -21,6 +21,9 @@ Operating rules:
 - Build your lane only. The orchestrator owns lane splitting; files outside
   your BOUNDARIES are out of scope even if they look related.
 - The files under `docs/gates/` are read-only at all times.
+- The files matching `docs/lanes/*-rulings.md` are also read-only at all
+  times. They are orchestrator-owned, the same class as `docs/gates/`; creating
+  or editing one fails the lane.
 - No placeholder implementations. Search before implementing and keep the
   existing voice of touched files.
 - No silent fallbacks or success-shaped defaults; no unrequested backwards-

--- a/.claude/agents/architect-judge.md
+++ b/.claude/agents/architect-judge.md
@@ -12,6 +12,10 @@ discussion. Use only the frozen judge template supplied by the orchestrator.
 Duties:
 
 - Read the frozen gate file named in the prompt.
+- Read `docs/lanes/<issue-slug>-rulings.md` when present. It is
+  orchestrator-owned, append-only, frozen post-freeze intent; read it alongside
+  the frozen gate file, spec, and lane report. If it is absent or empty, record
+  that there are no post-freeze rulings.
 - Check gates integrity with the freeze commit SHA and branch to judge.
 - Run each gate command exactly as written, unless the command is impossible to
   execute in this environment; then return INVALID with raw evidence.

--- a/.claude/agents/architect-monitor.md
+++ b/.claude/agents/architect-monitor.md
@@ -11,6 +11,8 @@ the orchestrator hands you and report evidence only.
 
 Operating rules:
 
+- You run as a BACKGROUND SUBAGENT, not a teammate. Your completion re-invokes
+  the orchestrator; your exit is the alert channel.
 - You receive a list of in-flight lanes: report paths, worktree paths, and
   duration hints (e.g. "full suite ~= 20m"). Duration hints exist so a
   long-legitimate run is not mistaken for a stall.
@@ -27,6 +29,10 @@ Operating rules:
 - You never kill a process, never message a lane, and never judge quality —
   evidence only. The brain reads your evidence and rules on what happens
   next.
+- If you were spawned teammate-style despite the default contract, honor a
+  `shutdown_request` promptly and exit with a short stand-down summary.
+- Never idle silently when an exit condition is met. Done, anomaly, and
+  shutdown are completion events; exit so the orchestrator is re-invoked.
 - Your `tools:` order pads Bash and Read away from the first and last slot
   (claude-code #60237 silently drops those two positions at subagent spawn).
 - If shell sleep is unavailable in this harness, perform slower sweeps

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -913,3 +913,59 @@ The run also produced four diagnoses worth codifying:
   harness-created worktree had a fast-forwarded ref but stale files on disk.
   Freeze commits must precede dispatch, and each lane must verify HEAD and
   required input files before building.
+
+### v5.1 addendum - architect-v5.1
+
+Source pointers: the approved spec is `docs/spec/architect-v5.1.md`; this run's
+trail is epic #20 with issues #21-#25 on `factory/v5.1` from spec approval
+commit `0a60bb6`; the in-repo ruling record is
+`docs/lanes/v51-docs-rulings.md`.
+
+Eight retro findings, paired as R/W summaries:
+
+- **R1/W1.** BLOCKED-with-evidence and respawn worked, but Claude-backend
+  shell-strip made backend choice an intake-time risk.
+- **R2/W2.** PHASE 0 caught an orchestrator defect, while the first harness
+  worktree still proved freeze visibility must be checked before dispatch.
+- **R3/W3.** Cold judge diff-vs-intent caught a masked failure, but the grill
+  missed issue-body, deleted-reference, and ignored-new-file classes.
+- **R4/W4.** One decomposition grill caught five draft defects, yet
+  post-freeze rulings lacked a durable in-repo home.
+- **R5/W5.** INVALID-vs-FAIL discipline held, while codex-backend judge blocks
+  and cache substitutions were still hand-assembled.
+- **R6/W6.** Interface handoff blocks avoided merge conflicts, but monitor
+  teammate spawns idled instead of matching the documented quiet-exit model.
+- **R7/W7.** Raw evidence under tool deprivation stayed honest, while direct
+  builder issue posting was effectively unavailable and required orchestrator
+  mirroring.
+- **R8/W8.** Sonnet-high brawn passed most first-wave lanes, but branch hygiene
+  was improvised by landing pre-factory commits on main before the run branch.
+
+v5.1 design decisions:
+
+- **D1. Backend canary at preflight.** Run a trivial shell canary per candidate
+  backend, mark shell-less backends DEGRADED, and select the verified fallback
+  before decomposition.
+- **D2. Factory branch and freeze-push-dispatch.** Cut `factory/<run>` at spec
+  approval, commit and push the freeze, then verify spawned worktree HEAD and
+  frozen inputs.
+- **D3. Wider decomposition grill.** Grill gates, issue bodies, deleted or
+  renamed references, and committability for new artifact paths.
+- **D4. Rulings file.** Keep post-freeze intent in append-only
+  `docs/lanes/<slug>-rulings.md` files owned by the orchestrator.
+- **D5. Codex judge template and substitution table.** Freeze the codex judge
+  block and sanctioned substitutions in dispatch text.
+- **D6. Monitor spawn semantics.** Treat the monitor as a background subagent;
+  teammate-style monitor spawns require explicit stand-down.
+- **D7. Issue mirror reality.** Accept `MIRROR: ORCHESTRATOR` as normal when
+  builders cannot post to GitHub directly.
+- **D8. Keep-list.** Preserve blocker exits, PHASE 0 duty, cold judging, one
+  grill, interface blocks, raw substitutions, INVALID discipline, and tier
+  outcome logging.
+
+First live D1 exercise: the v5.1 preflight backend canary returned
+`CANARY: DEGRADED` for a Claude haiku architect-builder spawn with
+Glob/Read/Edit/Write/Grep only and no shell; cumulative shell-strip evidence on
+2026-07-02 was 6/6 Claude subagent spawns. The backend selected at preflight for
+the whole v5.1 run was codex/tier-down (`gpt-5.5`, high effort), and no
+mid-wave backend switching occurred.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ factory, the repo needs:
 - `gh auth status` passing;
 - `gh` version 2.94.0 or newer, for native sub-issue and dependency flags.
 
+Preflight also runs a backend canary before dispatch so the factory records a
+working brawn backend instead of switching mid-wave.
+
 If any precondition is missing, the skill fails loudly instead of falling back
 to a local tracker.
 

--- a/docs/gates/v51-agents.md
+++ b/docs/gates/v51-agents.md
@@ -1,0 +1,32 @@
+# Gates: v51-agents (issue #24)
+
+Purpose: the monitor def states its background-subagent lifecycle (D6); the
+builder def bans touching `*-rulings.md`; the judge def reads the rulings
+file as intent (D4). Body-only edits; validator-inspected frontmatter is
+untouched. Spec: `docs/spec/architect-v5.1.md`. Fix contract: issue #24 body.
+
+Executor: Git Bash preferred; recorded same-pattern substitution permitted
+(PowerShell; UV_CACHE_DIR redirect for uv). All commands from the repo root
+of the branch under judgment.
+
+- GA1 — monitor lifecycle stated (semantics, not just keywords):
+  `grep -qi "background subagent" .claude/agents/architect-monitor.md && grep -q "shutdown_request" .claude/agents/architect-monitor.md && grep -qiE "exit is the alert|completion re-?invokes" .claude/agents/architect-monitor.md`
+  PASS = exit 0.
+- GA2 — builder rulings ban present (fixed-string; `--` guards the
+  leading-dash pattern):
+  `grep -Fq -- "-rulings.md" .claude/agents/architect-builder.md`
+  PASS = exit 0.
+- GA3 — judge rulings context present (fixed-string; `--` guards the
+  leading-dash pattern):
+  `grep -Fq -- "-rulings.md" .claude/agents/architect-judge.md`
+  PASS = exit 0.
+- GA4 — monitor frontmatter unchanged (CRLF-tolerant):
+  `grep -qE $'^name: architect-monitor\r?$' .claude/agents/architect-monitor.md && grep -qE $'^tools: Glob, .*Grep\r?$' .claude/agents/architect-monitor.md`
+  PASS = exit 0.
+- GA5 — validator green:
+  `uv run --no-project python tests/validate_skills.py`
+  PASS = exit 0 AND stdout contains "OK".
+
+Diff vs intent: only the three `.claude/agents/` files +
+`docs/lanes/v51-agents-01.md` change; deny mirrors, tools lines, and name
+fields are byte-identical to the base.

--- a/docs/gates/v51-dispatch.md
+++ b/docs/gates/v51-dispatch.md
@@ -1,0 +1,41 @@
+# Gates: v51-dispatch (issue #21)
+
+Purpose: dispatch.md absorbs the v5.1 run lessons — extended grill template
+(D3), codex-judge template (D5), sanctioned-substitutions table (D5),
+issue-mirror reality (D7), rulings-file line (D4) — with every existing
+contract preserved. Spec: `docs/spec/architect-v5.1.md`. Fix contract:
+issue #21 body.
+
+Executor: Git Bash preferred; recorded same-pattern substitution permitted
+(PowerShell; `UV_CACHE_DIR=.architect/tmp/uv-cache` for uv) — the report
+names the executor per gate. All commands from the repo root of the branch
+under judgment.
+
+- GD1 — the three D3 checks live INSIDE the grill template block (not
+  merely anywhere in the file):
+  `sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -q "check-ignore" && sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -qi "issue bodies" && sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -qi "deletes or renames"`
+  PASS = exit 0.
+- GD2 — codex-judge template present WITH required content between its
+  markers (empty markers fail):
+  `grep -q "architect-codex-judge-template:start" skills/architect/dispatch.md && sed -n '/architect-codex-judge-template:start/,/architect-codex-judge-template:end/p' skills/architect/dispatch.md | grep -q "stylistic preferences" && sed -n '/architect-codex-judge-template:start/,/architect-codex-judge-template:end/p' skills/architect/dispatch.md | grep -qi "tree audit" && sed -n '/architect-codex-judge-template:start/,/architect-codex-judge-template:end/p' skills/architect/dispatch.md | grep -q "rulings"`
+  PASS = exit 0.
+- GD3 — sanctioned-substitutions table entries:
+  `grep -q "UV_CACHE_DIR=.architect/tmp/uv-cache" skills/architect/dispatch.md && grep -qi "Win32 error 5" skills/architect/dispatch.md && grep -q "MIRROR: ORCHESTRATOR" skills/architect/dispatch.md`
+  PASS = exit 0.
+- GD4 — rulings-file convention named (literal, fixed-string):
+  `grep -Fq "docs/lanes/<issue-slug>-rulings.md" skills/architect/dispatch.md`
+  PASS = exit 0.
+- GD5 — preserved contracts intact:
+  `grep -q "architect-judge-template:start" skills/architect/dispatch.md && grep -q "architect-grill-template:start" skills/architect/dispatch.md && grep -q "^## Model alias table" skills/architect/dispatch.md`
+  PASS = exit 0.
+- GD6 — validator green:
+  `uv run --no-project python tests/validate_skills.py`
+  PASS = exit 0 AND stdout contains "OK".
+- GD7 — size budget:
+  `[ "$(grep -cve '^[[:space:]]*$' skills/architect/dispatch.md)" -le 440 ]`
+  PASS = exit 0.
+
+Diff vs intent: only `skills/architect/dispatch.md` + `docs/lanes/v51-dispatch-01.md`
+change; the codex-judge template carries the calibration line, tree-audit
+warning, four intent-context pointers, and the same verdict fields as C5;
+the grill template's defect-report format survives.

--- a/docs/gates/v51-docs.md
+++ b/docs/gates/v51-docs.md
@@ -1,0 +1,31 @@
+# Gates: v51-docs (issue #25)
+
+Purpose: DESIGN.md records the v5.1 retro decisions and this run's canary
+evidence; README gains the one user-visible change (canary preflight
+sentence). Runs after #21–#24 merge. Spec: `docs/spec/architect-v5.1.md`.
+Fix contract: issue #25 body.
+
+Executor: Git Bash preferred; recorded same-pattern substitution permitted
+(PowerShell; UV_CACHE_DIR redirect for uv). All commands from the repo root
+of the branch under judgment.
+
+- GC1 — DESIGN.md v5.1 addendum present (both strings absent from base
+  DESIGN.md; verified at freeze):
+  `grep -q "architect-v5.1" DESIGN.md && grep -qi "backend canary" DESIGN.md`
+  PASS = exit 0.
+- GC2 — README backend-canary sentence present ("backend canary" absent
+  from base README; the base's unrelated "Canary it" at line ~146 does not
+  match; verified at freeze):
+  `grep -qi "backend canary" README.md`
+  PASS = exit 0.
+- GC3 — validator green:
+  `uv run --no-project python tests/validate_skills.py`
+  PASS = exit 0 AND stdout contains "OK".
+- GC4 — README still HANDOFF-free (standing):
+  `! grep -qi "HANDOFF.md" README.md`
+  PASS = exit 0.
+
+Diff vs intent: only `README.md`, `DESIGN.md`, `docs/lanes/v51-docs-01.md`
+change; the DESIGN.md addendum names D1–D8 and cites the spec and this
+run's epic; README changes are limited to the canary/preflight sentence
+area.

--- a/docs/gates/v51-loop.md
+++ b/docs/gates/v51-loop.md
@@ -1,0 +1,33 @@
+# Gates: v51-loop (issue #23)
+
+Purpose: loop.md's monitor protocol states the background-subagent spawn
+semantics and shutdown_request fallback (D6), and the verdict-comments
+section adds the rulings file to the judge's intent context (D4). Spec:
+`docs/spec/architect-v5.1.md`. Fix contract: issue #23 body.
+
+Executor: Git Bash preferred; recorded same-pattern substitution permitted
+(PowerShell; UV_CACHE_DIR redirect for uv). All commands from the repo root
+of the branch under judgment.
+
+- GL1 — monitor spawn semantics present (semantics, not just keywords):
+  `grep -qi "background subagent" skills/architect/loop.md && grep -q "shutdown_request" skills/architect/loop.md && grep -qiE "exit is the alert|completion re-?invokes" skills/architect/loop.md`
+  PASS = exit 0.
+- GL2 — rulings-file convention named (literal, fixed-string):
+  `grep -Fq "docs/lanes/<issue-slug>-rulings.md" skills/architect/loop.md`
+  PASS = exit 0.
+- GL3 — exposed anchors survive exactly:
+  `grep -q "^## Factory block procedure" skills/architect/loop.md && grep -q "^## Monitor protocol" skills/architect/loop.md && grep -q "^## Verdict comments" skills/architect/loop.md && grep -q "^## Escalation digest" skills/architect/loop.md && grep -q "^## Failure ladder" skills/architect/loop.md`
+  PASS = exit 0.
+- GL4 — no tier-escalation-on-failure language (standing):
+  `! grep -qiE "tier[- ]?up|raising its model tier" skills/architect/loop.md`
+  PASS = exit 0.
+- GL5 — validator green:
+  `uv run --no-project python tests/validate_skills.py`
+  PASS = exit 0 AND stdout contains "OK".
+- GL6 — size budget:
+  `[ "$(grep -cve '^[[:space:]]*$' skills/architect/loop.md)" -le 115 ]`
+  PASS = exit 0.
+
+Diff vs intent: only `skills/architect/loop.md` + `docs/lanes/v51-loop-01.md`
+change; safety rails, failure ladder, and context discipline survive; the
+monitor baseline note (quiet exit = success) is present.

--- a/docs/gates/v51-skill.md
+++ b/docs/gates/v51-skill.md
@@ -1,0 +1,34 @@
+# Gates: v51-skill (issue #22)
+
+Purpose: SKILL.md gains the backend canary preflight (D1), factory-branch +
+freeze→push→dispatch ordering with post-spawn worktree verification (D2),
+and the rulings-file pointer (D4), without restructuring the frozen v5
+stages. Spec: `docs/spec/architect-v5.1.md`. Fix contract: issue #22 body.
+
+Executor: Git Bash preferred; recorded same-pattern substitution permitted
+(PowerShell; UV_CACHE_DIR redirect for uv). All commands from the repo root
+of the branch under judgment.
+
+- GS1 — canary preflight present:
+  `grep -qi "canary" skills/architect/SKILL.md && grep -q "DEGRADED" skills/architect/SKILL.md`
+  PASS = exit 0.
+- GS2 — freeze→push→dispatch preconditions present as ordered hard-stop
+  rules, with the factory-branch literal:
+  `grep -Fq "factory/<run>" skills/architect/SKILL.md && grep -qiE "hard-?stop" skills/architect/SKILL.md && grep -qiE "push(ed)?" skills/architect/SKILL.md && grep -qi "worktree" skills/architect/SKILL.md`
+  PASS = exit 0.
+- GS3 — rulings-file convention named (literal, fixed-string):
+  `grep -Fq "docs/lanes/<issue-slug>-rulings.md" skills/architect/SKILL.md`
+  PASS = exit 0.
+- GS4 — no tier-escalation-on-failure language (standing):
+  `! grep -qiE "tier[- ]?up|raising its model tier" skills/architect/SKILL.md`
+  PASS = exit 0.
+- GS5 — validator green:
+  `uv run --no-project python tests/validate_skills.py`
+  PASS = exit 0 AND stdout contains "OK".
+- GS6 — size budget:
+  `[ "$(grep -cve '^[[:space:]]*$' skills/architect/SKILL.md)" -le 190 ]`
+  PASS = exit 0.
+
+Diff vs intent: only `skills/architect/SKILL.md` + `docs/lanes/v51-skill-01.md`
+change; the v5 stage structure, hard rules, D9 doctrine, and stop rails
+survive; the canary rule states no mid-wave backend switching.

--- a/docs/lanes/v51-agents-01.md
+++ b/docs/lanes/v51-agents-01.md
@@ -1,0 +1,156 @@
+# v51-agents-01 Lane Report
+
+Executor: Codex via PowerShell in isolated worktree `v51-agents-01`.
+Freeze commit checked: `8e08b0b`.
+
+## PHASE 0
+
+Plan:
+
+1. Make body-only edits in `.claude/agents/architect-monitor.md`, `.claude/agents/architect-builder.md`, and `.claude/agents/architect-judge.md`; leave frontmatter `name:` and `tools:` byte-identical because `docs/gates/v51-agents.md:5` requires body-only edits and `docs/gates/v51-agents.md:30` limits the diff.
+2. Add the monitor lifecycle terms required by D6: background subagent, completion re-invokes the orchestrator, exit as alert, `shutdown_request` for teammate-style spawn, and no silent idling after an exit condition. The current monitor body said only "exit quietly" at `.claude/agents/architect-monitor.md:21`, while D6 requires the stronger contract in `docs/spec/architect-v5.1.md:139`.
+3. Add the builder ban on `docs/lanes/*-rulings.md`; the builder previously only protected `docs/gates/` at `.claude/agents/architect-builder.md:23`, while D4 says builders may not touch `*-rulings.md` in `docs/spec/architect-v5.1.md:124`.
+4. Add judge intent-context handling for `docs/lanes/<issue-slug>-rulings.md`; the judge previously read only the gate and diff intent at `.claude/agents/architect-judge.md:14`, while D4 requires frozen gate + spec + lane report + rulings file at `docs/spec/architect-v5.1.md:122`.
+5. Run each frozen gate sequentially from `docs/gates/v51-agents.md:12`, using the sanctioned PowerShell same-pattern substitution and `UV_CACHE_DIR=.architect/tmp/uv-cache` if needed, then write raw command output, exit codes, touched files, and final count to this report.
+
+Disagreements:
+
+- No disagreement with the fix contract after checking the frozen spec, frozen gate, and target files.
+- Execution-mechanical reconciliation: the gate text prefers Git Bash, but explicitly permits PowerShell and `UV_CACHE_DIR` substitutions in `docs/gates/v51-agents.md:9`; substitutions are recorded per use below.
+- I did not edit `docs/gates/**` or any `docs/lanes/*-rulings.md`; this lane's report path is `docs/lanes/v51-agents-01.md`, which is allowed by `docs/gates/v51-agents.md:30`.
+
+## Files Touched
+
+- `.claude/agents/architect-monitor.md`
+- `.claude/agents/architect-builder.md`
+- `.claude/agents/architect-judge.md`
+- `docs/lanes/v51-agents-01.md`
+
+## Gate Results
+
+### GA1
+
+Frozen command:
+
+```sh
+grep -qi "background subagent" .claude/agents/architect-monitor.md && grep -q "shutdown_request" .claude/agents/architect-monitor.md && grep -qiE "exit is the alert|completion re-?invokes" .claude/agents/architect-monitor.md
+```
+
+Executor named: PowerShell same-pattern substitution.
+Substitution recorded: Git Bash preferred -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if ((Select-String -Path .claude\agents\architect-monitor.md -Pattern 'background subagent' -Quiet) -and (Select-String -Path .claude\agents\architect-monitor.md -SimpleMatch -Pattern 'shutdown_request' -Quiet) -and (Select-String -Path .claude\agents\architect-monitor.md -Pattern 'exit is the alert|completion re-?invokes' -Quiet)) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GA2
+
+Frozen command:
+
+```sh
+grep -Fq -- "-rulings.md" .claude/agents/architect-builder.md
+```
+
+Executor named: PowerShell same-pattern substitution.
+Substitution recorded: Git Bash preferred -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if (Select-String -Path .claude\agents\architect-builder.md -SimpleMatch -Pattern '-rulings.md' -Quiet) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GA3
+
+Frozen command:
+
+```sh
+grep -Fq -- "-rulings.md" .claude/agents/architect-judge.md
+```
+
+Executor named: PowerShell same-pattern substitution.
+Substitution recorded: Git Bash preferred -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if (Select-String -Path .claude\agents\architect-judge.md -SimpleMatch -Pattern '-rulings.md' -Quiet) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GA4
+
+Frozen command:
+
+```sh
+grep -qE $'^name: architect-monitor\r?$' .claude/agents/architect-monitor.md && grep -qE $'^tools: Glob, .*Grep\r?$' .claude/agents/architect-monitor.md
+```
+
+Executor named: PowerShell same-pattern substitution.
+Substitution recorded: Git Bash preferred -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if ((Select-String -Path .claude\agents\architect-monitor.md -Pattern '^name: architect-monitor\r?$' -Quiet) -and (Select-String -Path .claude\agents\architect-monitor.md -Pattern '^tools: Glob, .*Grep\r?$' -Quiet)) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GA5
+
+Frozen command:
+
+```sh
+uv run --no-project python tests/validate_skills.py
+```
+
+Executor named: PowerShell.
+Substitution recorded: `UV_CACHE_DIR=.architect/tmp/uv-cache`.
+
+Executed command:
+
+```powershell
+New-Item -ItemType Directory -Force -Path .architect\tmp\uv-cache | Out-Null; $env:UV_CACHE_DIR = '.architect/tmp/uv-cache'; uv run --no-project python tests/validate_skills.py
+```
+
+Verbatim output:
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Exit code: 0
+
+## Final Count
+
+Final non-blank count of `docs/lanes/v51-agents-01.md`: 100
+STATUS: COMPLETE
+MIRROR: ORCHESTRATOR

--- a/docs/lanes/v51-dispatch-01.md
+++ b/docs/lanes/v51-dispatch-01.md
@@ -1,0 +1,236 @@
+# Lane Report: v51-dispatch-01
+
+## PHASE 0
+
+Plan:
+1. Touch only `skills/architect/dispatch.md` and this report.
+2. Extend the existing `architect-grill-template` block with D3 issue-body,
+   delete/rename reference, and `git check-ignore` checks.
+3. Add a new `architect-codex-judge-template` block parallel to C5, including
+   the calibration line, tree audit warning, sanctioned substitutions, four
+   intent-context pointers, and C5 verdict fields.
+4. Add the sanctioned substitutions table under `## Duration hints and
+   liveness`, with `docs/solutions/` citations.
+5. Add the issue-mirror reality note under `## Issue conventions`.
+6. Run frozen gates from `docs/gates/v51-dispatch.md` sequentially and record
+   raw command output and exit codes.
+
+Disagreements / scope tensions:
+- Scope tension only: `docs/spec/architect-v5.1.md:176` describes
+  `v51-rulings` as a later cross-file lane, but this lane's issue contract
+  explicitly requires the D4 rulings-file line in `dispatch.md`, and
+  `docs/gates/v51-dispatch.md:25` requires the literal path pattern. I will
+  implement only the `dispatch.md` portion, not the later cross-file lane.
+- No disagreement with the read-only rule. `docs/gates/v51-dispatch.md:38`
+  limits this lane to `skills/architect/dispatch.md` and this report. I will
+  not edit `docs/gates/**`, any `docs/lanes/*-rulings.md`, or other files.
+- No disagreement with the substitution requirement. The requested table is
+  supported by `docs/solutions/subagent-shell-strip-codex-fallback.md`,
+  `docs/solutions/uv-cache-sandbox-redirect.md`, and
+  `docs/solutions/cross-lane-content-dependency.md`.
+
+## Files Touched
+
+- `skills/architect/dispatch.md`
+- `docs/lanes/v51-dispatch-01.md`
+
+## Gate Results
+
+### GD1
+
+Executor: Git Bash attempt, then PowerShell same-pattern substitution.
+
+Frozen command:
+
+```bash
+sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -q "check-ignore" && sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -qi "issue bodies" && sed -n '/architect-grill-template:start/,/architect-grill-template:end/p' skills/architect/dispatch.md | grep -qi "deletes or renames"
+```
+
+Git Bash output:
+
+```text
+      0 [main] bash (44380) C:\Program Files\Git\usr\bin\bash.exe: *** fatal error - CreateFileMapping S-1-5-21-940813291-4134638421-1989498454-1002.1, Win32 error 5.  Terminating.
+```
+
+Git Bash exit code: 1
+
+Substitution command:
+
+```powershell
+$block = (Get-Content -Raw skills/architect/dispatch.md) -replace '(?s)^.*<!-- architect-grill-template:start -->','<!-- architect-grill-template:start -->' -replace '(?s)<!-- architect-grill-template:end -->.*$','<!-- architect-grill-template:end -->'; if (($block -match 'check-ignore') -and ($block -match '(?i)issue bodies') -and ($block -match '(?i)deletes or renames')) { exit 0 } else { $block; exit 1 }
+```
+
+Substitution output:
+
+```text
+```
+
+Substitution exit code: 0
+
+### GD2
+
+Executor: PowerShell same-pattern substitution.
+
+Command:
+
+```powershell
+$text = Get-Content -Raw skills/architect/dispatch.md; $block = $text -replace '(?s)^.*<!-- architect-codex-judge-template:start -->','<!-- architect-codex-judge-template:start -->' -replace '(?s)<!-- architect-codex-judge-template:end -->.*$','<!-- architect-codex-judge-template:end -->'; if (($text -match 'architect-codex-judge-template:start') -and ($block -match 'stylistic preferences') -and ($block -match '(?i)tree audit') -and ($block -match 'rulings')) { exit 0 } else { $block; exit 1 }
+```
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GD3
+
+Executor: PowerShell same-pattern substitution.
+
+Command:
+
+```powershell
+$text = Get-Content -Raw skills/architect/dispatch.md; if (($text -match 'UV_CACHE_DIR=\.architect/tmp/uv-cache') -and ($text -match '(?i)Win32 error 5') -and ($text -match 'MIRROR: ORCHESTRATOR')) { exit 0 } else { exit 1 }
+```
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GD4
+
+Executor: PowerShell same-pattern substitution.
+
+Command:
+
+```powershell
+$text = Get-Content -Raw skills/architect/dispatch.md; if ($text.Contains('docs/lanes/<issue-slug>-rulings.md')) { exit 0 } else { exit 1 }
+```
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GD5
+
+Executor: PowerShell same-pattern substitution.
+
+Command:
+
+```powershell
+$text = Get-Content -Raw skills/architect/dispatch.md; if (($text -match 'architect-judge-template:start') -and ($text -match 'architect-grill-template:start') -and ($text -match '(?m)^## Model alias table')) { exit 0 } else { exit 1 }
+```
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GD6
+
+Executor: PowerShell.
+
+Frozen command:
+
+```powershell
+uv run --no-project python tests/validate_skills.py
+```
+
+Frozen command output:
+
+```text
+error: failed to open file `C:\Users\danhm\AppData\Local\uv\cache\sdists-v9\.git`: Access is denied. (os error 5)
+```
+
+Frozen command exit code: 1
+
+Substitution command:
+
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python tests/validate_skills.py
+```
+
+Substitution output:
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Substitution exit code: 0
+
+### GD7
+
+Executor: PowerShell same-pattern substitution.
+
+Command:
+
+```powershell
+$count = (Get-Content skills/architect/dispatch.md | Where-Object { $_ -notmatch '^[\s]*$' }).Count; Write-Output $count; if ($count -le 440) { exit 0 } else { exit 1 }
+```
+
+Output:
+
+```text
+438
+```
+
+Exit code: 0
+
+## Touch Checks
+
+Command:
+
+```powershell
+git diff --name-only
+```
+
+Output:
+
+```text
+skills/architect/dispatch.md
+warning: in the working copy of 'skills/architect/dispatch.md', LF will be replaced by CRLF the next time Git touches it
+```
+
+Exit code: 0
+
+Command:
+
+```powershell
+git status --short
+```
+
+Output:
+
+```text
+ M skills/architect/dispatch.md
+?? docs/lanes/v51-dispatch-01.md
+```
+
+Exit code: 0
+
+Command:
+
+```powershell
+git diff -- docs/gates docs/lanes/*-rulings.md
+```
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+Final non-blank count of `skills/architect/dispatch.md`: 438
+
+STATUS: COMPLETE
+MIRROR: ORCHESTRATOR

--- a/docs/lanes/v51-docs-01.md
+++ b/docs/lanes/v51-docs-01.md
@@ -1,0 +1,145 @@
+# Lane report: v51-docs-01 (issue #25)
+
+## PHASE 0
+
+Plan:
+
+1. Add a v5.1 addendum at the end of the existing v5 section in `DESIGN.md`
+   after the current dogfood evidence block (`DESIGN.md:818`,
+   `DESIGN.md:883`).
+2. Add only one preflight/backend-canary sentence in `README.md` under
+   Preconditions (`README.md:68-76`), because the frozen gate says README
+   changes are limited to the canary/preflight sentence area
+   (`docs/gates/v51-docs.md:28-30`).
+3. Create this report with Phase 0, files touched, and raw gate output. Do not
+   edit `docs/gates/**` or `docs/lanes/*-rulings.md`; this lane's facts come
+   from `docs/lanes/v51-docs-rulings.md:7-16`.
+4. Run GC1-GC4 sequentially from `docs/gates/v51-docs.md:12-25`, using
+   PowerShell same-pattern commands as the sanctioned Git Bash substitution if
+   needed, and `UV_CACHE_DIR=.architect/tmp/uv-cache` for GC3 if uv needs the
+   workspace cache redirect.
+
+Disagreements / spec tensions:
+
+1. The issue body asks for "the eight retro findings (R/W summary)," but the
+   spec contains eight Went Right findings and eight Went Wrong findings
+   (`docs/spec/architect-v5.1.md:22-42`,
+   `docs/spec/architect-v5.1.md:45-75`). Resolved as eight paired R/W summary
+   bullets, not sixteen expanded paragraphs.
+2. The issue says append a "§12 v5.1" addendum, while the actual document
+   already has `## 12. v5 - the autonomous factory` (`DESIGN.md:818`).
+   Resolved as a subsection under the existing v5 section.
+3. The README gate is about the literal `HANDOFF.md`
+   (`docs/gates/v51-docs.md:24-25`). The current README contains lower-case
+   "handoff" as ordinary prose (`README.md:159`), so unrelated prose was not
+   rewritten.
+
+## Files touched
+
+- `DESIGN.md`
+- `README.md`
+- `docs/lanes/v51-docs-01.md`
+
+## Gates
+
+Executor: Codex lane `v51-docs-01` in PowerShell from repo root
+`C:\Users\danhm\tools\architect-loop\.architect\wt\v51-docs-01`.
+
+### GC1
+
+Frozen gate:
+
+```bash
+grep -q "architect-v5.1" DESIGN.md && grep -qi "backend canary" DESIGN.md
+```
+
+Sanctioned substitution used: Git Bash Win32-error-5 / PowerShell sandbox ->
+PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$ok = (Select-String -Path DESIGN.md -Pattern 'architect-v5.1' -Quiet) -and (Select-String -Path DESIGN.md -Pattern 'backend canary' -Quiet); if ($ok) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GC2
+
+Frozen gate:
+
+```bash
+grep -qi "backend canary" README.md
+```
+
+Sanctioned substitution used: Git Bash Win32-error-5 / PowerShell sandbox ->
+PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if (Select-String -Path README.md -Pattern 'backend canary' -Quiet) { exit 0 } else { exit 1 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+### GC3
+
+Frozen gate:
+
+```bash
+uv run --no-project python tests/validate_skills.py
+```
+
+Sanctioned substitution used: `UV_CACHE_DIR=.architect/tmp/uv-cache`.
+
+Executed command:
+
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python tests/validate_skills.py; exit $LASTEXITCODE
+```
+
+Verbatim output:
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Exit code: 0
+
+### GC4
+
+Frozen gate:
+
+```bash
+! grep -qi "HANDOFF.md" README.md
+```
+
+Sanctioned substitution used: Git Bash Win32-error-5 / PowerShell sandbox ->
+PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+if (Select-String -Path README.md -Pattern 'HANDOFF\.md' -Quiet) { exit 1 } else { exit 0 }
+```
+
+Verbatim output:
+
+```text
+```
+
+Exit code: 0
+
+STATUS: DONE
+MIRROR: ORCHESTRATOR

--- a/docs/lanes/v51-docs-rulings.md
+++ b/docs/lanes/v51-docs-rulings.md
@@ -1,0 +1,17 @@
+# Rulings: v51-docs (issue #25) — orchestrator-owned, append-only
+
+2026-07-02 (pre-dispatch, from the decomposition grill's evidence check):
+the facts the DESIGN.md addendum must cite, recorded in-repo because gh is
+unreachable from lane sandboxes:
+
+- This run: epic #20, issues #21–#25, factory branch `factory/v5.1`,
+  spec approval commit 0a60bb6.
+- Preflight canary evidence (first live D1 exercise): a Claude-backend
+  canary spawn (haiku, architect-builder def, 2026-07-02) returned
+  `CANARY: DEGRADED` — tools Glob/Read/Edit/Write/Grep only, no shell.
+  Cumulative shell-strip observations on this machine that day: 6 of 6
+  Claude subagent spawns (1 grill judge + 4 v5 builder lanes + this
+  canary). Backend selected AT PREFLIGHT for the whole v5.1 run:
+  codex/tier-down (gpt-5.5, effort high). No mid-wave switching occurred.
+- The v5-run evidence trail cited by the spec: epic #12, PR #19,
+  `docs/solutions/` (4 entries).

--- a/docs/lanes/v51-docs-rulings.md
+++ b/docs/lanes/v51-docs-rulings.md
@@ -15,3 +15,12 @@ unreachable from lane sandboxes:
   codex/tier-down (gpt-5.5, effort high). No mid-wave switching occurred.
 - The v5-run evidence trail cited by the spec: epic #12, PR #19,
   `docs/solutions/` (4 entries).
+
+2026-07-02 (post-flight, pre-judgment): the lane report's final status line
+reads `STATUS: DONE`, which is not an allowed form. Orchestrator ruling:
+interpreted as `STATUS: COMPLETE` (the report shows all gates run with
+recorded substitutions and exit codes; no concerns listed, no blocker).
+Recorded here rather than respawning over one word; the judge should treat
+the status-line deviation as ruled, not as a lane defect. Follow-up: the
+allowed-forms list is in the builder def and dispatch block — no text
+change needed, this was builder drift.

--- a/docs/lanes/v51-loop-01.md
+++ b/docs/lanes/v51-loop-01.md
@@ -1,0 +1,202 @@
+# Lane report: v51-loop-01
+
+## PHASE 0
+
+Plan stated before code:
+1. Edit only `skills/architect/loop.md`, preserving the required anchors and the existing safety rails, failure ladder, and context discipline.
+2. In `## Monitor protocol`, add D6's lifecycle rule: default monitor spawn is a background subagent; its completion re-invokes the orchestrator; teammate-style spawns are fallback-only and stand down via `shutdown_request`; quiet exit after normal lane completion is success.
+3. In `## Verdict comments`, add D4's judge context rule with the exact `docs/lanes/<issue-slug>-rulings.md` path and clarify that judge dispatch blocks carry no ruling prose.
+4. Create this report, run the frozen gates sequentially from `docs/gates/v51-loop.md`, and paste raw command output, exit codes, executor, files touched, and final non-blank count.
+
+Disagreements with the spec:
+1. `docs/spec/architect-v5.1.md:140` says both `loop.md` and the monitor definition gain the D6 lifecycle facts, and `docs/spec/architect-v5.1.md:174` defines `v51-loop-monitor` as `loop.md + architect-monitor def`. This lane's frozen gate says diff-vs-intent is only `skills/architect/loop.md` plus `docs/lanes/v51-loop-01.md` at `docs/gates/v51-loop.md:31`, and the issue boundary says the same. I did not touch the monitor definition in this lane.
+2. `docs/spec/architect-v5.1.md:176` through `docs/spec/architect-v5.1.md:177` says the rulings convention lands in `SKILL.md/loop.md/dispatch.md` plus builder/judge definitions, and `docs/spec/architect-v5.1.md:191` describes the convention being named in all three files. This lane's gate only checks `skills/architect/loop.md` (`docs/gates/v51-loop.md:15`) and restricts the diff at `docs/gates/v51-loop.md:31`. I implemented only the `loop.md` D4 part here.
+
+No disagreement with the frozen gate's read-only status or with the may-touch set after checking `docs/gates/v51-loop.md`, `docs/spec/architect-v5.1.md`, and `skills/architect/loop.md`.
+
+## Gate Results
+
+Executor note: Git Bash preferred. GL1 Git Bash attempt hit the sanctioned Win32 error 5, so GL1-GL4 and GL6 used PowerShell same-pattern substitutions. GL5 first ran verbatim, hit the sanctioned uv AppData cache denial, then reran with `UV_CACHE_DIR=.architect/tmp/uv-cache`.
+
+### GL1
+
+Frozen command:
+
+```sh
+grep -qi "background subagent" skills/architect/loop.md && grep -q "shutdown_request" skills/architect/loop.md && grep -qiE "exit is the alert|completion re-?invokes" skills/architect/loop.md
+```
+
+Executor: Git Bash
+
+Output:
+
+```text
+      0 [main] bash (17996) C:\Program Files\Git\usr\bin\bash.exe: *** fatal error - CreateFileMapping S-1-5-21-940813291-4134638421-1989498454-1002.1, Win32 error 5.  Terminating.
+```
+
+Exit code: 1
+
+Sanctioned substitution: Git Bash Win32 error 5 -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$p='skills\architect\loop.md'; if ((Select-String -Path $p -Pattern 'background subagent' -Quiet) -and (Select-String -Path $p -Pattern 'shutdown_request' -Quiet) -and (Select-String -Path $p -Pattern 'exit is the alert|completion re-?invokes' -Quiet)) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GL2
+
+Frozen command:
+
+```sh
+grep -Fq "docs/lanes/<issue-slug>-rulings.md" skills/architect/loop.md
+```
+
+Sanctioned substitution: Git Bash Win32 error 5 -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$p='skills\architect\loop.md'; if (Select-String -Path $p -Pattern 'docs/lanes/<issue-slug>-rulings.md' -SimpleMatch -Quiet) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GL3
+
+Frozen command:
+
+```sh
+grep -q "^## Factory block procedure" skills/architect/loop.md && grep -q "^## Monitor protocol" skills/architect/loop.md && grep -q "^## Verdict comments" skills/architect/loop.md && grep -q "^## Escalation digest" skills/architect/loop.md && grep -q "^## Failure ladder" skills/architect/loop.md
+```
+
+Sanctioned substitution: Git Bash Win32 error 5 -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$p='skills\architect\loop.md'; if ((Select-String -Path $p -Pattern '^## Factory block procedure' -Quiet) -and (Select-String -Path $p -Pattern '^## Monitor protocol' -Quiet) -and (Select-String -Path $p -Pattern '^## Verdict comments' -Quiet) -and (Select-String -Path $p -Pattern '^## Escalation digest' -Quiet) -and (Select-String -Path $p -Pattern '^## Failure ladder' -Quiet)) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GL4
+
+Frozen command:
+
+```sh
+! grep -qiE "tier[- ]?up|raising its model tier" skills/architect/loop.md
+```
+
+Sanctioned substitution: Git Bash Win32 error 5 -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$p='skills\architect\loop.md'; if (Select-String -Path $p -Pattern 'tier[- ]?up|raising its model tier' -Quiet) { exit 1 } else { exit 0 }
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+### GL5
+
+Frozen command:
+
+```sh
+uv run --no-project python tests/validate_skills.py
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+error: failed to open file `C:\Users\danhm\AppData\Local\uv\cache\sdists-v9\.git`: Access is denied. (os error 5)
+```
+
+Exit code: 1
+
+Sanctioned substitution: uv AppData cache denial -> `UV_CACHE_DIR=.architect/tmp/uv-cache`.
+
+Executed command:
+
+```powershell
+New-Item -ItemType Directory -Force .architect\tmp\uv-cache | Out-Null; $env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python tests/validate_skills.py
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Exit code: 0
+
+### GL6
+
+Frozen command:
+
+```sh
+[ "$(grep -cve '^[[:space:]]*$' skills/architect/loop.md)" -le 115 ]
+```
+
+Sanctioned substitution: Git Bash Win32 error 5 -> PowerShell same-pattern.
+
+Executed command:
+
+```powershell
+$count=(Get-Content skills\architect\loop.md | Where-Object { $_ -notmatch '^[\s]*$' }).Count; if ($count -le 115) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+
+```text
+```
+
+Exit code: 0
+
+## Files Touched
+
+- `skills/architect/loop.md`
+- `docs/lanes/v51-loop-01.md`
+
+## Final Non-Blank Count
+
+`skills/architect/loop.md`: 105
+
+STATUS: COMPLETE
+MIRROR: ORCHESTRATOR

--- a/docs/lanes/v51-skill-01.md
+++ b/docs/lanes/v51-skill-01.md
@@ -1,0 +1,186 @@
+# Lane report: v51-skill-01
+
+## PHASE 0
+
+Plan:
+1. Keep the v5 stage structure intact in `skills/architect/SKILL.md`.
+2. Add D1 inside `### 1. Intake`, next to existing mandatory preflight, so backend canaries run before decomposition records the brawn backend.
+3. Add D2 inside `### 2. Spec Gate` and `### 3. Decompose`, preserving the existing gates/freeze/decomposition flow while making `factory/<run>`, freeze commit, pushed branch, post-spawn HEAD verification, and frozen-file spot-check explicit.
+4. Add D4 inside `### 4. Factory Loop`, with the exact path `docs/lanes/<issue-slug>-rulings.md` and the judge-readable-file convention.
+5. Write only this report, then run the frozen gates sequentially and record verbatim output.
+
+Disagreements:
+1. The approved spec's `v51-rulings` deliverable says D4 spans `SKILL.md/loop.md/dispatch.md` plus builder/judge definitions (`docs/spec/architect-v5.1.md:176`), but this lane's gate and boundaries constrain the check to `skills/architect/SKILL.md` plus the lane report (`docs/gates/v51-skill.md:31`). I will implement only the SKILL.md pointer here.
+2. D4 says the rulings file is orchestrator-owned and committed before judge dispatch (`docs/spec/architect-v5.1.md:118`), while this slice declares `docs/lanes/*-rulings.md` read-only and only allows this lane report. I will not create or edit any `*-rulings.md`.
+3. D2 says spec approval cuts `factory/<run>` and all run commits land there (`docs/spec/architect-v5.1.md:91`); this worktree is actually on `lane/v51-skill-01` at `8e08b0b`. I can update the skill text to require the rule, but I cannot repair this run's branch topology from a builder lane.
+
+## Files touched
+
+- `skills/architect/SKILL.md`
+- `docs/lanes/v51-skill-01.md`
+
+## Gate results
+
+### GS1 - canary preflight present
+
+Frozen command:
+```sh
+grep -qi "canary" skills/architect/SKILL.md && grep -q "DEGRADED" skills/architect/SKILL.md
+```
+
+Executor: Git Bash via PowerShell
+
+Output:
+```text
+256
+      0 [main] bash (47652) C:\Program Files\Git\usr\bin\bash.exe: *** fatal error - CreateFileMapping S-1-5-21-940813291-4134638421-1989498454-1002.1, Win32 error 5.  Terminating.
+```
+
+Exit code: 256 observed via `$LASTEXITCODE`
+
+Sanctioned substitution: Git Bash Win32-error-5 -> PowerShell same-pattern.
+
+Executed command:
+```powershell
+$ok = (Select-String -Path skills/architect/SKILL.md -Pattern 'canary' -Quiet) -and (Select-String -Path skills/architect/SKILL.md -Pattern 'DEGRADED' -CaseSensitive -Quiet); if ($ok) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+```text
+
+```
+
+Exit code: 0
+
+### GS2 - freeze push dispatch preconditions present
+
+Frozen command:
+```sh
+grep -Fq "factory/<run>" skills/architect/SKILL.md && grep -qiE "hard-?stop" skills/architect/SKILL.md && grep -qiE "push(ed)?" skills/architect/SKILL.md && grep -qi "worktree" skills/architect/SKILL.md
+```
+
+Sanctioned substitution: Git Bash Win32-error-5 -> PowerShell same-pattern.
+
+Executed command:
+```powershell
+$text = Get-Content -Raw skills/architect/SKILL.md; $ok = $text.Contains('factory/<run>') -and ($text -match '(?i)hard-?stop') -and ($text -match '(?i)push(ed)?') -and ($text -match '(?i)worktree'); if ($ok) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+```text
+
+```
+
+Exit code: 0
+
+### GS3 - rulings-file convention named
+
+Frozen command:
+```sh
+grep -Fq "docs/lanes/<issue-slug>-rulings.md" skills/architect/SKILL.md
+```
+
+Sanctioned substitution: Git Bash Win32-error-5 -> PowerShell same-pattern.
+
+Executed command:
+```powershell
+$ok = (Get-Content -Raw skills/architect/SKILL.md).Contains('docs/lanes/<issue-slug>-rulings.md'); if ($ok) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+```text
+
+```
+
+Exit code: 0
+
+### GS4 - no tier escalation language
+
+Frozen command:
+```sh
+! grep -qiE "tier[- ]?up|raising its model tier" skills/architect/SKILL.md
+```
+
+Sanctioned substitution: Git Bash Win32-error-5 -> PowerShell same-pattern.
+
+Executed command:
+```powershell
+$found = Select-String -Path skills/architect/SKILL.md -Pattern 'tier[- ]?up|raising its model tier' -CaseSensitive:$false -Quiet; if (-not $found) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+```text
+
+```
+
+Exit code: 0
+
+### GS5 - validator green
+
+Frozen command:
+```sh
+uv run --no-project python tests/validate_skills.py
+```
+
+Executor: PowerShell
+
+Output:
+```text
+error: failed to open file `C:\Users\danhm\AppData\Local\uv\cache\sdists-v9\.git`: Access is denied. (os error 5)
+```
+
+Exit code: 1
+
+Sanctioned substitution: uv AppData cache denial -> `UV_CACHE_DIR=.architect/tmp/uv-cache`.
+
+Executed command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python tests/validate_skills.py
+```
+
+Executor: PowerShell
+
+Output:
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Exit code: 0
+
+### GS6 - size budget
+
+Frozen command:
+```sh
+[ "$(grep -cve '^[[:space:]]*$' skills/architect/SKILL.md)" -le 190 ]
+```
+
+Sanctioned substitution: Git Bash Win32-error-5 -> PowerShell same-pattern.
+
+Executed command:
+```powershell
+$count = (Get-Content skills/architect/SKILL.md | Where-Object { $_ -notmatch '^[\s]*$' }).Count; if ($count -le 190) { exit 0 } else { exit 1 }
+```
+
+Executor: PowerShell
+
+Output:
+```text
+
+```
+
+Exit code: 0
+
+## Final non-blank count
+
+`skills/architect/SKILL.md`: 177
+
+STATUS: COMPLETE
+MIRROR: ORCHESTRATOR

--- a/docs/spec/architect-v5.1.md
+++ b/docs/spec/architect-v5.1.md
@@ -1,6 +1,6 @@
 # Spec: architect v5.1 — hardening from the first factory run
 
-Status: DRAFT — awaiting human review at the spec gate.
+Status: APPROVED at the spec gate 2026-07-02 (human: "go"). A1-A5 stand unvetoed.
 Author: brain session, 2026-07-02 (same-day retro of the v5 dogfood run).
 Evidence base: epic #12 and issues #13–#18 (full verdict/ruling trail),
 `docs/solutions/` (4 codified diagnoses), `docs/lanes/v5-*-01.md` (raw lane

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -83,6 +83,14 @@ Preflight is mandatory and has no fallback: a GitHub remote exists, `gh auth
 status` passes, and `gh` is at least 2.94.0 for native `--blocked-by`,
 `--parent`, and `--blocking` support. Fail loudly if any precondition fails.
 
+Before decomposition records the brawn backend, canary every candidate backend
+once with a trivial task: list available tools; run `git log -1 --oneline` if a
+shell exists; reply `CANARY: SHELLS_OK` or `CANARY: DEGRADED`. A backend whose
+canary lacks a working shell executor is DEGRADED: select the fallback backend
+then, record the substitution and canary evidence on the epic, and resolve
+dispatch rules against that verified backend. Do not switch backend mid-wave
+unless a canary-passing backend later degrades; then use the failure ladder.
+
 Apply D9 while shaping the intake: name domain terms precisely, record sparse
 ADRs only for hard-to-reverse surprising trade-offs, and identify testing seams
 up front so builder lanes do not invent seams mid-flight.
@@ -97,6 +105,10 @@ or vetoes assumptions, and approves or rejects the plan. Approval authorizes
 the whole issue DAG; after approval, contact the human only through the epic
 digest or stop rails.
 
+On approval, cut `factory/<run>`. ALL run commits after approval, including
+spec amendments, gates, freeze, and lane merges, land on that branch. Main stays
+untouched until the single closing PR.
+
 Done when the approved spec and assumption rulings are committed or rejection
 is recorded.
 
@@ -109,6 +121,10 @@ Compile the approved spec into GitHub issues:
   may-touch and must-not-touch sets, gate path, raw-report path, and native
   parent plus blocked-by edges.
 - Gates per issue live in `docs/gates/` and freeze in git before dispatch.
+- Dispatch has hard-stop preconditions, in order: freeze committed on the
+  factory branch; factory branch pushed; after each spawn, verify the worktree
+  HEAD equals the freeze commit and spot-check one frozen file exists on disk.
+  Builders still perform FIRST-ACTION input verification as the last defense.
 - Run one cold read-only grill pass over the whole decomposition, not per
   issue. It attacks the DAG, gates, file-touch sets, dependency edges, missing
   context, non-falsifiable checks, and repo-name grep collisions.
@@ -151,6 +167,11 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
   Merge only after a passing verdict and clean touch-set evidence.
 - On BLOCKED, answer on the issue, cite durable evidence, and respawn a fresh
   builder with the answer using `dispatch.md` `## Respawn-with-answer template`.
+- Post-freeze rulings live append-only in
+  `docs/lanes/<issue-slug>-rulings.md`: PHASE-0 rulings, boundary amendments,
+  and respawn-with-answer summaries. The orchestrator owns the file, commits it
+  before judge dispatch, mirrors it to the issue thread for humans, and judges
+  read the file rather than thread prose.
 - On gate failure, diagnose from judge evidence, not a large direct diff. Fix
   the input, re-decompose, or stop; do not change tier because of failure.
 - On merge conflict, treat it as decomposition failure: kill the conflicting

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -84,15 +84,20 @@ or reports the gate BLOCKED — never silently skips a gate or invents output.
 
 ## C5 judge delegation template
 
-The orchestrator must send this template as-is except for replacing the three
-placeholder values. It must not add slice-specific prose, encouragement,
-summaries, or interpretation.
+The orchestrator must send this template as-is except for replacing
+placeholders. It must not add slice-specific prose, encouragement, summaries,
+or interpretation. Judge intent context is pointer-only: frozen gate file,
+spec pointer, lane report, and `docs/lanes/<issue-slug>-rulings.md`
+(orchestrator-owned, append-only; absent = no post-freeze rulings).
 
 <!-- architect-judge-template:start -->
 ```text
 Frozen gate file path: <docs/gates/<slice>.md>
 Freeze commit SHA: <freeze-sha>
 Branch to judge: <branch>
+Spec pointer: <spec path named by the frozen gate>
+Lane report: <docs/lanes/<issue-slug>-01.md>
+Rulings file: docs/lanes/<issue-slug>-rulings.md (absent = no post-freeze rulings)
 
 Verdict format:
 - Gates integrity: PASS | FAIL | INVALID
@@ -108,26 +113,77 @@ Verdict format:
 ```
 <!-- architect-judge-template:end -->
 
+## Codex judge delegation template
+
+The orchestrator must send this template as-is except for replacing the gate
+file path, freeze SHA, branch, and worktree note. It must not add slice-specific
+prose, encouragement, summaries, or interpretation.
+
+<!-- architect-codex-judge-template:start -->
+```text
+Frozen gate file path: <docs/gates/<slice>.md>
+Freeze commit SHA: <freeze-sha>
+Branch to judge: <branch>
+Worktree note: <worktree note>
+
+You are a cold read-only judge. You did not build this lane. Flag only gaps
+that affect correctness, the stated requirements, or documented project
+invariants -- cite file:line evidence for every finding. Do not report
+stylistic preferences.
+
+Tree audit: workspace-write exists only so validators can run. Any tracked-file
+modification during judgment means the verdict is discarded INVALID.
+
+Sanctioned substitutions, recorded per gate: Git Bash CreateFileMapping Win32
+error 5 -> PowerShell same-pattern; uv AppData cache denial -> run with
+`UV_CACHE_DIR=.architect/tmp/uv-cache`; gh unavailable -> report
+`MIRROR: ORCHESTRATOR`.
+
+Intent context pointers: frozen gate file above; spec pointer named by the
+frozen gate; lane report named by the issue/gate; rulings file
+`docs/lanes/<issue-slug>-rulings.md` (absent = no post-freeze rulings).
+
+Verdict format:
+- Gates integrity: PASS | FAIL | INVALID
+  Raw evidence: <git diff <freeze-sha>..HEAD -- docs/gates/>
+- Diff vs intent: PASS | FAIL | INVALID
+  Raw evidence: <file:line evidence from the diff and frozen gate/spec text>
+- Per gate:
+  - <gate id>: PASS | FAIL | INVALID
+    Command: <exact command from the frozen gate>
+    Executor: <executor used>
+    Raw evidence: <verbatim stdout/stderr and exit code>
+- Slice verdict: PASS | FAIL | INVALID
+  Decisive reason: <one sentence tied to raw evidence>
+```
+<!-- architect-codex-judge-template:end -->
+
 ## Grill delegation template
 
-The orchestrator must send this template as-is except for replacing the two
-placeholder values. It must not add slice-specific prose, encouragement,
-summaries, or interpretation.
+The orchestrator must send this template as-is except for replacing
+placeholders. It must not add slice-specific prose, encouragement, summaries,
+or interpretation.
 
 <!-- architect-grill-template:start -->
 ```text
 Draft gate file path: <docs/gates/<slice>.md>
 Branch: <branch>
+Issue bodies: <pasted issue bodies for this DAG>
 
 Task: try to falsify this draft. Execute each gate command against the
 current tree, verify every referenced path/SHA/pointer resolves, attack each
-acceptance criterion for non-falsifiability and for patterns that collide
-with repo realities (e.g. a grep pattern matching the repo's own name), and
-flag any assumption not evidenced in the repo.
+acceptance criterion and pasted issue bodies against the spec for
+contradictions and non-falsifiability, including patterns that collide with
+repo realities (e.g. a grep pattern matching the repo's own name), and flag any
+assumption not evidenced in the repo. For every file a lane deletes or renames,
+grep the whole repo for references and verify the owning lane's boundary covers
+them or a dependency edge orders the fix. For every NEW artifact path a lane
+will create, run `git check-ignore <path>` and flag the plan if ignored.
 
 Defect report format:
 - <gate id or clause>: FALSIFIED | HOLDS
   Evidence: <command run and verbatim output, or file:line>
+- DAG findings: <delete/rename reference and ignored-new-path findings, or none>
 - Assumptions not evidenced in the repo: <list or none>
 ```
 <!-- architect-grill-template:end -->
@@ -204,6 +260,11 @@ Claim is an orchestrator action, never a builder action: the orchestrator is
 the single dispatcher and assigns exactly one issue per lane immediately
 before spawning its builder. A builder never self-claims or picks its own
 next issue.
+
+On current backends, builders usually cannot post to issues: Codex has no
+network, and Claude subagents have a shell-strip watch item. `MIRROR:
+ORCHESTRATOR` is the normal mode; the orchestrator mirrors at event boundaries
+it already occupies. Direct builder posting stays permitted where supported.
 
 ```bash
 gh issue edit <n> --add-assignee "@me"   # orchestrator claims, before dispatch
@@ -287,6 +348,14 @@ There are no per-command kill ceilings. Long test suites are legitimate work,
 not stalls. Issue bodies and gate files may carry duration *hints* (e.g.
 "full suite ~ 20m") so the monitor does not flag a lane early; a hint is
 informative context for the monitor, never a ceiling anything enforces.
+
+Sanctioned substitutions:
+
+| Condition | Substitution | Citation |
+|---|---|---|
+| Git Bash CreateFileMapping Win32 error 5 in Codex sandbox | PowerShell same-pattern, recorded per gate | `docs/solutions/subagent-shell-strip-codex-fallback.md` |
+| `uv` AppData cache denial (os error 5) | `UV_CACHE_DIR=.architect/tmp/uv-cache`, recorded | `docs/solutions/uv-cache-sandbox-redirect.md` |
+| `gh` unavailable in sandbox | `MIRROR: ORCHESTRATOR` in the report | `docs/solutions/subagent-shell-strip-codex-fallback.md` |
 
 Liveness is judged from report/output file growth plus process-tree
 activity — never from wall-clock alone:

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -35,11 +35,17 @@ frontier, sleeps, and wakes only on an event.
 ## Monitor protocol
 
 One detection-only subagent (cheapest tier, e.g. haiku:low) is dispatched
+as a background subagent whose completion re-invokes the orchestrator; the
+exit is the alert channel. Teammate-style spawns idle instead of exiting
+and require a formal `shutdown_request` to stand down, so use that
+mechanism only when a teammate spawn is unavoidable. The monitor is sent
 with each wave — see `dispatch.md` "## Monitor dispatch". It sweeps every
 10 min: for each in-flight lane it checks report/output file growth since
 the last sweep, process-tree existence/activity, and a repeated-identical-
 command tail check. All healthy -> keep looping. All lanes done -> exit
-quietly. Anomaly -> exit immediately with an evidence report: lane id,
+quietly. In a normal all-green wave, harness notifications cover every
+event and the monitor's quiet exit is its only output; that is success,
+not waste. Anomaly -> exit immediately with an evidence report: lane id,
 minutes since last growth, tail excerpt, process state.
 
 The monitor never kills, never nudges, never decides — only the brain
@@ -55,6 +61,11 @@ is posted on the lane's issue with: per-gate PASS/FAIL/INVALID, a
 gates-integrity verdict, a diff-vs-intent verdict, the slice call
 KILL/CONTINUE, and the decisive reason tied to raw evidence — exact `gh`
 commands and comment format live in `dispatch.md` "## Issue conventions".
+The judge's intent context is exactly the frozen gate file, spec, lane
+report, and `docs/lanes/<issue-slug>-rulings.md`. That rulings file is
+orchestrator-owned, append-only, and committed before judge dispatch; if it
+is absent, there are no post-freeze rulings. Judge dispatch blocks carry no
+ruling prose.
 The issue is closed on merge. No verdict comment on an issue means the
 next factory block must not build on it as accepted; the brain may re-run
 judgment with a fresh judge if evidence is missing, but may not fill in a


### PR DESCRIPTION
Implements docs/spec/architect-v5.1.md (approved 2026-07-02). Second self-hosted factory run — epic #20 is the trail.

## What shipped
- Backend canary at preflight (D1) — exercised live: Claude backend DEGRADED 6/6, codex selected before decomposition.
- Factory branch + freeze→push→dispatch hard-stop preconditions with post-spawn worktree verification (D2) — main untouched until this PR.
- Extended grill: issue-body contradiction check, deleted-file reference sweep, git check-ignore committability check (D3) — falsified 8 draft gate clauses pre-freeze on its first run.
- Rulings files docs/lanes/<slug>-rulings.md as durable post-freeze intent (D4) — used twice this run (pre-dispatch facts; status-line ruling).
- Codex-judge template + sanctioned-substitutions table frozen in dispatch.md (D5).
- Monitor background-subagent semantics (D6) — this run's monitor exited ALL_DONE exactly per the new text.
- Issue-mirror reality documented (D7). Keep-list R1-R8 enforced (D8).

## Verification
5 issues, 5 first-try judge PASSes, zero judge FAILs, zero merge conflicts. Validator green; skill text 720/800 non-blank.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Issues shipped
Closes #20. Ships #21, #22, #23, #24, #25 (each closed at lane-merge time with its judge verdict on the issue).
