### PR TITLE
brawn default: codex-first (gpt-5.5 xhigh when Codex is on PATH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,15 @@ monitor agents the shell tools their gates require.
 
 ## Choosing your models
 
-Zero-config defaults: the brain is whatever session you launched; brawn runs
-one same-family tier down.
+Zero-config defaults: the brain is whatever session you launched; brawn is
+codex-first — GPT-5.5 at xhigh effort whenever the Codex CLI is installed,
+falling back to Sonnet at high reasoning only when it isn't.
 
-| Harness you launched | Brain | Default brawn |
-|---|---|---|
-| Claude Code | your session's model | `claude/tier-down` |
-| Codex | your session's model | `codex/tier-down` |
+| Harness you launched | Codex CLI on PATH? | Brain | Default brawn |
+|---|---|---|---|
+| Claude Code | yes | your session's model | `codex/best` (gpt-5.5, xhigh) |
+| Claude Code | no | your session's model | `claude/tier-down` (Sonnet, high) |
+| Codex | — | your session's model | `codex/best` (gpt-5.5, xhigh) |
 
 Override with flat `key = value` lines in `.architect/config` (repo) or
 `~/.architect/config` (user); repo wins. Optional routing rules send task

--- a/docs/solutions/cross-lane-content-dependency.md
+++ b/docs/solutions/cross-lane-content-dependency.md
@@ -1,4 +1,5 @@
 # Cross-Lane Content Dependency
+Recorded: 2026-07-02 (architect v5 dogfood run, epic #12)
 
 ## Problem
 

--- a/docs/solutions/subagent-shell-strip-codex-fallback.md
+++ b/docs/solutions/subagent-shell-strip-codex-fallback.md
@@ -1,4 +1,5 @@
 # Subagent Shell Strip and Codex Fallback
+Recorded: 2026-07-02 (architect v5 dogfood run, epic #12)
 
 ## Problem
 

--- a/docs/solutions/uv-cache-sandbox-redirect.md
+++ b/docs/solutions/uv-cache-sandbox-redirect.md
@@ -1,4 +1,5 @@
 # uv Cache Sandbox Redirect
+Recorded: 2026-07-02 (architect v5 dogfood run, epic #12)
 
 ## Problem
 

--- a/docs/solutions/worktree-stale-snapshot.md
+++ b/docs/solutions/worktree-stale-snapshot.md
@@ -1,4 +1,5 @@
 # Worktree Stale Snapshot
+Recorded: 2026-07-02 (architect v5 dogfood run, epic #12)
 
 ## Problem
 

--- a/skills/architect-research/SKILL.md
+++ b/skills/architect-research/SKILL.md
@@ -74,14 +74,16 @@ dispatch. State the plan in a few lines; proceed unless the user redirects.
 ### 3. Fan out
 
 Resolve the researcher model as brawn, same order as `/architect`: repo
-`.architect/config`, then user `~/.architect/config`, then the tier-down
-defaults in `skills/architect/dispatch.md`. One fresh researcher per lane,
-all parallel, in the background — this is the default-brawn example
-(codex/tier-down):
+`.architect/config`, then user `~/.architect/config`, then the codex-first
+default in `skills/architect/dispatch.md` — `codex/best` (gpt-5.5, xhigh)
+whenever the Codex CLI is on PATH; `claude/tier-down` (Sonnet at high) only
+when the orchestrator is Claude Code and Codex is absent. One fresh
+researcher per lane, all parallel, in the background — this is the
+default-brawn example (codex/best):
 
 ```bash
 codex exec --sandbox read-only -c web_search="live" \
-  -m gpt-5.5 -c model_reasoning_effort="high" \
+  -m gpt-5.5 -c model_reasoning_effort="xhigh" \
   -o .architect/research/<NN>-<lane>.md \
   - < .architect/research/<NN>-<lane>.prompt.md
 ```

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -29,9 +29,12 @@ flags in every command; this table is the source of those pins.
 
 Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` in `{claude,
 codex}`. Resolution order per role is repo `.architect/config`, then user
-`~/.architect/config`, then defaults: brain = the running session; brawn =
-tier-down per the alias table. Flat `key = value` lines are the supported
-format for role keys. Unknown keys warn and never fail.
+`~/.architect/config`, then defaults: brain = the running session; brawn is
+codex-first — `codex/best` (gpt-5.5, xhigh) whenever the Codex CLI is on
+PATH, from either harness (a Codex orchestrator trivially satisfies this);
+if the orchestrator is Claude Code and Codex is absent, brawn =
+`claude/tier-down` (Sonnet at high). Flat `key = value` lines are the
+supported format for role keys. Unknown keys warn and never fail.
 
 Optional dispatch-rules lines route task classes to a brawn tier:
 
@@ -44,13 +47,14 @@ when broad ambiguous refactor -> codex/best:xhigh # deeper search and edit budge
 ```
 
 Format: `when <task-class description> -> <cli>/<model-spec>[:<effort>] # why`.
-The trailing reason is optional but preferred. Absent file = tier-down default.
-Absent dispatch rules = tier-down default. A matching rule is still a judgment
-aid; the orchestrator records which rule was used and may override it with a
-reason recorded on the issue.
+The trailing reason is optional but preferred. Absent file = the codex-first
+default above. Absent dispatch rules = the codex-first default. A matching
+rule is still a judgment aid; the orchestrator records which rule was used
+and may override it with a reason recorded on the issue.
 
-Configured brawn CLI absent at preflight -> fall back to the tier-down default
-and write one epic-issue comment naming requested vs substituted. Cross-family
+Configured brawn CLI absent at preflight -> fall back per the codex-first
+default (on Claude Code without Codex: `claude/tier-down`) and write one
+epic-issue comment naming requested vs substituted. Cross-family
 review backend absent -> run review in a fresh same-CLI context and log the
 same-family bias caveat. Never hard-fail on model availability alone. Tier is
 fixed at decomposition by config plus dispatch rules and never moves because a


### PR DESCRIPTION
Human-directed change: both /architect and /architect-research default brawn to codex/best (gpt-5.5, xhigh) when the Codex CLI is installed — regardless of orchestrator harness — falling back to claude/tier-down (Sonnet, high) only on Claude Code without Codex. Backed by run evidence (codex-backend was the working lane path in both factory runs) and the D1 canary still verifies the backend live at preflight. Also: Recorded timestamps on docs/solutions entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)