### PR TITLE
Conversational status tree (factory run #43)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,8 @@ Glossary only. No implementation details, no spec content.
 - **Tracker** - GitHub issues are the coordination state: claims are
   assignments, progress and verdicts are comments, the tracking issue carries
   the digest. "Not in the tracker = didn't happen."
+- **Status tree** - a read-only render over run artifacts and the tracker;
+  never a new state store.
 - **Spec approval** - the one human step: review one spec document, edit or
   veto its recorded assumptions, approve in-session or by commenting
   `APPROVE` on the tracking issue. Verbatim pre-approval can authorize a run

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -397,6 +397,16 @@ loop-hardening research ([docs/research/loop-improvements.md](docs/research/loop
   repo and evidence rows need post-judgment information, so build jobs and
   the orchestrator never edit them mid-run; pointers accumulate and one
   docs job consumes them before the PR.
+- **Conversational status display.** Decision: a mid-run status question runs
+  the status tree script and prints that plain-text tree beside the prose
+  answer. Why: Lazyagent's agent-tree precedent shows the right visual shape;
+  Agent View does not list spawned subagents; `gh` 2.94 exposes the JSON tree
+  fields (`parent`, `blockedBy`, state) needed for a read-only issue view; and
+  chat surfaces do not render ANSI, so color follows `isatty` and `NO_COLOR`.
+  The run scripts are invoked from the repo root or with `-RepoRoot`;
+  live-watch was descoped by human ruling. Evidence:
+  [docs/research/status-display-evidence.md](docs/research/status-display-evidence.md)
+  and [docs/jobs/status-scripts-rulings.md](docs/jobs/status-scripts-rulings.md).
 - **Nontrivial diagnoses are codified to `docs/solutions/<slug>.md`** and
   read back at grounding, so each run makes the next one easier. Measured
   basis: [docs/research/lesson-store-evidence.md](docs/research/lesson-store-evidence.md).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ switch), irreversible actions, two consecutive killed jobs, scope growing
 beyond the approved spec, and blockers that collide with an approved
 assumption.
 
+**Ask it how it's going.** During a run, any status-flavored question prints
+the live status tree beside the prose answer. It is plain text, so it works
+in every surface; color auto-disables when piped. The script is also directly
+runnable from the repo root (`skills/architect/status.ps1` or
+`skills/architect/status.sh`), or from elsewhere by passing `-RepoRoot`.
+
+```text
+factory/status-tree
+orchestrator  running
+watchdog      idle
+✓ MERGED      status: skill wiring
+◐ JUDGING     status: scripts contract
+▣ REPORTED    status: docs closure
+● BUILDING    status: validator
+⊘ QUEUED      status: digest blocked by #46
+○ READY       status: follow-up
+```
+
 **GitHub is the memory.** Specs and frozen checks live in git; disagreements,
 blocker answers, verdicts, and the digest live as issue comments. Not in the
 tracker = didn't happen, and any later session can recover the run from

--- a/docs/checks/status-docs.md
+++ b/docs/checks/status-docs.md
@@ -1,0 +1,37 @@
+# Checks: status-docs
+
+Purpose: verify the docs closure for the status tree.
+Spec (fix contract): `docs/spec/status-tree.md` A5; evidence
+`docs/research/status-display-evidence.md`.
+Files owned: `README.md`, `CONTEXT.md`, `DESIGN.md`.
+
+Executor: PowerShell primary; native `git.exe` fine. Orchestrator
+bookkeeping commits exempt from touch-set checks.
+
+## SD1 — README
+
+- `git grep -ci "how's it going\|how it's going" -- README.md` → count ≥ 1
+- `git grep -ci "status.ps1" -- README.md` → count ≥ 1
+- README contains a fenced sample tree using at least three of the six
+  glyphs — quote the block.
+
+## SD2 — CONTEXT
+
+- `git grep -ci "status tree" -- CONTEXT.md` → count ≥ 1
+- The entry states it is a read-only render (quote the line); the glossary
+  above the retired-terms section stays clean:
+  PowerShell equivalent of `sed '/## Retired terms/,$d' CONTEXT.md` piped to
+  word-boundary grep for `gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag` → no output.
+
+## SD3 — DESIGN
+
+- `git grep -c "status-display-evidence" -- DESIGN.md` → count ≥ 1
+- `git grep -ci "status tree" -- DESIGN.md` → count ≥ 1
+- `git grep -ciE "lazyagent|agent view" -- DESIGN.md` → count ≥ 1
+- The entry notes live-watch was descoped by human ruling — quote it.
+
+## SD4 — link integrity self-check
+
+`git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md` — verify each
+listed target exists with `Test-Path`; paste results. (Full validator runs
+at composite.)

--- a/docs/checks/status-scripts.md
+++ b/docs/checks/status-scripts.md
@@ -32,25 +32,33 @@ if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
 ```
 PASS: `SS2_OK`.
 
-## SS3 — functional: fixture tree renders BUILDING, QUEUED, MERGED
+## SS3 — functional: degraded-mode phases render from fixtures
 
-Setup fixtures under `.architect/tmp/stfix/` simulating a run named in the
-job report (a fake worktree dir `wt/demo-job-01` containing no report; an
-events file `wt/demo-job-01.events.jsonl` whose last command event is
-recognizable, e.g. containing `"command":"pytest -q"`). Invoke the script
-with `-RepoRoot` pointed at a fixture root laid out like a repo (the script
-must accept the flag per the spec). Because `gh` is absent, the header must
-carry `tracker: unavailable (local view)`.
+Fixture layout (exact; no git repo needed — branch-read failure must yield
+`branch: unknown` and continue). Root 1 at `.architect/tmp/stfix/root1/`:
+
+```
+root1/.architect/wt/demo-build-01/            (worktree dir, no report inside)
+root1/.architect/wt/demo-build-01.events.jsonl  (last command event contains "command":"pytest -q")
+root1/.architect/wt/demo-blocked-01/docs/jobs/demo-blocked-01.md   (ends: STATUS: BLOCKED (x))
+root1/.architect/wt/demo-judge-01/docs/jobs/demo-judge-01.md      (ends: STATUS: COMPLETE)
+root1/.architect/wt/demo-judge-01.judge.md    (any content)
+root1/.architect/wt/demo-rep-01/docs/jobs/demo-rep-01.md          (ends: STATUS: COMPLETE)
+root1/docs/spec/demo.md                        (any content)
+```
+
+Root 2 at `.architect/tmp/stfix/root2/`: empty directory.
+
+Commands: run the ps1 with `-RepoRoot .architect/tmp/stfix/root1`, then with
+`-RepoRoot .architect/tmp/stfix/root2`. In this sandbox `gh` is present but
+fails auth — the script must treat failing gh identically to absent gh.
 
 PASS criteria (verbatim output pasted):
-- exit code 0
-- output contains `tracker: unavailable (local view)`
-- a `●` (BUILDING) line for the fixture job and a `last:` sub-line
-  containing `pytest -q`
-- with a second fixture where the report exists and ends
-  `STATUS: BLOCKED (x)`, a `!` line appears
-- with no factory artifacts at all (empty fixture root), output contains
-  `NO ACTIVE FACTORY RUN` and exit 0
+- root1: exit 0; header contains `tracker: unavailable (local view)` and
+  `branch: unknown`; a `●` line for demo-build with a `last:` sub-line
+  containing `pytest -q`; a `!` line for demo-blocked; a `◐` line for
+  demo-judge; a `▣` line for demo-rep; NO `✓`/`⊘`/`○` rows.
+- root2: exit 0; output contains `NO ACTIVE FACTORY RUN`.
 
 ## SS4 — piped output contains zero ESC bytes
 
@@ -65,8 +73,10 @@ PASS: `False`. (Same idea for status.sh is composite-side; record that.)
 
 - `(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count` → ≥1
 - `(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count` → ≥1
-- `(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count` → ≥2 (definition + call)
-- `$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"` → `SS5_OK`
+- `(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count` → ≥2 (definition + call; full enforcement is proven by the orchestrator's composite validator run)
+- `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"` → `SS5_OK`
+  (fresh cache dir — the shared `.architect/tmp/uv-cache` is corrupt in this
+  sandbox: `sdists-v9\.git` access denied)
 
 ## SS6 — read-only guard (static)
 

--- a/docs/checks/status-scripts.md
+++ b/docs/checks/status-scripts.md
@@ -1,0 +1,74 @@
+# Checks: status-scripts
+
+Purpose: verify the status-tree scripts and validator contract.
+Spec (fix contract): `docs/spec/status-tree.md` — Interface contract section.
+Files owned: `skills/architect/status.ps1`, `skills/architect/status.sh`,
+`tests/validate_skills.py`.
+
+Executor: PowerShell primary (MSYS binaries die in this sandbox); native
+`git.exe` fine. `gh` is unavailable here — degraded mode is the tested path.
+Orchestrator bookkeeping commits (reports under `docs/jobs/`, rulings) are
+exempt from touch-set checks. Fixtures live under `.architect/tmp/stfix/`.
+
+## SS1 — files exist with contract markers
+
+PowerShell, PASS criteria:
+- `Test-Path skills/architect/status.ps1; Test-Path skills/architect/status.sh` → `True`, `True`
+- Both scripts contain all six phase glyph markers (`✓`,`◐`,`!`,`●`,`⊘`,`○`
+  — in ps1 these may appear as `[char]0x2713` etc.; the check is that
+  `check_status_contract` in WA-style terms passes, see SS5) and the literal
+  `NO ACTIVE FACTORY RUN`:
+  `(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count` → ≥1
+  `(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count` → ≥1
+- `(Get-Content skills/architect/status.sh -TotalCount 1)` starts with `#!`
+
+## SS2 — ps1 parses
+
+Run directly in the PowerShell session (not nested `powershell -Command`):
+```powershell
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/status.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
+```
+PASS: `SS2_OK`.
+
+## SS3 — functional: fixture tree renders BUILDING, QUEUED, MERGED
+
+Setup fixtures under `.architect/tmp/stfix/` simulating a run named in the
+job report (a fake worktree dir `wt/demo-job-01` containing no report; an
+events file `wt/demo-job-01.events.jsonl` whose last command event is
+recognizable, e.g. containing `"command":"pytest -q"`). Invoke the script
+with `-RepoRoot` pointed at a fixture root laid out like a repo (the script
+must accept the flag per the spec). Because `gh` is absent, the header must
+carry `tracker: unavailable (local view)`.
+
+PASS criteria (verbatim output pasted):
+- exit code 0
+- output contains `tracker: unavailable (local view)`
+- a `●` (BUILDING) line for the fixture job and a `last:` sub-line
+  containing `pytest -q`
+- with a second fixture where the report exists and ends
+  `STATUS: BLOCKED (x)`, a `!` line appears
+- with no factory artifacts at all (empty fixture root), output contains
+  `NO ACTIVE FACTORY RUN` and exit 0
+
+## SS4 — piped output contains zero ESC bytes
+
+PowerShell:
+```powershell
+$out = & powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1 | Out-String
+([Text.Encoding]::UTF8.GetBytes($out) -contains 27)
+```
+PASS: `False`. (Same idea for status.sh is composite-side; record that.)
+
+## SS5 — validator contract
+
+- `(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count` → ≥1
+- `(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count` → ≥1
+- `(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count` → ≥2 (definition + call)
+- `$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"` → `SS5_OK`
+
+## SS6 — read-only guard (static)
+
+`Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'`
+PASS: no matches — the status tree reads; it never mutates.

--- a/docs/checks/status-tracker.md
+++ b/docs/checks/status-tracker.md
@@ -1,0 +1,40 @@
+# Checks: status-tracker (addendum to status-scripts, second-FAIL re-spec)
+
+Purpose: statically verify the tracker-mode algorithm in BOTH scripts —
+the gh path cannot execute in this sandbox, so these checks pin the
+algorithm's load-bearing features; the orchestrator proves behavior with a
+live render at composite.
+Spec (fix contract): `docs/spec/status-tree.md` — the amended tracker-mode
+algorithm in the Interface contract.
+Files owned: unchanged from `docs/checks/status-scripts.md`.
+
+## ST1 — one gh call with the full-state shape, in both scripts
+
+- `(Select-String -Path skills/architect/status.ps1 -Pattern '--state all').Count` → ≥1
+- `(Select-String -Path skills/architect/status.sh -Pattern '--state all').Count` → ≥1
+- `(Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'blockedBy').Count` → ≥2
+
+## ST2 — parent filtering exists in both scripts
+
+- `(Select-String -Path skills/architect/status.ps1 -Pattern 'parent').Count` → ≥1
+- `(Select-String -Path skills/architect/status.sh -Pattern 'parent').Count` → ≥1
+- Quote the sh lines that (a) select the tracking-issue candidate from
+  `parent.number` references and (b) filter sub-issues by that parent —
+  file:line, verbatim.
+
+## ST3 — successful-empty and no-candidate handling
+
+- Both scripts contain the literal `tracker: no open run` → Select-String
+  count ≥1 each.
+- Quote the sh branch showing `[]`/no-candidate leads to
+  `NO ACTIVE FACTORY RUN` when no artifacts exist — file:line, verbatim.
+
+## ST4 — parity statement
+
+- The report quotes both scripts' tracker-mode sections side by side and
+  states any behavioral difference found (target: none).
+
+## ST5 — regression: SS1-SS6 all still pass
+
+- Re-run every check in `docs/checks/status-scripts.md` and record
+  verbatim output (the fixtures and degraded mode must be unaffected).

--- a/docs/checks/status-tracker.md
+++ b/docs/checks/status-tracker.md
@@ -38,3 +38,30 @@ Files owned: unchanged from `docs/checks/status-scripts.md`.
 
 - Re-run every check in `docs/checks/status-scripts.md` and record
   verbatim output (the fixtures and degraded mode must be unaffected).
+
+## ST6-ST8 — third-judgment re-architecture addendum (pinned jq, stub seam)
+
+Added by orchestrator ruling after the third judgment (see rulings file);
+no prior ST results are invalidated.
+
+### ST6 — the pinned jq expression appears VERBATIM in both scripts
+
+- Extract the `--jq` expression from each script and diff it against the
+  spec's pinned block — quote both and state `IDENTICAL` or the diff.
+
+### ST7 — stub-seam render matches the live-verified sample
+
+- Write the spec's four sample lines (TRACK/SUB x3) to
+  `.architect/tmp/stfix/stub.tsv`; run BOTH... the ps1 with
+  `STATUS_GH_STUB` set to that file against fixture root1. PASS: output
+  contains a `✓` row for issue 45, `⊘` (or artifact-phase) rows for 44/46
+  with 46 listing blocker 44, tracker header shows `#43`, and NO `?` or
+  other out-of-contract glyph appears. Verbatim output pasted.
+- Second stub containing only `NOOPENRUN` against empty root2. PASS:
+  `NO ACTIVE FACTORY RUN`.
+
+### ST8 — stray-file guard
+
+- With fixture root1 plus a stray `.architect/wt/ghost-01.events.jsonl`
+  (no `ghost-01/` directory), the render contains NO `ghost` row. Verbatim
+  output pasted.

--- a/docs/checks/status-wiring.md
+++ b/docs/checks/status-wiring.md
@@ -19,10 +19,12 @@ Commands (`git grep -c` prints `<path>:<count>`) and PASS criteria:
 ## SW2 — size guard with headroom evidence
 
 ```powershell
-$env:UV_CACHE_DIR='.architect/tmp/uv-cache'
-uv run --no-project python -c "t=sum(1 for p in ['skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'] for l in open(p,encoding='utf-8') if l.strip()); print(t)"
+$files='skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'
+$total=($files | ForEach-Object { (Get-Content $_ | Where-Object { $_.Trim() }).Count } | Measure-Object -Sum).Sum
+"TOTAL $total"
 ```
-PASS: printed total ≤ 799 (was 789 at freeze; net addition ≤ 10).
+PASS: `TOTAL` ≤ 799 (measured 789 at freeze; net addition ≤ 10). Pure
+PowerShell on purpose — the shared uv cache is corrupt in this sandbox.
 
 ## SW3 — no collateral edits
 

--- a/docs/checks/status-wiring.md
+++ b/docs/checks/status-wiring.md
@@ -1,0 +1,34 @@
+# Checks: status-wiring
+
+Purpose: verify the skill wiring for the status tree under the size cap.
+Spec (fix contract): `docs/spec/status-tree.md` — A4 cap is binding.
+Files owned: `skills/architect/SKILL.md`, `skills/architect/dispatch.md`.
+
+Executor: PowerShell primary; native `git.exe` fine. Orchestrator
+bookkeeping commits exempt from touch-set checks.
+
+## SW1 — wiring present
+
+Commands (`git grep -c` prints `<path>:<count>`) and PASS criteria:
+- `git grep -ci "status.ps1" -- skills/architect/SKILL.md` → count ≥ 1
+- `git grep -c "verbatim" -- skills/architect/SKILL.md` → count ≥ 1
+  (the print-it-verbatim, never-hand-compose rule)
+- `git grep -c "## Status display" -- skills/architect/dispatch.md` → count 1
+- `git grep -ci "status.sh" -- skills/architect/dispatch.md` → count ≥ 1
+
+## SW2 — size guard with headroom evidence
+
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'
+uv run --no-project python -c "t=sum(1 for p in ['skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'] for l in open(p,encoding='utf-8') if l.strip()); print(t)"
+```
+PASS: printed total ≤ 799 (was 789 at freeze; net addition ≤ 10).
+
+## SW3 — no collateral edits
+
+- `git diff --name-only <freeze-sha-on-your-HEAD>..HEAD` at report time plus
+  final `git status --short` must show only the two owned files (and the
+  exempt report). Paste both.
+- `git grep -c "## Factory Loop\|### 4. Factory Loop" -- skills/architect/SKILL.md` → count ≥ 1 (section survived)
+- Pointer integrity: every `dispatch.md section` pointer named in SKILL.md
+  still resolves — list each and its heading grep count of 1.

--- a/docs/jobs/status-docs-01.md
+++ b/docs/jobs/status-docs-01.md
@@ -1,0 +1,226 @@
+# status-docs-01
+
+MIRROR: ORCHESTRATOR
+
+## Phase 0
+
+| Item | Result |
+|---|---|
+| Plan | Verify HEAD and frozen check file; inspect `docs/checks/status-docs.md`, `docs/spec/status-tree.md`, `docs/research/status-display-evidence.md`, `docs/jobs/status-scripts-rulings.md`, `README.md`, `CONTEXT.md`, `DESIGN.md`; edit only `README.md`, `CONTEXT.md`, `DESIGN.md`; run `docs/checks/status-docs.md` checks sequentially; write `docs/jobs/status-docs-01.md`. |
+| Checked before concluding issue was sound | `docs/spec/status-tree.md` A5 assigns docs closure to `README.md`, `CONTEXT.md`, `DESIGN.md`; `docs/checks/status-docs.md` checks only those docs plus link targets; `docs/research/status-display-evidence.md` and `docs/jobs/status-scripts-rulings.md` provide the requested citation basis. |
+| Disagreement | `docs/spec/status-tree.md` phase table lists seven phase glyphs including `!` for BLOCKED, while GitHub #46 asks the README sample to use six glyphs. Non-blocking execution used the six non-`!` tree glyphs in the compact sample. |
+
+### First-Action Verification
+
+Command:
+```powershell
+git log -1 --oneline
+```
+Output:
+```text
+e92dd50 orchestrator fix completion: restore stderr suppression now that jq quoting is fixed (#44)
+```
+
+Command:
+```powershell
+Test-Path -LiteralPath 'docs/checks/status-docs.md'; if (Test-Path -LiteralPath 'docs/checks/status-docs.md') { Get-Item -LiteralPath 'docs/checks/status-docs.md' | Select-Object -ExpandProperty FullName }
+```
+Output:
+```text
+True
+C:\Users\danhm\architect-loop\.architect\wt\status-docs-01\docs\checks\status-docs.md
+```
+
+Command:
+```powershell
+git merge-base --is-ancestor eacc00e HEAD; if ($LASTEXITCODE -eq 0) { 'eacc00e is ancestor' } else { "eacc00e ancestor check failed: exit $LASTEXITCODE" }
+```
+Output:
+```text
+eacc00e is ancestor
+```
+
+Command:
+```powershell
+git diff --name-only
+```
+Output:
+```text
+CONTEXT.md
+DESIGN.md
+README.md
+warning: in the working copy of 'CONTEXT.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'DESIGN.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'README.md', LF will be replaced by CRLF the next time Git touches it
+```
+
+## SD1 - README
+
+Command:
+```powershell
+git grep -ci "how's it going\|how it's going" -- README.md
+```
+Output:
+```text
+README.md:1
+```
+
+Command:
+```powershell
+git grep -ci "status.ps1" -- README.md
+```
+Output:
+```text
+README.md:1
+```
+
+Command:
+```powershell
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); $OutputEncoding = [Console]::OutputEncoding; $utf8 = [System.Text.UTF8Encoding]::new($false, $true); $lines = [System.IO.File]::ReadAllLines((Resolve-Path -LiteralPath 'README.md'), $utf8); $start = [Array]::IndexOf($lines, '```text'); $lines[$start..($start + 10)]
+```
+Output:
+````text
+```text
+factory/status-tree
+orchestrator  running
+watchdog      idle
+✓ MERGED      status: skill wiring
+◐ JUDGING     status: scripts contract
+▣ REPORTED    status: docs closure
+● BUILDING    status: validator
+⊘ QUEUED      status: digest blocked by #46
+○ READY       status: follow-up
+```
+````
+
+## SD2 - CONTEXT
+
+Command:
+```powershell
+git grep -ci "status tree" -- CONTEXT.md
+```
+Output:
+```text
+CONTEXT.md:1
+```
+
+Command:
+```powershell
+git grep -i "read-only render" -- CONTEXT.md
+```
+Output:
+```text
+CONTEXT.md:- **Status tree** - a read-only render over run artifacts and the tracker;
+```
+
+Command:
+```powershell
+$content = Get-Content -LiteralPath 'CONTEXT.md'; $retired = ($content | Select-String -Pattern '^## Retired terms').LineNumber; $before = $content[0..($retired - 2)]; $before | Select-String -Pattern '\b(gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag)\b' -CaseSensitive:$false
+```
+Output:
+```text
+```
+
+## SD3 - DESIGN
+
+Command:
+```powershell
+git grep -c "status-display-evidence" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:1
+```
+
+Command:
+```powershell
+git grep -ci "status tree" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:1
+```
+
+Command:
+```powershell
+git grep -ciE "lazyagent|agent view" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:2
+```
+
+Command:
+```powershell
+git grep -i "live-watch was descoped" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:  live-watch was descoped by human ruling. Evidence:
+```
+
+## SD4 - link integrity self-check
+
+Command:
+```powershell
+git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md
+```
+Output:
+```text
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/adr/0001-in-session-loop-replaces-external-driver.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/spec/architect-v5.1.md)
+DESIGN.md:](docs/research/loop-improvements.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/solutions/worktree-stale-snapshot.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/research/status-display-evidence.md)
+DESIGN.md:](docs/jobs/status-scripts-rulings.md)
+DESIGN.md:](docs/research/lesson-store-evidence.md)
+DESIGN.md:](docs/research/loop-improvements.md)
+DESIGN.md:](docs/research/agent-pipeline-patterns.md)
+DESIGN.md:](docs/adr/0001-in-session-loop-replaces-external-driver.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/solutions/subagent-shell-strip-codex-fallback.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/solutions/git-bash-msys-codex-sandbox.md)
+DESIGN.md:](docs/solutions/uv-cache-sandbox-redirect.md)
+```
+
+Command:
+```powershell
+$lines = git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md; foreach ($line in $lines) { if ($line -match '\]\((docs/[^)#]+)\)') { $target = $Matches[1]; '{0}: {1}' -f $target, (Test-Path -LiteralPath $target) } }
+```
+Output:
+```text
+docs/spec/architect-v5.md: True
+docs/adr/0001-in-session-loop-replaces-external-driver.md: True
+docs/research/autonomous-software-factory.md: True
+docs/spec/architect-v5.md: True
+docs/research/autonomous-software-factory.md: True
+docs/spec/architect-v5.md: True
+docs/spec/architect-v5.1.md: True
+docs/research/loop-improvements.md: True
+docs/research/autonomous-software-factory.md: True
+docs/research/factory-hardening-evidence.md: True
+docs/solutions/worktree-stale-snapshot.md: True
+docs/research/factory-hardening-evidence.md: True
+docs/research/status-display-evidence.md: True
+docs/jobs/status-scripts-rulings.md: True
+docs/research/lesson-store-evidence.md: True
+docs/research/loop-improvements.md: True
+docs/research/agent-pipeline-patterns.md: True
+docs/adr/0001-in-session-loop-replaces-external-driver.md: True
+docs/spec/architect-v5.md: True
+docs/solutions/subagent-shell-strip-codex-fallback.md: True
+docs/research/factory-hardening-evidence.md: True
+docs/solutions/git-bash-msys-codex-sandbox.md: True
+docs/solutions/uv-cache-sandbox-redirect.md: True
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/status-scripts-01.md
+++ b/docs/jobs/status-scripts-01.md
@@ -203,3 +203,127 @@ Output:
 ```
 
 STATUS: COMPLETE
+
+## Respawn session
+
+Ruling addressed: `skills/architect/status.sh` no longer selects the lexically last `docs/spec/*.md`; it scans spec files and chooses the newest numeric mtime using `stat -c %Y` with `stat -f %m` fallback.
+
+MTIME FIXTURE
+
+Command:
+```
+$base = '.architect/tmp/stfix'
+New-Item -ItemType Directory -Force -Path "$base/root1/docs/spec" | Out-Null
+Set-Content -LiteralPath "$base/root1/docs/spec/zzz-old.md" -Encoding UTF8 -Value 'old lexical winner'
+Start-Sleep -Milliseconds 25
+Set-Content -LiteralPath "$base/root1/docs/spec/aaa-new.md" -Encoding UTF8 -Value 'new mtime winner'
+Set-Content -LiteralPath "$base/root1/docs/spec/demo.md" -Encoding UTF8 -Value 'demo older than both'
+(Get-Item -LiteralPath "$base/root1/docs/spec/demo.md").LastWriteTimeUtc = [datetime]'2024-01-01T00:00:00Z'
+(Get-Item -LiteralPath "$base/root1/docs/spec/zzz-old.md").LastWriteTimeUtc = [datetime]'2025-01-01T00:00:00Z'
+(Get-Item -LiteralPath "$base/root1/docs/spec/aaa-new.md").LastWriteTimeUtc = [datetime]'2026-01-01T00:00:00Z'
+Get-ChildItem -LiteralPath "$base/root1/docs/spec" -Filter '*.md' | Sort-Object Name | ForEach-Object { "$($_.Name) $($_.LastWriteTimeUtc.ToString('o'))" }
+```
+Output:
+```
+aaa-new.md 2026-01-01T00:00:00.0000000Z
+demo.md 2024-01-01T00:00:00.0000000Z
+zzz-old.md 2025-01-01T00:00:00.0000000Z
+```
+
+STATUS.SH MTIME STATIC PROOF
+
+Command:
+```
+Select-String -Path skills/architect/status.sh -Pattern 'stat -c %Y|stat -f %m|find "\$root/docs/spec".*\|\s*sort'
+```
+Output:
+```
+
+skills\architect\status.sh:20:    mtime=$(stat -c %Y "$spec" 2>/dev/null || stat -f %m "$spec" 2>/dev/null || printf 0)
+
+```
+
+Shell functional note: per respawn instruction, MSYS binaries die in this sandbox and `skills/architect/status.sh` cannot be executed here. I did not run Bash. The shell script is validated statically here; the orchestrator composite runner must execute the shell functional pass.
+
+SS1
+
+Command:
+```
+Test-Path skills/architect/status.ps1
+Test-Path skills/architect/status.sh
+(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Get-Content skills/architect/status.sh -TotalCount 1)
+```
+Output:
+```
+True
+True
+1
+1
+#!/usr/bin/env bash
+```
+
+SS3 ROOT1
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+```
+Output:
+```
+STATUS TREE spec: aaa-new.md branch: unknown
+tracker: unavailable (local view)
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+```
+
+SS3 ROOT2
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+```
+Output:
+```
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+SS6
+
+Command:
+```
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'
+```
+Output:
+```
+```
+
+VALIDATOR
+
+Command:
+```
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python tests/validate_skills.py
+```
+Output:
+```
+OK - 2 skills validated, v4 contracts clean
+```
+
+DOCS CHECKS DIFF
+
+Command:
+```
+git diff --name-only -- docs/checks
+```
+Output:
+```
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/status-scripts-01.md
+++ b/docs/jobs/status-scripts-01.md
@@ -204,6 +204,369 @@ Output:
 
 STATUS: COMPLETE
 
+## Re-spec session
+
+PRECONDITION
+
+Command:
+```
+git cat-file -e HEAD:docs/checks/status-tracker.md
+git show HEAD:docs/spec/status-tree.md | Select-String -Pattern 'tracker: no open run'
+```
+Output:
+```
+check_exit=0
+spec_has_tracker_no_open_run=True
+```
+
+ST1
+
+Command:
+```
+(Select-String -Path skills/architect/status.ps1 -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.sh -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'blockedBy').Count
+```
+Output:
+```
+1
+1
+4
+```
+
+ST2
+
+Command:
+```
+(Select-String -Path skills/architect/status.ps1 -Pattern 'parent').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'parent').Count
+Select-String -Path skills/architect/status.sh -Pattern 'parent_refs|parent_number|tracking' | ForEach-Object { "$($_.Path):$($_.LineNumber):$($_.Line)" }
+```
+Output:
+```
+4
+7
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:39:parent_number(){ printf '%s' "$1" | sed -n 's/.*"parent"[[:space:]]*:[[:space:]]*{[^}]*"number"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1; }
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:93:tracking=
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:96:  parent_refs=' '
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:98:    p=$(parent_number "$obj")
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:99:    [ -n "$p" ] && parent_refs="$parent_refs$p "
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:107:    case "$parent_refs" in *" $num "*)
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:108:      if [ "$num" -gt "$highest" ]; then highest=$num; tracking=$num; fi
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:114:if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:119:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:120:  printf 'tracker: #%s\n' "$tracking"
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:130:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:132:    [ "$(parent_number "$obj")" = "$tracking" ] || continue
+```
+
+ST3
+
+Command:
+```
+(Select-String -Path skills/architect/status.ps1 -Pattern 'tracker: no open run').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'tracker: no open run').Count
+Show-Lines 'skills/architect/status.sh' 112 123
+```
+Output:
+```
+1
+1
+skills/architect/status.sh:112:fi
+skills/architect/status.sh:113:slugs=$(artifact_slugs)
+skills/architect/status.sh:114:if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
+skills/architect/status.sh:115:  printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
+skills/architect/status.sh:116:  exit 0
+skills/architect/status.sh:117:fi
+skills/architect/status.sh:118:printf 'STATUS TREE spec: %s branch: %s\n' "$(newest_spec)" "$branch"
+skills/architect/status.sh:119:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+skills/architect/status.sh:120:  printf 'tracker: #%s\n' "$tracking"
+skills/architect/status.sh:121:elif [ "$tracker" -eq 1 ]; then
+skills/architect/status.sh:122:  printf 'tracker: no open run\n'
+skills/architect/status.sh:123:else
+```
+
+ST4
+
+PowerShell tracker section:
+```
+skills/architect/status.ps1:83:$ghJson = ""
+skills/architect/status.ps1:84:$trackerReachable = $false
+skills/architect/status.ps1:85:if (Get-Command gh) {
+skills/architect/status.ps1:86:    try { $ghJson = (& gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>$null); $trackerReachable = ($LASTEXITCODE -eq 0) }
+skills/architect/status.ps1:87:    catch { $ghJson = ""; $trackerReachable = $false }
+skills/architect/status.ps1:88:}
+skills/architect/status.ps1:89:$issues = @()
+skills/architect/status.ps1:90:if ($trackerReachable -and $ghJson) { try { $issues = @($ghJson | ConvertFrom-Json) } catch { $issues = @() } }
+skills/architect/status.ps1:91:$parentRefs = @($issues | Where-Object { $_.parent } | ForEach-Object { $_.parent.number } | Select-Object -Unique)
+skills/architect/status.ps1:92:$trackingIssue = @($issues | Where-Object { $_.state -eq "OPEN" -and $parentRefs -contains $_.number } | Sort-Object number -Descending | Select-Object -First 1)
+skills/architect/status.ps1:93:$tracking = ""
+skills/architect/status.ps1:94:$subIssues = @()
+skills/architect/status.ps1:95:if ($trackingIssue.Count -gt 0) {
+skills/architect/status.ps1:96:    $tracking = $trackingIssue[0].number
+skills/architect/status.ps1:97:    $subIssues = @($issues | Where-Object { $_.parent -and $_.parent.number -eq $tracking })
+skills/architect/status.ps1:98:}
+skills/architect/status.ps1:99:$slugs = ArtifactSlugs
+skills/architect/status.ps1:100:if (((-not $trackerReachable) -or ($trackerReachable -and -not $tracking)) -and $slugs.Count -eq 0) {
+skills/architect/status.ps1:101:    Write-Output "NO ACTIVE FACTORY RUN"
+skills/architect/status.ps1:102:    Write-Output "spec: $(NewestSpec)"
+skills/architect/status.ps1:103:    exit 0
+skills/architect/status.ps1:104:}
+skills/architect/status.ps1:105:Write-Output "STATUS TREE spec: $(NewestSpec) branch: $branch"
+skills/architect/status.ps1:106:if ($trackerReachable -and $tracking) { Write-Output "tracker: #$tracking" } elseif ($trackerReachable) { Write-Output "tracker: no open run" } else { Write-Output "tracker: unavailable (local view)" }
+skills/architect/status.ps1:107:Write-Output "ORCHESTRATOR: local view"
+skills/architect/status.ps1:108:$wdCfg = @(Get-ChildItem -LiteralPath (J $root ".architect/tmp") -Filter "wd-*.json")
+skills/architect/status.ps1:109:$wdProc = @(Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -match 'watchdog\.(ps1|sh)' })
+skills/architect/status.ps1:110:Write-Output "WATCHDOG: process=$($wdProc.Count -gt 0) config=$($wdCfg.Count)"
+skills/architect/status.ps1:111:if ($trackerReachable -and $tracking) {
+skills/architect/status.ps1:112:    foreach ($issue in $subIssues) {
+skills/architect/status.ps1:113:        $slug = Slugify $issue.title
+skills/architect/status.ps1:114:        $p = Phase $slug $issue
+skills/architect/status.ps1:115:        $extra = ""
+skills/architect/status.ps1:116:        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + ((OpenBlockerNumbers $issue) -join ",") }
+skills/architect/status.ps1:117:        Write-Output "$($p[0]) #$($issue.number) $($issue.title) .architect/wt/$slug-01$extra"
+skills/architect/status.ps1:118:        if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
+skills/architect/status.ps1:119:    }
+skills/architect/status.ps1:120:} else {
+skills/architect/status.ps1:121:    foreach ($slug in $slugs) {
+skills/architect/status.ps1:122:        $p = Phase $slug $null
+skills/architect/status.ps1:123:        if ($p[1] -in @("BUILDING", "BLOCKED", "JUDGING", "REPORTED")) {
+skills/architect/status.ps1:124:            Write-Output "$($p[0]) $slug .architect/wt/$slug-01"
+skills/architect/status.ps1:125:            if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
+skills/architect/status.ps1:126:        }
+```
+
+Shell tracker section:
+```
+skills/architect/status.sh:85:gh_json=
+skills/architect/status.sh:86:tracker=0
+skills/architect/status.sh:87:if command -v gh >/dev/null 2>&1; then
+skills/architect/status.sh:88:  if gh_json=$(gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>/dev/null); then
+skills/architect/status.sh:89:    tracker=1
+skills/architect/status.sh:90:  fi
+skills/architect/status.sh:91:fi
+skills/architect/status.sh:92:issue_objs=
+skills/architect/status.sh:93:tracking=
+skills/architect/status.sh:94:if [ "$tracker" -eq 1 ]; then
+skills/architect/status.sh:95:  issue_objs=$(printf '%s\n' "$gh_json" | json_objects)
+skills/architect/status.sh:96:  parent_refs=' '
+skills/architect/status.sh:97:  while IFS= read -r obj; do
+skills/architect/status.sh:98:    p=$(parent_number "$obj")
+skills/architect/status.sh:99:    [ -n "$p" ] && parent_refs="$parent_refs$p "
+skills/architect/status.sh:100:  done <<< "$issue_objs"
+skills/architect/status.sh:101:  highest=0
+skills/architect/status.sh:102:  while IFS= read -r obj; do
+skills/architect/status.sh:103:    num=$(issue_number "$obj")
+skills/architect/status.sh:104:    state=$(issue_state "$obj")
+skills/architect/status.sh:105:    [ -n "$num" ] || continue
+skills/architect/status.sh:106:    [ "$state" = OPEN ] || continue
+skills/architect/status.sh:107:    case "$parent_refs" in *" $num "*)
+skills/architect/status.sh:108:      if [ "$num" -gt "$highest" ]; then highest=$num; tracking=$num; fi
+skills/architect/status.sh:109:      ;;
+skills/architect/status.sh:110:    esac
+skills/architect/status.sh:111:  done <<< "$issue_objs"
+skills/architect/status.sh:112:fi
+skills/architect/status.sh:113:slugs=$(artifact_slugs)
+skills/architect/status.sh:114:if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
+skills/architect/status.sh:115:  printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
+skills/architect/status.sh:116:  exit 0
+skills/architect/status.sh:117:fi
+skills/architect/status.sh:118:printf 'STATUS TREE spec: %s branch: %s\n' "$(newest_spec)" "$branch"
+skills/architect/status.sh:119:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+skills/architect/status.sh:120:  printf 'tracker: #%s\n' "$tracking"
+skills/architect/status.sh:121:elif [ "$tracker" -eq 1 ]; then
+skills/architect/status.sh:122:  printf 'tracker: no open run\n'
+skills/architect/status.sh:123:else
+skills/architect/status.sh:124:  printf 'tracker: unavailable (local view)\n'
+skills/architect/status.sh:125:fi
+skills/architect/status.sh:126:printf 'ORCHESTRATOR: local view\n'
+skills/architect/status.sh:127:cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/null | wc -l | tr -d ' ')
+skills/architect/status.sh:128:ps -eo args= 2>/dev/null | grep 'watchdog\.\(ps1\|sh\)' >/dev/null && proc=True || proc=False
+skills/architect/status.sh:129:printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
+skills/architect/status.sh:130:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+skills/architect/status.sh:131:  while IFS= read -r obj; do
+skills/architect/status.sh:132:    [ "$(parent_number "$obj")" = "$tracking" ] || continue
+skills/architect/status.sh:133:    num=$(issue_number "$obj")
+skills/architect/status.sh:134:    title=$(issue_title "$obj")
+skills/architect/status.sh:135:    state=$(issue_state "$obj")
+skills/architect/status.sh:136:    blockers=$(open_blockers "$obj")
+skills/architect/status.sh:137:    [ -n "$num" ] || continue
+skills/architect/status.sh:138:    slug=$(slugify "$title"); set -- $(phase "$slug" "$state" "$blockers")
+skills/architect/status.sh:139:    extra=; [ "$2" = QUEUED ] && extra=" blocked-by: $blockers"
+skills/architect/status.sh:140:    printf '%s #%s %s .architect/wt/%s-01%s\n' "$1" "$num" "$title" "$slug" "$extra"
+skills/architect/status.sh:141:    [ "$2" = BUILDING ] && last_command "$slug"
+skills/architect/status.sh:142:  done <<< "$issue_objs"
+skills/architect/status.sh:143:else
+skills/architect/status.sh:144:  for slug in $slugs; do
+```
+
+Parity statement:
+```
+Behavioral difference found: none. Both scripts make one all-state gh call, compute open tracking candidates from referenced parent numbers, choose the highest-numbered candidate, render only sub-issues for that parent, filter QUEUED blockers to OPEN blockers, and use tracker: no open run for reachable-empty/no-candidate local views.
+```
+
+ST5 / SS1
+
+Command:
+```
+Test-Path skills/architect/status.ps1
+Test-Path skills/architect/status.sh
+(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Get-Content skills/architect/status.sh -TotalCount 1)
+```
+Output:
+```
+True
+True
+1
+1
+#!/usr/bin/env bash
+```
+
+ST5 / SS2
+
+Command:
+```
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/status.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
+```
+Output:
+```
+SS2_OK
+```
+
+ST5 / SS3 fixture create
+
+Command:
+```
+$base = '.architect/tmp/stfix'
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-build-01" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-blocked-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-judge-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-rep-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/docs/spec" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root2" | Out-Null
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-build-01.events.jsonl" -Encoding UTF8 -Value '{"command":"pytest -q"}'
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-blocked-01/docs/jobs/demo-blocked-01.md" -Encoding UTF8 -Value "STATUS: BLOCKED (x)"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-judge-01/docs/jobs/demo-judge-01.md" -Encoding UTF8 -Value "STATUS: COMPLETE"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-judge-01.judge.md" -Encoding UTF8 -Value "judge"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-rep-01/docs/jobs/demo-rep-01.md" -Encoding UTF8 -Value "STATUS: COMPLETE"
+Set-Content -LiteralPath "$base/root1/docs/spec/demo.md" -Encoding UTF8 -Value "demo"
+'FIXTURE_READY'
+```
+Output:
+```
+FIXTURE_READY
+```
+
+ST5 / SS3 root1
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+```
+Output:
+```
+STATUS TREE spec: demo.md branch: unknown
+tracker: unavailable (local view)
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+```
+
+ST5 / SS3 root2
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+```
+Output:
+```
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+ST5 / SS4
+
+Command:
+```
+$out = & powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1 | Out-String
+([Text.Encoding]::UTF8.GetBytes($out) -contains 27)
+```
+Output:
+```
+False
+```
+
+ST5 / SS5
+
+Command:
+```
+(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count
+(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count
+(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"
+```
+Output:
+```
+2
+4
+2
+SS5_OK
+```
+
+ST5 / SS6
+
+Command:
+```
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'
+```
+Output:
+```
+```
+
+VALIDATOR
+
+Command:
+```
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python tests/validate_skills.py
+```
+Output:
+```
+OK - 2 skills validated, v4 contracts clean
+```
+
+DOCS CHECKS DIFF
+
+Command:
+```
+git diff --name-only -- docs/checks
+```
+Output:
+```
+```
+
+TOUCH SET
+
+Command:
+```
+git status --short
+```
+Output:
+```
+ M docs/jobs/status-scripts-01.md
+ M skills/architect/status.ps1
+ M skills/architect/status.sh
+```
+
+STATUS: COMPLETE
+
 ## Respawn session
 
 Ruling addressed: `skills/architect/status.sh` no longer selects the lexically last `docs/spec/*.md`; it scans spec files and chooses the newest numeric mtime using `stat -c %Y` with `stat -f %m` fallback.

--- a/docs/jobs/status-scripts-01.md
+++ b/docs/jobs/status-scripts-01.md
@@ -1016,3 +1016,382 @@ Output:
 ```
 
 STATUS: COMPLETE
+
+## Final fix session
+
+First action ruling anchor:
+
+Command:
+```powershell
+Select-String -Path docs/jobs/status-scripts-rulings.md -Pattern 'fourth judgment' -SimpleMatch
+```
+Output:
+```text
+docs\jobs\status-scripts-rulings.md:39:- 2026-07-03 fourth judgment FAIL fired the self-imposed rail; factory
+```
+
+Changes made:
+- `skills/architect/status.ps1`: phase glyphs are ANSI-colored only when `[Console]::IsOutputRedirected` is false and `NO_COLOR` is unset; the `gh issue list` call is wrapped in `Push-Location -LiteralPath $root` / `Pop-Location`.
+- `skills/architect/status.sh`: phase glyphs are ANSI-colored only when `[ -t 1 ]` and `NO_COLOR` is unset; the `gh issue list` call runs in `(cd "$root" && ...)`.
+- The pinned `--jq` expression was not changed.
+
+Fixture refresh:
+
+Command:
+```powershell
+New-Item -ItemType Directory -Force -Path @(
+  '.architect/tmp/stfix/root1/.architect/wt/demo-build-01',
+  '.architect/tmp/stfix/root1/.architect/wt/demo-blocked-01/docs/jobs',
+  '.architect/tmp/stfix/root1/.architect/wt/demo-judge-01/docs/jobs',
+  '.architect/tmp/stfix/root1/.architect/wt/demo-rep-01/docs/jobs',
+  '.architect/tmp/stfix/root1/docs/spec',
+  '.architect/tmp/stfix/root2'
+) | Out-Null
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/demo-build-01.events.jsonl' -Value '{"command":"pytest -q"}' -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/demo-blocked-01/docs/jobs/demo-blocked-01.md' -Value "x`nSTATUS: BLOCKED (x)" -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/demo-judge-01/docs/jobs/demo-judge-01.md' -Value "x`nSTATUS: COMPLETE" -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/demo-judge-01.judge.md' -Value 'judge' -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/demo-rep-01/docs/jobs/demo-rep-01.md' -Value "x`nSTATUS: COMPLETE" -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/docs/spec/demo.md' -Value 'demo' -Encoding UTF8
+'FIXTURE_OK'
+```
+Output:
+```text
+FIXTURE_OK
+```
+
+SS1:
+
+Command:
+```powershell
+Test-Path skills/architect/status.ps1
+Test-Path skills/architect/status.sh
+(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Get-Content skills/architect/status.sh -TotalCount 1)
+```
+Output:
+```text
+True
+True
+1
+1
+#!/usr/bin/env bash
+```
+
+SS2:
+
+Command:
+```powershell
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/status.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
+```
+Output:
+```text
+SS2_OK
+```
+
+SS3:
+
+Command:
+```powershell
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: unavailable (local view)
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+SS4:
+
+Command:
+```powershell
+$out = & powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1 | Out-String
+([Text.Encoding]::UTF8.GetBytes($out) -contains 27)
+```
+Output:
+```text
+False
+```
+
+status.sh piped no-ESC remains composite-side under the PowerShell/native-git-only boundary here; static evidence is the `[ -t 1 ]` guard in `color_glyph`.
+
+SS5:
+
+Command:
+```powershell
+(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count
+(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count
+(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"
+```
+Output:
+```text
+2
+4
+2
+SS5_OK
+```
+
+SS6:
+
+Command:
+```powershell
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'
+```
+Output:
+```text
+```
+
+ST1:
+
+Command:
+```powershell
+(Select-String -Path skills/architect/status.ps1 -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.sh -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'blockedBy').Count
+```
+Output:
+```text
+1
+1
+4
+```
+
+ST2:
+
+Command:
+```powershell
+(Select-String -Path skills/architect/status.ps1 -Pattern 'parent').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'parent').Count
+Select-String -Path skills/architect/status.sh -Pattern 'parent|TRACK|SUB|tracking' | ForEach-Object { "$($_.Path):$($_.LineNumber):$($_.Line)" }
+```
+Output:
+```text
+2
+2
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:32:  tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk '/^STATUS:/{sub(/^STATUS:[[:space:]]*/,""); s=$0} END{print s}'
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:64:tracker_lines(){
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:65:  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:71:  (cd "$root" && gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr")
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:77:tracker=0
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:78:tracker_tsv=
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:79:if tracker_tsv=$(tracker_lines 2>/dev/null); then tracker=1; fi
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:80:tracking=
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:81:if [ "$tracker" -eq 1 ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:83:    [ "$kind" = TRACK ] && tracking=$num
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:84:  done <<< "$tracker_tsv"
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:87:if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:92:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:93:  printf 'tracker: #%s\n' "$tracking"
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:94:elif [ "$tracker" -eq 1 ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:95:  printf 'tracker: no open run\n'
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:97:  printf 'tracker: unavailable (local view)\n'
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:103:if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:105:    [ "$kind" = SUB ] || continue
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:110:  done <<< "$tracker_tsv"
+```
+
+ST3:
+
+Command:
+```powershell
+(Select-String -Path skills/architect/status.ps1 -Pattern 'tracker: no open run').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'tracker: no open run').Count
+Select-String -Path skills/architect/status.sh -Pattern 'NOOPENRUN|NO ACTIVE FACTORY RUN|tracker: no open run|\[ -z "\$tracking" \]' | ForEach-Object { "$($_.Path):$($_.LineNumber):$($_.Line)" }
+```
+Output:
+```text
+1
+1
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:65:  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:87:if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:88:  printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
+C:\Users\danhm\architect-loop\.architect\wt\status-scripts-01\skills\architect\status.sh:95:  printf 'tracker: no open run\n'
+```
+
+ST4:
+
+Command:
+```powershell
+$i=0; Get-Content skills/architect/status.ps1 | ForEach-Object { $i++; if ($i -ge 69 -and $i -le 99) { 'skills/architect/status.ps1:{0}:{1}' -f $i, $_ } }
+$i=0; Get-Content skills/architect/status.sh | ForEach-Object { $i++; if ($i -ge 64 -and $i -le 84) { 'skills/architect/status.sh:{0}:{1}' -f $i, $_ } }
+```
+Output:
+```text
+skills/architect/status.ps1:69:function TrackerLines() {
+skills/architect/status.ps1:70:    $PinnedJq = '. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+skills/architect/status.ps1:71:    if ($env:STATUS_GH_STUB -and (Test-Path -LiteralPath $env:STATUS_GH_STUB -PathType Leaf)) {
+skills/architect/status.ps1:72:        return @{ Reachable = $true; Lines = @(Get-Content -LiteralPath $env:STATUS_GH_STUB) }
+skills/architect/status.ps1:73:    }
+skills/architect/status.ps1:74:    if (-not (Get-Command gh)) { return @{ Reachable = $false; Lines = @() } }
+skills/architect/status.ps1:75:    try {
+skills/architect/status.ps1:76:        Push-Location -LiteralPath $root
+skills/architect/status.ps1:77:        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null }
+skills/architect/status.ps1:78:        finally { Pop-Location }
+skills/architect/status.ps1:79:        return @{ Reachable = ($LASTEXITCODE -eq 0); Lines = @($out) }
+skills/architect/status.ps1:80:    } catch {
+skills/architect/status.ps1:81:        return @{ Reachable = $false; Lines = @() }
+skills/architect/status.ps1:82:    }
+skills/architect/status.ps1:83:}
+skills/architect/status.ps1:84:
+skills/architect/status.ps1:85:$root = [System.IO.Path]::GetFullPath($RepoRoot)
+skills/architect/status.ps1:86:if (-not (Test-Path -LiteralPath $root -PathType Container)) { Write-Output "unreadable repo: $RepoRoot"; exit 1 }
+skills/architect/status.ps1:87:$useColor = (-not [Console]::IsOutputRedirected) -and (-not $env:NO_COLOR)
+skills/architect/status.ps1:88:function ColorGlyph($Glyph, $Code) {
+skills/architect/status.ps1:89:    if (-not $useColor) { return $Glyph }
+skills/architect/status.ps1:90:    $esc = [char]27
+skills/architect/status.ps1:91:    return "$esc[$Code" + "m$Glyph$esc[0m"
+skills/architect/status.ps1:92:}
+skills/architect/status.ps1:93:$G = @{
+skills/architect/status.ps1:94:    Merged = ColorGlyph ([char]0x2713) "32"
+skills/architect/status.ps1:95:    Judging = ColorGlyph ([char]0x25D0) "36"
+skills/architect/status.ps1:96:    Blocked = ColorGlyph "!" "31"
+skills/architect/status.ps1:97:    Reported = ColorGlyph ([char]0x25A3) "35"
+skills/architect/status.ps1:98:    Building = ColorGlyph ([char]0x25CF) "34"
+skills/architect/status.ps1:99:    Queued = ColorGlyph ([char]0x2298) "33"
+skills/architect/status.sh:64:tracker_lines(){
+skills/architect/status.sh:65:  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+skills/architect/status.sh:66:  if [ -n "${STATUS_GH_STUB:-}" ] && [ -r "$STATUS_GH_STUB" ]; then
+skills/architect/status.sh:67:    cat "$STATUS_GH_STUB"
+skills/architect/status.sh:68:    return 0
+skills/architect/status.sh:69:  fi
+skills/architect/status.sh:70:  command -v gh >/dev/null 2>&1 || return 1
+skills/architect/status.sh:71:  (cd "$root" && gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr")
+skills/architect/status.sh:72:}
+skills/architect/status.sh:73:
+skills/architect/status.sh:74:branch=
+skills/architect/status.sh:75:[ -e "$root/.git" ] && branch=$(git -C "$root" branch --show-current 2>/dev/null || true)
+skills/architect/status.sh:76:[ -n "$branch" ] || branch=unknown
+skills/architect/status.sh:77:tracker=0
+skills/architect/status.sh:78:tracker_tsv=
+skills/architect/status.sh:79:if tracker_tsv=$(tracker_lines 2>/dev/null); then tracker=1; fi
+skills/architect/status.sh:80:tracking=
+skills/architect/status.sh:81:if [ "$tracker" -eq 1 ]; then
+skills/architect/status.sh:82:  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+skills/architect/status.sh:83:    [ "$kind" = TRACK ] && tracking=$num
+skills/architect/status.sh:84:  done <<< "$tracker_tsv"
+```
+
+Behavioral difference found: none in tracker-mode graph logic. Both scripts still delegate the graph decision to the same pinned `gh --jq` expression and parse only TSV lines; both now run real `gh` from the target repo root.
+
+ST5:
+
+SS1-SS6 re-run above: PASS.
+
+ST6:
+
+Command:
+```powershell
+$spec = (Select-String -Path docs/spec/status-tree.md -Pattern "gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq '(.*)'" | Select-Object -First 1).Matches[0].Groups[1].Value
+$ps = (Select-String -Path skills/architect/status.ps1 -Pattern '\$PinnedJq = ''(.*)''' | Select-Object -First 1).Matches[0].Groups[1].Value
+$sh = (Select-String -Path skills/architect/status.sh -Pattern "jq_expr='(.*)'" | Select-Object -First 1).Matches[0].Groups[1].Value
+'SPEC:'
+$spec
+'PS1:'
+$ps
+'SH:'
+$sh
+if ($spec -eq $ps -and $ps -eq $sh) { 'IDENTICAL' } else { 'DIFF' }
+```
+Output:
+```text
+SPEC:
+. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end
+PS1:
+. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end
+SH:
+. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end
+IDENTICAL
+```
+
+ST7:
+
+Command:
+```powershell
+Set-Content -LiteralPath '.architect/tmp/stfix/stub.tsv' -Value @(
+  "TRACK`t43",
+  "SUB`t46`tOPEN`t44`tstatus: docs closure",
+  "SUB`t45`tCLOSED`t`tstatus: skill wiring (10-line cap)",
+  "SUB`t44`tOPEN`t`tstatus: scripts + validator contract"
+) -Encoding UTF8
+Set-Content -LiteralPath '.architect/tmp/stfix/noopen.tsv' -Value 'NOOPENRUN' -Encoding UTF8
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/stub.tsv').Path
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/noopen.tsv').Path
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+$env:STATUS_GH_STUB = $null
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: #43
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+⊘ #46 status: docs closure .architect/wt/status-docs-closure-01 blocked-by: 44
+✓ #45 status: skill wiring (10-line cap) .architect/wt/status-skill-wiring-10-line-cap-01
+○ #44 status: scripts + validator contract .architect/wt/status-scripts-validator-contract-01
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+ST8:
+
+Command:
+```powershell
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/ghost-01.events.jsonl' -Value '{"command":"ghost"}' -Encoding UTF8
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/stub.tsv').Path
+$out = powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+$out
+'contains ghost: ' + (($out | Out-String) -match 'ghost')
+$env:STATUS_GH_STUB = $null
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: #43
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+⊘ #46 status: docs closure .architect/wt/status-docs-closure-01 blocked-by: 44
+✓ #45 status: skill wiring (10-line cap) .architect/wt/status-skill-wiring-10-line-cap-01
+○ #44 status: scripts + validator contract .architect/wt/status-scripts-validator-contract-01
+contains ghost: False
+```
+
+Full validator:
+
+Command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python tests/validate_skills.py
+```
+Output:
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Final diff/status:
+
+Command:
+```powershell
+git status --short
+```
+Output:
+```text
+ M docs/jobs/status-scripts-01.md
+ M skills/architect/status.ps1
+ M skills/architect/status.sh
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/status-scripts-01.md
+++ b/docs/jobs/status-scripts-01.md
@@ -1,0 +1,205 @@
+MIRROR: ORCHESTRATOR
+
+PHASE 0
+
+FIRST-ACTION input verification:
+Command:
+```
+git log -1 --oneline
+Test-Path -LiteralPath docs/checks/status-scripts.md
+```
+Output:
+```
+eacc00e re-freeze: stress-test amendments (degraded-mode phase honesty, REPORTED glyph, exact SS3 fixtures, fresh uv cache, PS-native size count)
+True
+```
+
+Plan:
+1. Read `docs/spec/status-tree.md`, `docs/checks/status-scripts.md`, `tests/validate_skills.py`, and existing `skills/architect/watchdog.*`.
+2. Add `skills/architect/status.ps1` and `skills/architect/status.sh` as read-only status renderers.
+3. Update `tests/validate_skills.py` only to require the two new sibling scripts and enforce the status contract markers.
+4. Create SS3 fixtures under `.architect/tmp/stfix/`.
+5. Run every check in `docs/checks/status-scripts.md` sequentially with temp/cache paths under `.architect/tmp/`.
+
+Disagreements:
+- None.
+
+Checked before concluding the issue is sound:
+- `docs/spec/status-tree.md` defines the interface contract, degraded mode, glyph phases, and may-touch split for issue A.
+- `docs/checks/status-scripts.md` freezes executable checks for `skills/architect/status.ps1`, `skills/architect/status.sh`, and `tests/validate_skills.py`.
+- `tests/validate_skills.py` already has `REQUIRED_SIBLINGS["architect"]` and centralized validator checks, so the requested validator addition fits the existing structure.
+- `skills/architect/watchdog.ps1` and `skills/architect/watchdog.sh` are existing sibling scripts and confirm this repo keeps architect helper scripts in `skills/architect/`.
+
+LINE COUNTS
+
+Command:
+```
+(Get-Content -LiteralPath skills/architect/status.ps1).Count
+(Get-Content -LiteralPath skills/architect/status.sh).Count
+```
+Output:
+```
+118
+97
+```
+
+SS1
+
+Command:
+```
+Test-Path skills/architect/status.ps1
+Test-Path skills/architect/status.sh
+(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Get-Content skills/architect/status.sh -TotalCount 1)
+```
+Output:
+```
+True
+True
+1
+1
+#!/usr/bin/env bash
+```
+
+SS2
+
+Command:
+```
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/status.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
+```
+Output:
+```
+SS2_OK
+```
+
+SS3 FIXTURE CREATE
+
+Command:
+```
+$base = '.architect/tmp/stfix'
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-build-01" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-blocked-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-judge-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/.architect/wt/demo-rep-01/docs/jobs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root1/docs/spec" | Out-Null
+New-Item -ItemType Directory -Force -Path "$base/root2" | Out-Null
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-build-01.events.jsonl" -Encoding UTF8 -Value '{"command":"pytest -q"}'
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-blocked-01/docs/jobs/demo-blocked-01.md" -Encoding UTF8 -Value "STATUS: BLOCKED (x)"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-judge-01/docs/jobs/demo-judge-01.md" -Encoding UTF8 -Value "STATUS: COMPLETE"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-judge-01.judge.md" -Encoding UTF8 -Value "judge"
+Set-Content -LiteralPath "$base/root1/.architect/wt/demo-rep-01/docs/jobs/demo-rep-01.md" -Encoding UTF8 -Value "STATUS: COMPLETE"
+Set-Content -LiteralPath "$base/root1/docs/spec/demo.md" -Encoding UTF8 -Value "demo"
+```
+Output:
+```
+```
+
+SS3 ROOT1
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+```
+Output:
+```
+STATUS TREE spec: demo.md branch: unknown
+tracker: unavailable (local view)
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+```
+
+SS3 ROOT2
+
+Command:
+```
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+```
+Output:
+```
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+SS4
+
+Command:
+```
+$out = & powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1 | Out-String
+([Text.Encoding]::UTF8.GetBytes($out) -contains 27)
+```
+Output:
+```
+False
+```
+
+SS5
+
+Command:
+```
+(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count
+(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count
+(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"
+```
+Output:
+```
+2
+3
+2
+SS5_OK
+```
+
+SS6
+
+Command:
+```
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'
+```
+Output:
+```
+```
+
+VALIDATOR
+
+Command:
+```
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python tests/validate_skills.py
+```
+Output:
+```
+OK - 2 skills validated, v4 contracts clean
+```
+
+TOUCH SET
+
+Command:
+```
+git status --short
+```
+Output:
+```
+ M tests/validate_skills.py
+?? docs/jobs/status-scripts-01.md
+?? skills/architect/status.ps1
+?? skills/architect/status.sh
+```
+
+DOCS CHECKS DIFF
+
+Command:
+```
+git diff --name-only -- docs/checks
+```
+Output:
+```
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/status-scripts-01.md
+++ b/docs/jobs/status-scripts-01.md
@@ -204,6 +204,332 @@ Output:
 
 STATUS: COMPLETE
 
+## Re-architecture session
+
+FIRST-ACTION
+
+Command:
+```powershell
+Select-String -Path docs/checks/status-tracker.md -Pattern 'ST6|ST7|ST8'
+Select-String -Path docs/spec/status-tree.md -Pattern 'STATUS_GH_STUB'
+```
+Output:
+```text
+docs\checks\status-tracker.md:42:## ST6-ST8 — third-judgment re-architecture addendum (pinned jq, stub seam)
+docs\checks\status-tracker.md:47:### ST6 — the pinned jq expression appears VERBATIM in both scripts
+docs\checks\status-tracker.md:52:### ST7 — stub-seam render matches the live-verified sample
+docs\checks\status-tracker.md:63:### ST8 — stray-file guard
+docs\spec\status-tree.md:67:Testing seam: if env var `STATUS_GH_STUB` names a readable file, both
+```
+
+Implementation summary:
+```text
+Replaced duplicated tracker JSON graph logic in both scripts with the pinned gh --jq expression.
+Added STATUS_GH_STUB in both scripts.
+Changed artifact row discovery to require an actual .architect/wt/<slug>-01 directory.
+Updated the validator to require STATUS_GH_STUB, --jq, tracker: no open run, and blockedBy.nodes markers.
+```
+
+SS1
+
+Command:
+```powershell
+Test-Path skills/architect/status.ps1
+Test-Path skills/architect/status.sh
+(Select-String -Path skills/architect/status.sh -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'NO ACTIVE FACTORY RUN').Count
+(Get-Content skills/architect/status.sh -TotalCount 1)
+```
+Output:
+```text
+True
+True
+1
+1
+#!/usr/bin/env bash
+```
+
+SS2
+
+Command:
+```powershell
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/status.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'SS2_OK' } else { $e }
+```
+Output:
+```text
+SS2_OK
+```
+
+SS3
+
+Command:
+```powershell
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: unavailable (local view)
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+SS4
+
+Command:
+```powershell
+$out = & powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1 | Out-String
+([Text.Encoding]::UTF8.GetBytes($out) -contains 27)
+```
+Output:
+```text
+False
+```
+
+SS5
+
+Command:
+```powershell
+(Select-String -Path tests/validate_skills.py -Pattern '"status.ps1"').Count
+(Select-String -Path tests/validate_skills.py -Pattern '"status.sh"').Count
+(Select-String -Path tests/validate_skills.py -Pattern 'check_status_contract').Count
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('SS5_OK')"
+```
+Output:
+```text
+2
+4
+2
+SS5_OK
+```
+
+SS6
+
+Command:
+```powershell
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'
+```
+Output:
+```text
+```
+
+ST1-ST3
+
+Command:
+```powershell
+(Select-String -Path skills/architect/status.ps1 -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.sh -Pattern '--state all').Count
+(Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'blockedBy').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'parent').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'parent').Count
+(Select-String -Path skills/architect/status.ps1 -Pattern 'tracker: no open run').Count
+(Select-String -Path skills/architect/status.sh -Pattern 'tracker: no open run').Count
+```
+Output:
+```text
+1
+1
+4
+2
+2
+1
+1
+```
+
+ST2/ST3 shell quote
+
+Command:
+```powershell
+Select-String -Path skills/architect/status.sh -Pattern 'jq_expr=|gh issue list|TRACK|SUB|NO ACTIVE FACTORY RUN|tracker: no open run' | ForEach-Object { "skills/architect/status.sh:$($_.LineNumber):$($_.Line)" }
+```
+Output:
+```text
+skills/architect/status.sh:64:  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+skills/architect/status.sh:70:  gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr"
+skills/architect/status.sh:82:    [ "$kind" = TRACK ] && tracking=$num
+skills/architect/status.sh:87:  printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
+skills/architect/status.sh:94:  printf 'tracker: no open run\n'
+skills/architect/status.sh:104:    [ "$kind" = SUB ] || continue
+```
+
+ST4
+
+PowerShell tracker section:
+```text
+skills/architect/status.ps1:69:function TrackerLines() {
+skills/architect/status.ps1:70:    $PinnedJq = '. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+skills/architect/status.ps1:71:    if ($env:STATUS_GH_STUB -and (Test-Path -LiteralPath $env:STATUS_GH_STUB -PathType Leaf)) {
+skills/architect/status.ps1:72:        return @{ Reachable = $true; Lines = @(Get-Content -LiteralPath $env:STATUS_GH_STUB) }
+skills/architect/status.ps1:76:        $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null
+skills/architect/status.ps1:93:    foreach ($line in $trackerData.Lines) {
+skills/architect/status.ps1:95:        $parts = $line -split "`t", 5
+skills/architect/status.ps1:96:        if ($parts[0] -eq "TRACK" -and $parts.Count -ge 2) { $tracking = $parts[1]; continue }
+skills/architect/status.ps1:97:        if ($parts[0] -eq "SUB" -and $parts.Count -ge 5) {
+```
+
+Shell tracker section:
+```text
+skills/architect/status.sh:63:tracker_lines(){
+skills/architect/status.sh:64:  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+skills/architect/status.sh:65:  if [ -n "${STATUS_GH_STUB:-}" ] && [ -r "$STATUS_GH_STUB" ]; then
+skills/architect/status.sh:70:  gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr"
+skills/architect/status.sh:78:if tracker_tsv=$(tracker_lines 2>/dev/null); then tracker=1; fi
+skills/architect/status.sh:81:  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+skills/architect/status.sh:82:    [ "$kind" = TRACK ] && tracking=$num
+skills/architect/status.sh:103:  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+skills/architect/status.sh:104:    [ "$kind" = SUB ] || continue
+```
+
+Parity statement:
+```text
+Behavioral difference found: none in tracker-mode graph logic. Both scripts delegate the entire graph decision to the same pinned gh --jq expression, use STATUS_GH_STUB when readable, and only parse TRACK/SUB/NOOPENRUN TSV lines.
+```
+
+ST5
+
+Output:
+```text
+SS1-SS6 re-run above: PASS.
+```
+
+ST6
+
+Command:
+```powershell
+$spec = '. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+$ps = (Select-String -Path skills/architect/status.ps1 -Pattern '\$PinnedJq = ''(.*)''' | Select-Object -First 1).Matches[0].Groups[1].Value
+$sh = (Select-String -Path skills/architect/status.sh -Pattern "jq_expr='(.*)'" | Select-Object -First 1).Matches[0].Groups[1].Value
+"ps1 IDENTICAL: $($ps -ceq $spec)"
+"sh IDENTICAL: $($sh -ceq $spec)"
+```
+Output:
+```text
+ps1 IDENTICAL: True
+sh IDENTICAL: True
+```
+
+ST7
+
+Command:
+```powershell
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/stub.tsv').Path
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+Remove-Item Env:STATUS_GH_STUB
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/noopen.tsv').Path
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root2
+Remove-Item Env:STATUS_GH_STUB
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: #43
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+⊘ #46 status: docs closure .architect/wt/status-docs-closure-01 blocked-by: 44
+✓ #45 status: skill wiring (10-line cap) .architect/wt/status-skill-wiring-10-line-cap-01
+○ #44 status: scripts + validator contract .architect/wt/status-scripts-validator-contract-01
+
+NO ACTIVE FACTORY RUN
+spec: unknown
+```
+
+NOOPENRUN with artifacts
+
+Command:
+```powershell
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/noopen.tsv').Path
+powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+Remove-Item Env:STATUS_GH_STUB
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: no open run
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+! demo-blocked .architect/wt/demo-blocked-01
+● demo-build .architect/wt/demo-build-01
+    last: pytest -q age: unknown
+◐ demo-judge .architect/wt/demo-judge-01
+▣ demo-rep .architect/wt/demo-rep-01
+```
+
+ST8
+
+Command:
+```powershell
+Set-Content -LiteralPath '.architect/tmp/stfix/root1/.architect/wt/ghost-01.events.jsonl' -Encoding UTF8 -Value '{"command":"ghost"}'
+$env:STATUS_GH_STUB = (Resolve-Path '.architect/tmp/stfix/stub.tsv').Path
+$out = powershell -NoProfile -File skills/architect/status.ps1 -RepoRoot .architect/tmp/stfix/root1
+$out
+"contains ghost: $($out -match 'ghost')"
+Remove-Item Env:STATUS_GH_STUB
+```
+Output:
+```text
+STATUS TREE spec: demo.md branch: unknown
+tracker: #43
+ORCHESTRATOR: local view
+WATCHDOG: process=False config=0
+⊘ #46 status: docs closure .architect/wt/status-docs-closure-01 blocked-by: 44
+✓ #45 status: skill wiring (10-line cap) .architect/wt/status-skill-wiring-10-line-cap-01
+○ #44 status: scripts + validator contract .architect/wt/status-scripts-validator-contract-01
+contains ghost:
+```
+
+Validator
+
+Command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-st'; uv run --no-project python tests/validate_skills.py
+```
+Output:
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Old duplicated graph parser scan
+
+Command:
+```powershell
+Select-String -Path skills/architect/status.ps1,skills/architect/status.sh -Pattern 'ConvertFrom-Json|parentRefs|json_objects|parent_number|open_blockers|issue_number\('
+```
+Output:
+```text
+```
+
+Touch-set and frozen-check guard
+
+Command:
+```powershell
+git diff --name-only -- docs/checks
+git status --short
+```
+Output:
+```text
+ M skills/architect/status.ps1
+ M skills/architect/status.sh
+ M tests/validate_skills.py
+```
+
+Bash execution note:
+```text
+Not run in this session by instruction: PowerShell + native git only. The shell script was statically checked for the identical pinned jq expression, STATUS_GH_STUB seam, TSV-only parsing, no old graph parser helpers, and read-only command guard.
+```
+
+STATUS: COMPLETE
+
 ## Re-spec session
 
 PRECONDITION

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -42,3 +42,15 @@
   - SS4 must still pass), (2) the tracker gh call honors the repo root
   (-R/--repo from the target root's origin, or run gh with the target as
   cwd). Fifth judgment; merge on PASS; any further FAIL kills the issue.
+- 2026-07-03 composite live render failed after judgment 5 on two defects
+  invisible to the sandbox (ps1: 2>$null on native gh poisoning try/catch,
+  which also masked PS<=5 stripping embedded quotes from the jq argument;
+  sh: whitespace-IFS collapsing empty TSV fields). Factory parked; HUMAN
+  RULING: "FIX, let the orchestrator take a crack at this" - an explicit,
+  recorded exception to the orchestrator-never-writes-code rule for this
+  fix only. Orchestrator applied four surgical edits (stderr redirect
+  removed + PS<=5 quote escaping + UTF-8 console output in ps1; unit-
+  separator TSV parsing in sh), live-verified both scripts against run #43
+  (correct trees, piped output ESC-free, stub regression green). Judgment
+  still goes to a fresh judge - the no-self-grading invariant holds even
+  for orchestrator-authored code.

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -8,3 +8,15 @@
   mtime-newest (match the ps1 behavior); prove it with a two-spec fixture
   where lexical and mtime order disagree; re-run SS1, SS3, SS6; append a
   respawn session to the report. Boundaries unchanged.
+- 2026-07-03 second judgment: SS1-SS6 PASS, diff-vs-intent FAIL on a
+  DIFFERENT defect - status.sh tracker mode lacks parent filtering and
+  treats gh's successful-empty [] as tracker-present. Orchestrator
+  diagnosis: the freeze under-specified the tracker-mode algorithm for a
+  path the sandbox cannot execute; two builders could not converge on
+  unwritten intent. Ladder: second FAIL -> re-decompose. The spec now
+  carries the exact algorithm (one --state all call; candidate = OPEN
+  issue referenced as parent, highest-numbered; sub-issues any state;
+  [] / no candidate -> NO ACTIVE or `tracker: no open run`), and the
+  frozen addendum docs/checks/status-tracker.md pins it statically (ST1-ST5,
+  parity across both scripts). Fresh builder dispatched against the
+  re-spec; live tracker-mode proof remains a composite check.

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -54,3 +54,10 @@
   (correct trees, piped output ESC-free, stub regression green). Judgment
   still goes to a fresh judge - the no-self-grading invariant holds even
   for orchestrator-authored code.
+- 2026-07-03 judgment 6 FAIL: the orchestrator fix leaked failing-gh stderr
+  in degraded mode (the removed 2>$null had been HIDING the true root
+  cause - quote-stripping made gh exit nonzero - not causing the failure).
+  Completion of the same authorized fix: quoting stays fixed, stderr
+  suppression restored. Live-verified: tracker mode green; GH_TOKEN=bad
+  yields the degraded view with 0 stderr bytes. Judgment 7 dispatched; a
+  FAIL there stops the run for human ruling (no further orchestrator edits).

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -20,3 +20,19 @@
   frozen addendum docs/checks/status-tracker.md pins it statically (ST1-ST5,
   parity across both scripts). Fresh builder dispatched against the
   re-spec; live tracker-mode proof remains a composite check.
+- 2026-07-03 third judgment: all SS/ST checks PASS; diff-vs-intent FAIL on
+  a third distinct defect - ps1 tracker-candidate identification broken
+  under real gh. ORCHESTRATOR LIVE CONFIRMATION: with gh working and run
+  #43 open, status.ps1 printed `tracker: no open run` (judge upheld by
+  direct evidence). Oddity-rule ruling (three failures on one point =
+  question the architecture): the architecture was wrong - graph logic
+  implemented twice in two shells that cannot execute it in-sandbox. The
+  discovered gh shape (`blockedBy` is an object with `.nodes`) proves the
+  class. Re-architecture: ALL graph logic moves into one pinned gh --jq
+  expression, live-verified by the orchestrator and frozen in the spec
+  with sample output; shells parse TSV only; STATUS_GH_STUB testing seam
+  added so tracker rendering is sandbox-testable; stray-file guard and
+  no-out-of-contract-glyph rules pinned (live render also showed `?`
+  glyphs and stale-file rows). ST6-ST8 appended to the addendum checks.
+  SELF-IMPOSED RAIL: a fourth FAIL on this issue stops the factory and
+  escalates to the human.

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -1,0 +1,10 @@
+# Rulings: status-scripts (orchestrator-owned, append-only)
+
+- 2026-07-03 first judgment: checks integrity PASS, SS1-SS6 all PASS,
+  diff-vs-intent FAIL — `status.sh` selects the lexically last
+  `docs/spec/` file; the spec's output rules say the MOST RECENT (newest by
+  modification time) spec file. The fixture had one spec file, so no frozen
+  check could catch it. Respawn ruling: fix the sh spec selection to
+  mtime-newest (match the ps1 behavior); prove it with a two-spec fixture
+  where lexical and mtime order disagree; re-run SS1, SS3, SS6; append a
+  respawn session to the report. Boundaries unchanged.

--- a/docs/jobs/status-scripts-rulings.md
+++ b/docs/jobs/status-scripts-rulings.md
@@ -36,3 +36,9 @@
   glyphs and stale-file rows). ST6-ST8 appended to the addendum checks.
   SELF-IMPOSED RAIL: a fourth FAIL on this issue stops the factory and
   escalates to the human.
+- 2026-07-03 fourth judgment FAIL fired the self-imposed rail; factory
+  parked and escalated. HUMAN RULING: "one final respawn" - fix (1) ANSI
+  color emitted when stdout is a TTY and NO_COLOR unset (plain when piped
+  - SS4 must still pass), (2) the tracker gh call honors the repo root
+  (-R/--repo from the target root's origin, or run gh with the target as
+  cwd). Fifth judgment; merge on PASS; any further FAIL kills the issue.

--- a/docs/jobs/status-wiring-01.md
+++ b/docs/jobs/status-wiring-01.md
@@ -1,0 +1,132 @@
+# status-wiring-01
+
+## Phase 0
+
+| Item | Raw evidence |
+|---|---|
+| First action HEAD | `git log -1 --oneline` -> `eacc00e re-freeze: stress-test amendments (degraded-mode phase honesty, REPORTED glyph, exact SS3 fixtures, fresh uv cache, PS-native size count)` |
+| First action check file | `Test-Path -LiteralPath 'docs/checks/status-wiring.md'` -> `True` |
+| Files checked before edit | `docs/spec/status-tree.md`; `docs/checks/status-wiring.md`; `skills/architect/SKILL.md`; `skills/architect/dispatch.md` |
+| Pre-edit size guard | `TOTAL 789` |
+| Plan | Add one Factory Loop status-request bullet to `skills/architect/SKILL.md`; add one `## Status display` note to `skills/architect/dispatch.md`; do not edit `docs/checks/**`; run SW1, SW2, SW3 sequentially. |
+| Disagreements | None blocking. The report path `docs/jobs/status-wiring-01.md` is outside implementation MAY TOUCH, but the issue separately requires this report path. |
+| Issue mirror | `MIRROR: ORCHESTRATOR` |
+
+## SW1
+
+Command:
+```powershell
+git grep -ci "status.ps1" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:1
+```
+
+Command:
+```powershell
+git grep -c "verbatim" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:1
+```
+
+Command:
+```powershell
+git grep -c "## Status display" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -ci "status.sh" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+## SW2
+
+Command:
+```powershell
+$files='skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'
+$total=($files | ForEach-Object { (Get-Content $_ | Where-Object { $_.Trim() }).Count } | Measure-Object -Sum).Sum
+"TOTAL $total"
+```
+Output:
+```text
+TOTAL 794
+```
+
+## SW3
+
+Command:
+```powershell
+git diff --name-only eacc00e..HEAD
+```
+Output:
+```text
+```
+
+Command:
+```powershell
+git grep -c "## Factory Loop\|### 4. Factory Loop" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:1
+```
+
+Pointer command:
+```powershell
+git grep -c "## Model alias table" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Pointer command:
+```powershell
+git grep -c "## Issue conventions" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Pointer command:
+```powershell
+git grep -c "## Monitor dispatch" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Pointer command:
+```powershell
+git grep -c "## Respawn-with-answer template" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Final command:
+```powershell
+git status --short
+```
+Output:
+```text
+ M skills/architect/SKILL.md
+ M skills/architect/dispatch.md
+?? docs/jobs/status-wiring-01.md
+```
+
+STATUS: COMPLETE

--- a/docs/research/status-display-evidence.md
+++ b/docs/research/status-display-evidence.md
@@ -1,0 +1,55 @@
+# Status-display evidence (prior art + cross-platform rendering)
+
+Research handoff, 2026-07-03. Two read-only researchers (codex gpt-5.5 high,
+live web search); orchestrator-verified. Feeds `docs/spec/status-tree.md`.
+
+## Prior art: how parallel-agent status is displayed today
+
+- The field converges on worktrees + status extracted from logs/hooks:
+  claude-squad (one tmux session per agent), Swarm (Rust dashboard scraping
+  tmux, `[WAIT]` markers), Vibe Kanban (web board, statuses "updated
+  automatically when coding agents start working"), Conductor/Nimbalyst
+  (GUI), tmux status-bar writeups (Stop-hook summarizes transcript JSONL,
+  refresh every 5s). Lazyagent is the closest visual precedent: a TUI with
+  an "agent tree" of parent-child subagent relationships fed by event
+  streams (news.ycombinator.com/item?id=47778479).
+- Claude Code native surfaces don't cover this case: Agent View explicitly
+  does not list "subagents and teammates spawned by a session"
+  (code.claude.com/docs/en/agent-view), and factory builders are `codex
+  exec` processes invisible to it. The statusline
+  (code.claude.com/docs/en/statusline; script + JSON stdin,
+  `refreshInterval` ≥1s) is a possible future one-line summary surface —
+  CLI-documented only, desktop support unverified.
+- NOT FOUND anywhere: a documented status command rendering a job tree from
+  `gh` issue data plus local event files. The ingredients are proven; the
+  combination is ours.
+
+## Rendering facts (Windows PowerShell 5.1 + POSIX, zero dependencies)
+
+- ANSI works in Windows Terminal/ConPTY (VirtualTerminalLevel=1 default
+  there; `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag is the documented
+  fallback — learn.microsoft.com console-virtual-terminal-sequences). PS
+  5.1 cmdlets don't emit ANSI, but scripts emitting raw escapes render fine.
+- Chat surfaces don't render ANSI → the script must auto-disable color when
+  stdout is not a TTY and honor `NO_COLOR`. Tree glyphs carry the
+  information without color.
+- PS 5.1 encoding pitfalls are known: UTF-8-no-BOM script files misread
+  non-ASCII (about_character_encoding) — box-drawing characters are emitted
+  via `[char]` codes or the script ships ASCII tree rails.
+- `watch` is not POSIX; curses is not in the Windows stdlib. Irrelevant
+  here: live refresh was descoped (human ruling 2026-07-03).
+
+## Data plumbing facts
+
+- One `gh issue list --json` call returns the whole tree: `parent`,
+  `subIssues`, `subIssuesSummary`, `blockedBy`, `blocking`, `state`,
+  `assignees`, `number`, `title` (gh manual; fields added in v2.94.0,
+  github.blog changelog 2026-06-10).
+- "Last command" per builder tails `.architect/wt/<job>.events.jsonl`
+  (already written by dispatch redirection); `Get-Content -Tail -Encoding`
+  handles PS 5.1; GNU `tail` on POSIX.
+- Job phase derives from artifacts the run already produces: worktree
+  existence, report file + STATUS line, judge output file, issue state.
+- `gh` is absent inside the codex sandbox (established run evidence), so
+  the script needs a local-artifacts-only degraded mode — which is also
+  what makes its functional checks sandbox-runnable.

--- a/docs/spec/status-tree.md
+++ b/docs/spec/status-tree.md
@@ -49,22 +49,30 @@ repo); `.architect/wt/<slug>-01.events.jsonl` tails (encoding-aware);
 `.architect/tmp/wd-*.json` config presence.
 
 **Phase derivation (per sub-issue), first match wins:**
-| Glyph | Phase | Rule |
-|---|---|---|
-| `✓` | MERGED | issue CLOSED |
-| `◐` | JUDGING | report exists AND judge output file exists without a verdict recorded on the issue yet, or judge events growing |
-| `!` | BLOCKED | report's STATUS line starts with `BLOCKED` |
-| `●` | BUILDING | worktree exists, no report yet (append `last:` sub-line from the newest command event) |
-| `⊘` | QUEUED | issue OPEN with open blocked-by issues (list them) |
-| `○` | READY | issue OPEN, no open blockers, no worktree |
+| Glyph | Phase | Needs tracker? | Rule |
+|---|---|---|---|
+| `✓` | MERGED | yes | issue CLOSED |
+| `◐` | JUDGING | no | report exists AND judge output file (`.architect/wt/<slug>-01.judge*.md`) exists |
+| `!` | BLOCKED | no | report's STATUS line starts with `BLOCKED` |
+| `▣` | REPORTED | no | report exists, no judge file yet |
+| `●` | BUILDING | no | worktree exists, no report yet (append `last:` sub-line from the newest command event) |
+| `⊘` | QUEUED | yes | issue OPEN with open blocked-by issues (list them) |
+| `○` | READY | yes | issue OPEN, no open blockers, no worktree |
+
+**Degraded mode (tracker data unavailable):** when `gh` is absent OR fails
+(auth, network — treat identically), render only artifact-backed rows
+(`●`/`!`/`◐`/`▣`, keyed by worktree/report slugs) under the header note
+`tracker: unavailable (local view)`; the tracker-dependent phases
+(`✓`/`⊘`/`○`) and issue titles are simply not shown. This is honest, and it
+is what makes the functional checks sandbox-runnable.
 
 **Output rules:** color only when stdout is a TTY AND `NO_COLOR` is unset;
 box-drawing glyphs emitted via `[char]` codes in ps1 (PS 5.1 encoding
-safety) and UTF-8 literals in sh; when `gh` fails or is absent, print the
-tree from local artifacts only with one header note `tracker: unavailable
-(local view)`; when no factory branch and no open tracking issue exists,
-print `NO ACTIVE FACTORY RUN` plus the most recent `docs/spec/` file name.
-Exit 0 in all of these cases; nonzero only on unreadable repo.
+safety) and UTF-8 literals in sh; if the branch cannot be read, header says
+`branch: unknown` and rendering continues; when no factory artifacts and no
+open tracking issue exist, print `NO ACTIVE FACTORY RUN` plus the most
+recent `docs/spec/` file name. Exit 0 in all of these cases; nonzero only
+on unreadable repo.
 
 **Skill text:** SKILL.md Factory Loop step gains one bullet: on a human
 status request, run the status script (path), print its output verbatim in
@@ -85,8 +93,10 @@ naming the script, its data sources, and the piped-no-color behavior.
 - **A1.** Each script stays ≤ ~120 lines; PS 5.1-compatible (no `&&`,
   ternary, `?.`); no dependencies beyond git, optional gh, and the shell.
 - **A2.** Validator adds both files to `REQUIRED_SIBLINGS["architect"]` and
-  a `check_status_contract()` asserting the six phase glyph strings and the
-  `NO ACTIVE FACTORY RUN` marker exist in both scripts.
+  a `check_status_contract()` asserting the seven phase glyph strings and
+  the `NO ACTIVE FACTORY RUN` and `tracker: unavailable` markers exist in
+  both scripts (ps1 may satisfy glyph checks via its `[char]` code forms;
+  the validator greps for either form).
 - **A3.** Functional checks run sandbox-side in degraded mode (gh absent
   there), against synthetic `.architect/wt/` fixtures; the orchestrator
   runs one live gh-backed render at composite.

--- a/docs/spec/status-tree.md
+++ b/docs/spec/status-tree.md
@@ -40,9 +40,17 @@ question" — following the staged proposal presented in-session. Live
 (`--repo-root` in sh). No other flags.
 
 **Data sources, in order:** current branch (`git branch --show-current`);
-the open tracking issue + sub-issues via ONE
-`gh issue list --json number,title,state,parent,blockedBy,assignees`
-call when `gh` works; `.architect/wt/<slug>-01/` worktrees;
+the tracking issue + sub-issues via ONE
+`gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy`
+call when `gh` works — the tracker-mode algorithm, identical in both
+scripts: (1) candidate tracking issues = OPEN issues whose number appears
+as `parent.number` of ≥1 issue in the result; pick the highest-numbered
+candidate (the latest run); (2) sub-issues = issues of ANY state whose
+`parent.number` equals it (closed sub-issues render `✓ MERGED`);
+(3) QUEUED lists only blockers that are still OPEN; (4) an empty result
+`[]`, or no candidate, means the tracker is reachable but no run is active:
+with no local artifacts print `NO ACTIVE FACTORY RUN`; with artifacts,
+render the local view under the header note `tracker: no open run`; `.architect/wt/<slug>-01/` worktrees;
 `docs/jobs/<slug>-01.md` STATUS lines (checked in worktree first, then
 repo); `.architect/wt/<slug>-01.events.jsonl` tails (encoding-aware);
 `.architect/wt/<slug>-01.judge.md` presence; watchdog process +

--- a/docs/spec/status-tree.md
+++ b/docs/spec/status-tree.md
@@ -40,17 +40,38 @@ question" — following the staged proposal presented in-session. Live
 (`--repo-root` in sh). No other flags.
 
 **Data sources, in order:** current branch (`git branch --show-current`);
-the tracking issue + sub-issues via ONE
-`gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy`
-call when `gh` works — the tracker-mode algorithm, identical in both
-scripts: (1) candidate tracking issues = OPEN issues whose number appears
-as `parent.number` of ≥1 issue in the result; pick the highest-numbered
-candidate (the latest run); (2) sub-issues = issues of ANY state whose
-`parent.number` equals it (closed sub-issues render `✓ MERGED`);
-(3) QUEUED lists only blockers that are still OPEN; (4) an empty result
-`[]`, or no candidate, means the tracker is reachable but no run is active:
-with no local artifacts print `NO ACTIVE FACTORY RUN`; with artifacts,
-render the local view under the header note `tracker: no open run`; `.architect/wt/<slug>-01/` worktrees;
+the tracking issue + sub-issues via ONE gh call whose ENTIRE graph logic
+lives in this pinned `--jq` expression — both scripts embed it VERBATIM
+(single implementation; shells only parse the TSV lines it emits):
+
+```
+gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq '. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+```
+
+Live-verified sample output (this repo, run #43, 2026-07-03 — ground truth
+for tests; note `blockedBy` is an OBJECT `{nodes:[...]}` in gh JSON, which
+is why the expression reads `.blockedBy.nodes`):
+
+```
+TRACK	43
+SUB	46	OPEN	44	status: docs closure
+SUB	45	CLOSED		status: skill wiring (10-line cap)
+SUB	44	OPEN		status: scripts + validator contract
+```
+
+Line contract: `TRACK<TAB>n` once; `SUB<TAB>number<TAB>STATE<TAB>open-blocker
+numbers comma-joined (may be empty)<TAB>title` per sub-issue; the single
+line `NOOPENRUN` when no candidate exists. `SUB ... CLOSED` renders
+`✓ MERGED`; OPEN with blockers → `⊘ QUEUED` (list the blockers); OPEN
+without blockers falls through to the artifact-derived phases, else `○`.
+Testing seam: if env var `STATUS_GH_STUB` names a readable file, both
+scripts use its content INSTEAD of calling gh (tests only) — this makes
+tracker-mode rendering sandbox-testable against the sample above. In
+tracker mode, local artifacts only ENRICH tracker rows (matching slugs);
+stray files without a worktree DIRECTORY are never rendered as rows, and
+no glyph outside the seven ever appears. `NOOPENRUN`/empty means: no local
+artifacts → `NO ACTIVE FACTORY RUN`; artifacts → local view under
+`tracker: no open run`; `.architect/wt/<slug>-01/` worktrees;
 `docs/jobs/<slug>-01.md` STATUS lines (checked in worktree first, then
 repo); `.architect/wt/<slug>-01.events.jsonl` tails (encoding-aware);
 `.architect/wt/<slug>-01.judge.md` presence; watchdog process +

--- a/docs/spec/status-tree.md
+++ b/docs/spec/status-tree.md
@@ -1,0 +1,117 @@
+# Spec: status-tree — a conversational factory status display
+
+One read-only status tree over state the factory already writes. When the
+human asks how it's going ("status", "how's it going", any equivalent), the
+orchestrator runs the script, prints its output verbatim in a code block,
+and answers the question in prose alongside. Evidence:
+`docs/research/status-display-evidence.md`.
+
+## Approval record
+
+Pre-approved at invocation, 2026-07-03: "let's forget the live watch. Just
+use the 'status' tui. When user requests 'how's it going', 'status' or
+anything like that, then it prints the tui along with answering the
+question" — following the staged proposal presented in-session. Live
+`--watch` mode is explicitly descoped.
+
+## Goal
+
+- `skills/architect/status.ps1` and `status.sh`: print the factory status
+  tree — run header, orchestrator line, watchdog line, one line per
+  sub-issue with phase glyph + title + location, a `last:` sub-line for
+  building jobs, and a queued section for blocked issues.
+- Skill wiring: a status request during a run triggers script + prose
+  answer. Total net addition to SKILL.md+loop.md+dispatch.md ≤ 10 non-blank
+  lines (guard is at 789/800).
+- Works on every surface: colored on a TTY, plain text when piped (the
+  orchestrator's shell), degraded local-only mode when `gh` is unavailable.
+
+## Non-goals
+
+- No live refresh / `--watch` / alternate-screen anything (human ruling).
+- No new state files, no daemon, no hooks: the script only reads what runs
+  already produce.
+- No statusline integration (possible later; desktop support unverified).
+
+## Interface contract
+
+**Invocation:** `powershell -NoProfile -File skills/architect/status.ps1`
+(or `bash skills/architect/status.sh`), optional `-RepoRoot <path>`
+(`--repo-root` in sh). No other flags.
+
+**Data sources, in order:** current branch (`git branch --show-current`);
+the open tracking issue + sub-issues via ONE
+`gh issue list --json number,title,state,parent,blockedBy,assignees`
+call when `gh` works; `.architect/wt/<slug>-01/` worktrees;
+`docs/jobs/<slug>-01.md` STATUS lines (checked in worktree first, then
+repo); `.architect/wt/<slug>-01.events.jsonl` tails (encoding-aware);
+`.architect/wt/<slug>-01.judge.md` presence; watchdog process +
+`.architect/tmp/wd-*.json` config presence.
+
+**Phase derivation (per sub-issue), first match wins:**
+| Glyph | Phase | Rule |
+|---|---|---|
+| `✓` | MERGED | issue CLOSED |
+| `◐` | JUDGING | report exists AND judge output file exists without a verdict recorded on the issue yet, or judge events growing |
+| `!` | BLOCKED | report's STATUS line starts with `BLOCKED` |
+| `●` | BUILDING | worktree exists, no report yet (append `last:` sub-line from the newest command event) |
+| `⊘` | QUEUED | issue OPEN with open blocked-by issues (list them) |
+| `○` | READY | issue OPEN, no open blockers, no worktree |
+
+**Output rules:** color only when stdout is a TTY AND `NO_COLOR` is unset;
+box-drawing glyphs emitted via `[char]` codes in ps1 (PS 5.1 encoding
+safety) and UTF-8 literals in sh; when `gh` fails or is absent, print the
+tree from local artifacts only with one header note `tracker: unavailable
+(local view)`; when no factory branch and no open tracking issue exists,
+print `NO ACTIVE FACTORY RUN` plus the most recent `docs/spec/` file name.
+Exit 0 in all of these cases; nonzero only on unreadable repo.
+
+**Skill text:** SKILL.md Factory Loop step gains one bullet: on a human
+status request, run the status script (path), print its output verbatim in
+a fenced code block, and answer the question in prose — never hand-compose
+the tree. dispatch.md gains a two-to-four-line `## Status display` note
+naming the script, its data sources, and the piped-no-color behavior.
+
+## Scope: three issues
+
+| Issue | Files |
+|---|---|
+| A `status-scripts` | `skills/architect/status.ps1` (new), `skills/architect/status.sh` (new), `tests/validate_skills.py` |
+| B `status-wiring` | `skills/architect/SKILL.md`, `skills/architect/dispatch.md` |
+| C `status-docs` (blocked by A, B) | `README.md`, `CONTEXT.md`, `DESIGN.md` |
+
+## Assumptions (pre-approved unless vetoed on the tracking issue)
+
+- **A1.** Each script stays ≤ ~120 lines; PS 5.1-compatible (no `&&`,
+  ternary, `?.`); no dependencies beyond git, optional gh, and the shell.
+- **A2.** Validator adds both files to `REQUIRED_SIBLINGS["architect"]` and
+  a `check_status_contract()` asserting the six phase glyph strings and the
+  `NO ACTIVE FACTORY RUN` marker exist in both scripts.
+- **A3.** Functional checks run sandbox-side in degraded mode (gh absent
+  there), against synthetic `.architect/wt/` fixtures; the orchestrator
+  runs one live gh-backed render at composite.
+- **A4.** The wiring bullet lives in SKILL.md's Factory Loop step; total
+  net non-blank additions across the three guarded files ≤ 10 lines; if a
+  builder cannot fit it, that is a BLOCKED, not a guard edit.
+- **A5.** Docs: README gains a short "Ask it how it's going" paragraph with
+  a sample tree in the max-detail /architect section; CONTEXT gains a
+  "Status tree" glossary line; DESIGN gains one decision entry citing the
+  evidence doc. No diagram changes.
+- **A6.** This run's artifacts: checks under `docs/checks/`, reports under
+  `docs/jobs/`, branch `factory/status-tree`.
+- **A7.** Tier: builders `codex/tier-down` (gpt-5.5 high); judges
+  `codex/best` (xhigh) — same class as the last two runs.
+
+## Validation strategy
+
+Per issue: contract greps + sandboxed functional renders (A: fixture-driven
+phase derivation for BUILDING/QUEUED/MERGED at minimum, no-color-when-piped
+byte check; B: pointer integrity + size guard; C: link/mention checks).
+Composite: validator green; one live render on this repo with gh available;
+size guard ≤ 800.
+
+## Preflight evidence
+
+Same-session: gh 2.96.0 auth OK; codex 0.139.0 canary `CANARY: SHELLS_OK`
+(and the MSYS diagnostic canary exercising the sandbox). Skill-text size
+guard measured 789/800 before this run.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -193,6 +193,8 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
 - Sleep between events. Wake only when a job reports DONE, BLOCKED, stalled,
   or killed evidence; when the watchdog exits with anomaly evidence; or when
   the ready issues need recomputation.
+- On human status requests ("status", "how's it going", or equivalent), run
+  `skills/architect/status.ps1` on Windows or `skills/architect/status.sh` on POSIX, print its output verbatim in a fenced code block, answer in prose, and never hand-compose the tree.
 - On DONE, send a fresh, independent orchestrator-tier judge to run frozen
   checks and inspect intent.
   Merge only after a passing verdict and clean touch-set evidence.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -338,6 +338,11 @@ The watchdog never kills, nudges, or judges. It exits with typed evidence:
 Use the LLM fallback only for backends where the orchestrator cannot launch a
 background process whose exit wakes the loop.
 
+## Status display
+
+`skills/architect/status.ps1` (Windows) and `skills/architect/status.sh` (POSIX) read only run artifacts plus `gh`.
+Piped output is plain text by design; callers print it verbatim instead of hand-composing status.
+
 <!-- architect-monitor-fallback-template:start -->
 ```text
 You are the detection-only fallback monitor for this dispatch wave. Use this

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -1,0 +1,118 @@
+param([string]$RepoRoot = (Get-Location).Path)
+
+$ErrorActionPreference = "SilentlyContinue"
+
+function J($A, $B) { return [System.IO.Path]::Combine($A, $B) }
+function TailText($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $len = [Math]::Min([int64]4096, $fs.Length)
+        [void]$fs.Seek(-$len, [System.IO.SeekOrigin]::End)
+        $buf = New-Object byte[] $len
+        [void]$fs.Read($buf, 0, $len)
+    } finally { $fs.Close() }
+    $utf8 = New-Object System.Text.UTF8Encoding($false, $true)
+    try { return $utf8.GetString($buf) } catch { return [System.Text.Encoding]::Unicode.GetString($buf) }
+}
+function NewestSpec() {
+    $specDir = J $root "docs/spec"
+    $spec = Get-ChildItem -LiteralPath $specDir -Filter "*.md" | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    if ($spec) { return $spec.Name }
+    return "unknown"
+}
+function LastCommand($Slug) {
+    $ev = J (J $root ".architect/wt") "$Slug-01.events.jsonl"
+    $text = TailText $ev
+    $matches = [regex]::Matches($text, '"command"\s*:\s*"((?:\\.|[^"\\])*)"')
+    if ($matches.Count -eq 0) { return "" }
+    $cmd = $matches[$matches.Count - 1].Groups[1].Value.Replace('\"', '"').Replace('\\', '\')
+    return "    last: $cmd age: unknown"
+}
+function StatusLine($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    $m = [regex]::Matches((TailText $Path), '(?m)^\uFEFF?STATUS:\s*(.+)$')
+    if ($m.Count -eq 0) { return "" }
+    return $m[$m.Count - 1].Groups[1].Value
+}
+function Slugify($Title) {
+    $s = $Title.ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+    return $s.Trim('-')
+}
+function ReportPath($Slug) {
+    $inside = J (J (J (J $root ".architect/wt") "$Slug-01") "docs/jobs") "$Slug-01.md"
+    if (Test-Path -LiteralPath $inside) { return $inside }
+    $repo = J (J $root "docs/jobs") "$Slug-01.md"
+    if (Test-Path -LiteralPath $repo) { return $repo }
+    return $inside
+}
+function ArtifactSlugs() {
+    $set = @{}
+    $wt = J $root ".architect/wt"
+    if (Test-Path -LiteralPath $wt) {
+        foreach ($d in (Get-ChildItem -LiteralPath $wt -Directory -Filter "*-01")) { $set[$d.Name.Substring(0, $d.Name.Length - 3)] = $true }
+        foreach ($f in (Get-ChildItem -LiteralPath $wt -File -Filter "*-01.events.jsonl")) { $set[$f.Name -replace '-01\.events\.jsonl$', ''] = $true }
+        foreach ($f in (Get-ChildItem -LiteralPath $wt -File -Filter "*-01.judge*.md")) { $set[$f.Name -replace '-01\.judge.*$', ''] = $true }
+        foreach ($f in (Get-ChildItem -LiteralPath $wt -Recurse -File -Filter "*-01.md")) { if ($f.FullName -match '\\docs\\jobs\\([^\\]+)-01\.md$') { $set[$matches[1]] = $true } }
+    }
+    $jobs = J $root "docs/jobs"
+    if (Test-Path -LiteralPath $jobs) {
+        foreach ($f in (Get-ChildItem -LiteralPath $jobs -File -Filter "*-01.md")) { $set[$f.Name -replace '-01\.md$', ''] = $true }
+    }
+    return @($set.Keys | Sort-Object)
+}
+function Phase($Slug, $Issue) {
+    if ($Issue -and $Issue.state -eq "CLOSED") { return @($G.Merged, "MERGED") }
+    $report = ReportPath $Slug
+    $judge = @(Get-ChildItem -LiteralPath (J $root ".architect/wt") -File -Filter "$Slug-01.judge*.md")
+    if ((Test-Path -LiteralPath $report) -and $judge.Count -gt 0) { return @($G.Judging, "JUDGING") }
+    $status = StatusLine $report
+    if ($status.StartsWith("BLOCKED")) { return @($G.Blocked, "BLOCKED") }
+    if (Test-Path -LiteralPath $report) { return @($G.Reported, "REPORTED") }
+    if (Test-Path -LiteralPath (J (J $root ".architect/wt") "$Slug-01")) { return @($G.Building, "BUILDING") }
+    if ($Issue -and $Issue.blockedBy -and @($Issue.blockedBy).Count -gt 0) { return @($G.Queued, "QUEUED") }
+    return @($G.Ready, "READY")
+}
+
+$root = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $root -PathType Container)) { Write-Output "unreadable repo: $RepoRoot"; exit 1 }
+$G = @{ Merged = [char]0x2713; Judging = [char]0x25D0; Blocked = "!"; Reported = [char]0x25A3; Building = [char]0x25CF; Queued = [char]0x2298; Ready = [char]0x25CB }
+if (Test-Path -LiteralPath (J $root ".git")) { $branch = (& git -C $root branch --show-current 2>$null) } else { $branch = "" }
+if (-not $branch) { $branch = "unknown" }
+$ghJson = ""
+try { $ghJson = (& gh issue list --json number,title,state,parent,blockedBy,assignees 2>$null) } catch { $ghJson = "" }
+$issues = @()
+if ($LASTEXITCODE -eq 0 -and $ghJson) { try { $issues = @($ghJson | ConvertFrom-Json) } catch { $issues = @() } }
+$parents = @($issues | Where-Object { $_.parent } | ForEach-Object { $_.parent.number } | Select-Object -Unique)
+if ($parents.Count -gt 0) { $tracking = $parents[0]; $issues = @($issues | Where-Object { $_.parent -and $_.parent.number -eq $tracking }) } else { $tracking = "" }
+$trackerOk = $issues.Count -gt 0
+$slugs = ArtifactSlugs
+if ((-not $trackerOk) -and $slugs.Count -eq 0) {
+    Write-Output "NO ACTIVE FACTORY RUN"
+    Write-Output "spec: $(NewestSpec)"
+    exit 0
+}
+Write-Output "STATUS TREE spec: $(NewestSpec) branch: $branch"
+if ($trackerOk -and $tracking) { Write-Output "tracker: #$tracking" } elseif ($trackerOk) { Write-Output "tracker: available" } else { Write-Output "tracker: unavailable (local view)" }
+Write-Output "ORCHESTRATOR: local view"
+$wdCfg = @(Get-ChildItem -LiteralPath (J $root ".architect/tmp") -Filter "wd-*.json")
+$wdProc = @(Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -match 'watchdog\.(ps1|sh)' })
+Write-Output "WATCHDOG: process=$($wdProc.Count -gt 0) config=$($wdCfg.Count)"
+if ($trackerOk) {
+    foreach ($issue in $issues) {
+        $slug = Slugify $issue.title
+        $p = Phase $slug $issue
+        $extra = ""
+        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + (($issue.blockedBy | ForEach-Object { $_.number }) -join ",") }
+        Write-Output "$($p[0]) #$($issue.number) $($issue.title) .architect/wt/$slug-01$extra"
+        if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
+    }
+} else {
+    foreach ($slug in $slugs) {
+        $p = Phase $slug $null
+        if ($p[1] -in @("BUILDING", "BLOCKED", "JUDGING", "REPORTED")) {
+            Write-Output "$($p[0]) $slug .architect/wt/$slug-01"
+            if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
+        }
+    }
+}

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -51,19 +51,12 @@ function ArtifactSlugs() {
     $wt = J $root ".architect/wt"
     if (Test-Path -LiteralPath $wt) {
         foreach ($d in (Get-ChildItem -LiteralPath $wt -Directory -Filter "*-01")) { $set[$d.Name.Substring(0, $d.Name.Length - 3)] = $true }
-        foreach ($f in (Get-ChildItem -LiteralPath $wt -File -Filter "*-01.events.jsonl")) { $set[$f.Name -replace '-01\.events\.jsonl$', ''] = $true }
-        foreach ($f in (Get-ChildItem -LiteralPath $wt -File -Filter "*-01.judge*.md")) { $set[$f.Name -replace '-01\.judge.*$', ''] = $true }
-        foreach ($f in (Get-ChildItem -LiteralPath $wt -Recurse -File -Filter "*-01.md")) { if ($f.FullName -match '\\docs\\jobs\\([^\\]+)-01\.md$') { $set[$matches[1]] = $true } }
-    }
-    $jobs = J $root "docs/jobs"
-    if (Test-Path -LiteralPath $jobs) {
-        foreach ($f in (Get-ChildItem -LiteralPath $jobs -File -Filter "*-01.md")) { $set[$f.Name -replace '-01\.md$', ''] = $true }
     }
     return @($set.Keys | Sort-Object)
 }
-function OpenBlockerNumbers($Issue) { if (-not $Issue -or -not $Issue.blockedBy) { return @() }; return @($Issue.blockedBy | Where-Object { $_.state -eq "OPEN" } | ForEach-Object { $_.number }) }
-function Phase($Slug, $Issue) {
-    if ($Issue -and $Issue.state -eq "CLOSED") { return @($G.Merged, "MERGED") }
+function Phase($Slug, $State, $Blockers) {
+    if ($State -eq "CLOSED") { return @($G.Merged, "MERGED") }
+    if ($State -eq "OPEN" -and $Blockers) { return @($G.Queued, "QUEUED") }
     $report = ReportPath $Slug
     $judge = @(Get-ChildItem -LiteralPath (J $root ".architect/wt") -File -Filter "$Slug-01.judge*.md")
     if ((Test-Path -LiteralPath $report) -and $judge.Count -gt 0) { return @($G.Judging, "JUDGING") }
@@ -71,8 +64,20 @@ function Phase($Slug, $Issue) {
     if ($status.StartsWith("BLOCKED")) { return @($G.Blocked, "BLOCKED") }
     if (Test-Path -LiteralPath $report) { return @($G.Reported, "REPORTED") }
     if (Test-Path -LiteralPath (J (J $root ".architect/wt") "$Slug-01")) { return @($G.Building, "BUILDING") }
-    if ((OpenBlockerNumbers $Issue).Count -gt 0) { return @($G.Queued, "QUEUED") }
     return @($G.Ready, "READY")
+}
+function TrackerLines() {
+    $PinnedJq = '. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+    if ($env:STATUS_GH_STUB -and (Test-Path -LiteralPath $env:STATUS_GH_STUB -PathType Leaf)) {
+        return @{ Reachable = $true; Lines = @(Get-Content -LiteralPath $env:STATUS_GH_STUB) }
+    }
+    if (-not (Get-Command gh)) { return @{ Reachable = $false; Lines = @() } }
+    try {
+        $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null
+        return @{ Reachable = ($LASTEXITCODE -eq 0); Lines = @($out) }
+    } catch {
+        return @{ Reachable = $false; Lines = @() }
+    }
 }
 
 $root = [System.IO.Path]::GetFullPath($RepoRoot)
@@ -80,21 +85,19 @@ if (-not (Test-Path -LiteralPath $root -PathType Container)) { Write-Output "unr
 $G = @{ Merged = [char]0x2713; Judging = [char]0x25D0; Blocked = "!"; Reported = [char]0x25A3; Building = [char]0x25CF; Queued = [char]0x2298; Ready = [char]0x25CB }
 if (Test-Path -LiteralPath (J $root ".git")) { $branch = (& git -C $root branch --show-current 2>$null) } else { $branch = "" }
 if (-not $branch) { $branch = "unknown" }
-$ghJson = ""
-$trackerReachable = $false
-if (Get-Command gh) {
-    try { $ghJson = (& gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>$null); $trackerReachable = ($LASTEXITCODE -eq 0) }
-    catch { $ghJson = ""; $trackerReachable = $false }
-}
-$issues = @()
-if ($trackerReachable -and $ghJson) { try { $issues = @($ghJson | ConvertFrom-Json) } catch { $issues = @() } }
-$parentRefs = @($issues | Where-Object { $_.parent } | ForEach-Object { $_.parent.number } | Select-Object -Unique)
-$trackingIssue = @($issues | Where-Object { $_.state -eq "OPEN" -and $parentRefs -contains $_.number } | Sort-Object number -Descending | Select-Object -First 1)
+$trackerData = TrackerLines
+$trackerReachable = $trackerData.Reachable
 $tracking = ""
 $subIssues = @()
-if ($trackingIssue.Count -gt 0) {
-    $tracking = $trackingIssue[0].number
-    $subIssues = @($issues | Where-Object { $_.parent -and $_.parent.number -eq $tracking })
+if ($trackerReachable) {
+    foreach ($line in $trackerData.Lines) {
+        if (-not $line) { continue }
+        $parts = $line -split "`t", 5
+        if ($parts[0] -eq "TRACK" -and $parts.Count -ge 2) { $tracking = $parts[1]; continue }
+        if ($parts[0] -eq "SUB" -and $parts.Count -ge 5) {
+            $subIssues += [pscustomobject]@{ Number = $parts[1]; State = $parts[2]; Blockers = $parts[3]; Title = $parts[4] }
+        }
+    }
 }
 $slugs = ArtifactSlugs
 if (((-not $trackerReachable) -or ($trackerReachable -and -not $tracking)) -and $slugs.Count -eq 0) {
@@ -110,16 +113,16 @@ $wdProc = @(Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -match '
 Write-Output "WATCHDOG: process=$($wdProc.Count -gt 0) config=$($wdCfg.Count)"
 if ($trackerReachable -and $tracking) {
     foreach ($issue in $subIssues) {
-        $slug = Slugify $issue.title
-        $p = Phase $slug $issue
+        $slug = Slugify $issue.Title
+        $p = Phase $slug $issue.State $issue.Blockers
         $extra = ""
-        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + ((OpenBlockerNumbers $issue) -join ",") }
-        Write-Output "$($p[0]) #$($issue.number) $($issue.title) .architect/wt/$slug-01$extra"
+        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + $issue.Blockers }
+        Write-Output "$($p[0]) #$($issue.Number) $($issue.Title) .architect/wt/$slug-01$extra"
         if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
     }
 } else {
     foreach ($slug in $slugs) {
-        $p = Phase $slug $null
+        $p = Phase $slug "" ""
         if ($p[1] -in @("BUILDING", "BLOCKED", "JUDGING", "REPORTED")) {
             Write-Output "$($p[0]) $slug .architect/wt/$slug-01"
             if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -77,13 +77,14 @@ function TrackerLines() {
     if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return @{ Reachable = $false; Lines = @() } }
     try {
         Push-Location -LiteralPath $root
-        # No stderr redirect: PS 5.1 wraps native stderr in ErrorRecords and
-        # poisons this try/catch even when gh succeeds (run #43 live evidence).
         # PS <=5 strips embedded double quotes when passing args to native
         # commands; gh must receive the pinned jq with its quotes intact.
+        # (The original live failure: quote-stripping made gh exit nonzero
+        # while 2>$null hid its parse error. Quoting fixed, stderr stays
+        # suppressed so failing gh is as silent as absent gh.)
         $jqArg = $PinnedJq
         if ($PSVersionTable.PSVersion.Major -le 5) { $jqArg = $PinnedJq -replace '"', '\"' }
-        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $jqArg }
+        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $jqArg 2>$null }
         finally { Pop-Location }
         return @{ Reachable = ($LASTEXITCODE -eq 0); Lines = @($out) }
     } catch {

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -61,6 +61,7 @@ function ArtifactSlugs() {
     }
     return @($set.Keys | Sort-Object)
 }
+function OpenBlockerNumbers($Issue) { if (-not $Issue -or -not $Issue.blockedBy) { return @() }; return @($Issue.blockedBy | Where-Object { $_.state -eq "OPEN" } | ForEach-Object { $_.number }) }
 function Phase($Slug, $Issue) {
     if ($Issue -and $Issue.state -eq "CLOSED") { return @($G.Merged, "MERGED") }
     $report = ReportPath $Slug
@@ -70,7 +71,7 @@ function Phase($Slug, $Issue) {
     if ($status.StartsWith("BLOCKED")) { return @($G.Blocked, "BLOCKED") }
     if (Test-Path -LiteralPath $report) { return @($G.Reported, "REPORTED") }
     if (Test-Path -LiteralPath (J (J $root ".architect/wt") "$Slug-01")) { return @($G.Building, "BUILDING") }
-    if ($Issue -and $Issue.blockedBy -and @($Issue.blockedBy).Count -gt 0) { return @($G.Queued, "QUEUED") }
+    if ((OpenBlockerNumbers $Issue).Count -gt 0) { return @($G.Queued, "QUEUED") }
     return @($G.Ready, "READY")
 }
 
@@ -80,30 +81,39 @@ $G = @{ Merged = [char]0x2713; Judging = [char]0x25D0; Blocked = "!"; Reported =
 if (Test-Path -LiteralPath (J $root ".git")) { $branch = (& git -C $root branch --show-current 2>$null) } else { $branch = "" }
 if (-not $branch) { $branch = "unknown" }
 $ghJson = ""
-try { $ghJson = (& gh issue list --json number,title,state,parent,blockedBy,assignees 2>$null) } catch { $ghJson = "" }
+$trackerReachable = $false
+if (Get-Command gh) {
+    try { $ghJson = (& gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>$null); $trackerReachable = ($LASTEXITCODE -eq 0) }
+    catch { $ghJson = ""; $trackerReachable = $false }
+}
 $issues = @()
-if ($LASTEXITCODE -eq 0 -and $ghJson) { try { $issues = @($ghJson | ConvertFrom-Json) } catch { $issues = @() } }
-$parents = @($issues | Where-Object { $_.parent } | ForEach-Object { $_.parent.number } | Select-Object -Unique)
-if ($parents.Count -gt 0) { $tracking = $parents[0]; $issues = @($issues | Where-Object { $_.parent -and $_.parent.number -eq $tracking }) } else { $tracking = "" }
-$trackerOk = $issues.Count -gt 0
+if ($trackerReachable -and $ghJson) { try { $issues = @($ghJson | ConvertFrom-Json) } catch { $issues = @() } }
+$parentRefs = @($issues | Where-Object { $_.parent } | ForEach-Object { $_.parent.number } | Select-Object -Unique)
+$trackingIssue = @($issues | Where-Object { $_.state -eq "OPEN" -and $parentRefs -contains $_.number } | Sort-Object number -Descending | Select-Object -First 1)
+$tracking = ""
+$subIssues = @()
+if ($trackingIssue.Count -gt 0) {
+    $tracking = $trackingIssue[0].number
+    $subIssues = @($issues | Where-Object { $_.parent -and $_.parent.number -eq $tracking })
+}
 $slugs = ArtifactSlugs
-if ((-not $trackerOk) -and $slugs.Count -eq 0) {
+if (((-not $trackerReachable) -or ($trackerReachable -and -not $tracking)) -and $slugs.Count -eq 0) {
     Write-Output "NO ACTIVE FACTORY RUN"
     Write-Output "spec: $(NewestSpec)"
     exit 0
 }
 Write-Output "STATUS TREE spec: $(NewestSpec) branch: $branch"
-if ($trackerOk -and $tracking) { Write-Output "tracker: #$tracking" } elseif ($trackerOk) { Write-Output "tracker: available" } else { Write-Output "tracker: unavailable (local view)" }
+if ($trackerReachable -and $tracking) { Write-Output "tracker: #$tracking" } elseif ($trackerReachable) { Write-Output "tracker: no open run" } else { Write-Output "tracker: unavailable (local view)" }
 Write-Output "ORCHESTRATOR: local view"
 $wdCfg = @(Get-ChildItem -LiteralPath (J $root ".architect/tmp") -Filter "wd-*.json")
 $wdProc = @(Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -match 'watchdog\.(ps1|sh)' })
 Write-Output "WATCHDOG: process=$($wdProc.Count -gt 0) config=$($wdCfg.Count)"
-if ($trackerOk) {
-    foreach ($issue in $issues) {
+if ($trackerReachable -and $tracking) {
+    foreach ($issue in $subIssues) {
         $slug = Slugify $issue.title
         $p = Phase $slug $issue
         $extra = ""
-        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + (($issue.blockedBy | ForEach-Object { $_.number }) -join ",") }
+        if ($p[1] -eq "QUEUED") { $extra = " blocked-by: " + ((OpenBlockerNumbers $issue) -join ",") }
         Write-Output "$($p[0]) #$($issue.number) $($issue.title) .architect/wt/$slug-01$extra"
         if ($p[1] -eq "BUILDING") { $last = LastCommand $slug; if ($last) { Write-Output $last } }
     }

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -73,7 +73,9 @@ function TrackerLines() {
     }
     if (-not (Get-Command gh)) { return @{ Reachable = $false; Lines = @() } }
     try {
-        $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null
+        Push-Location -LiteralPath $root
+        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null }
+        finally { Pop-Location }
         return @{ Reachable = ($LASTEXITCODE -eq 0); Lines = @($out) }
     } catch {
         return @{ Reachable = $false; Lines = @() }
@@ -82,7 +84,21 @@ function TrackerLines() {
 
 $root = [System.IO.Path]::GetFullPath($RepoRoot)
 if (-not (Test-Path -LiteralPath $root -PathType Container)) { Write-Output "unreadable repo: $RepoRoot"; exit 1 }
-$G = @{ Merged = [char]0x2713; Judging = [char]0x25D0; Blocked = "!"; Reported = [char]0x25A3; Building = [char]0x25CF; Queued = [char]0x2298; Ready = [char]0x25CB }
+$useColor = (-not [Console]::IsOutputRedirected) -and (-not $env:NO_COLOR)
+function ColorGlyph($Glyph, $Code) {
+    if (-not $useColor) { return $Glyph }
+    $esc = [char]27
+    return "$esc[$Code" + "m$Glyph$esc[0m"
+}
+$G = @{
+    Merged = ColorGlyph ([char]0x2713) "32"
+    Judging = ColorGlyph ([char]0x25D0) "36"
+    Blocked = ColorGlyph "!" "31"
+    Reported = ColorGlyph ([char]0x25A3) "35"
+    Building = ColorGlyph ([char]0x25CF) "34"
+    Queued = ColorGlyph ([char]0x2298) "33"
+    Ready = ColorGlyph ([char]0x25CB) "37"
+}
 if (Test-Path -LiteralPath (J $root ".git")) { $branch = (& git -C $root branch --show-current 2>$null) } else { $branch = "" }
 if (-not $branch) { $branch = "unknown" }
 $trackerData = TrackerLines

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -1,6 +1,9 @@
 param([string]$RepoRoot = (Get-Location).Path)
 
 $ErrorActionPreference = "SilentlyContinue"
+# PS 5.1 defaults redirected output to the OEM codepage, which turns the
+# phase glyphs into '?'. Emit UTF-8 so the tree survives pipes and chat.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
 
 function J($A, $B) { return [System.IO.Path]::Combine($A, $B) }
 function TailText($Path) {
@@ -71,10 +74,16 @@ function TrackerLines() {
     if ($env:STATUS_GH_STUB -and (Test-Path -LiteralPath $env:STATUS_GH_STUB -PathType Leaf)) {
         return @{ Reachable = $true; Lines = @(Get-Content -LiteralPath $env:STATUS_GH_STUB) }
     }
-    if (-not (Get-Command gh)) { return @{ Reachable = $false; Lines = @() } }
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return @{ Reachable = $false; Lines = @() } }
     try {
         Push-Location -LiteralPath $root
-        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $PinnedJq 2>$null }
+        # No stderr redirect: PS 5.1 wraps native stderr in ErrorRecords and
+        # poisons this try/catch even when gh succeeds (run #43 live evidence).
+        # PS <=5 strips embedded double quotes when passing args to native
+        # commands; gh must receive the pinned jq with its quotes intact.
+        $jqArg = $PinnedJq
+        if ($PSVersionTable.PSVersion.Major -le 5) { $jqArg = $PinnedJq -replace '"', '\"' }
+        try { $out = & gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq $jqArg }
         finally { Pop-Location }
         return @{ Reachable = ($LASTEXITCODE -eq 0); Lines = @($out) }
     } catch {

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -8,7 +8,8 @@ done
 case "$root" in /*) ;; *) root="$(pwd)/$root";; esac
 [ -d "$root" ] || { printf 'unreadable repo: %s\n' "$root"; exit 1; }
 
-g_merged='✓'; g_judging='◐'; g_blocked='!'; g_reported='▣'; g_building='●'; g_queued='⊘'; g_ready='○'
+color_glyph(){ if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then printf '\033[%sm%s\033[0m' "$2" "$1"; else printf '%s' "$1"; fi; }
+g_merged=$(color_glyph '✓' 32); g_judging=$(color_glyph '◐' 36); g_blocked=$(color_glyph '!' 31); g_reported=$(color_glyph '▣' 35); g_building=$(color_glyph '●' 34); g_queued=$(color_glyph '⊘' 33); g_ready=$(color_glyph '○' 37)
 j(){ printf '%s/%s' "$1" "$2"; }
 newest_spec(){
   spec_dir="$root/docs/spec"
@@ -67,7 +68,7 @@ tracker_lines(){
     return 0
   fi
   command -v gh >/dev/null 2>&1 || return 1
-  gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr"
+  (cd "$root" && gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr")
 }
 
 branch=

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -11,8 +11,20 @@ case "$root" in /*) ;; *) root="$(pwd)/$root";; esac
 g_merged='✓'; g_judging='◐'; g_blocked='!'; g_reported='▣'; g_building='●'; g_queued='⊘'; g_ready='○'
 j(){ printf '%s/%s' "$1" "$2"; }
 newest_spec(){
-  spec=$(find "$root/docs/spec" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort | tail -n 1)
-  [ -n "$spec" ] && basename "$spec" || printf unknown
+  spec_dir="$root/docs/spec"
+  newest=
+  newest_mtime=
+  [ -d "$spec_dir" ] || { printf unknown; return; }
+  for spec in "$spec_dir"/*.md; do
+    [ -f "$spec" ] || continue
+    mtime=$(stat -c %Y "$spec" 2>/dev/null || stat -f %m "$spec" 2>/dev/null || printf 0)
+    case "$mtime" in ''|*[!0-9]*) mtime=0;; esac
+    if [ -z "$newest" ] || [ "$mtime" -gt "$newest_mtime" ]; then
+      newest=$spec
+      newest_mtime=$mtime
+    fi
+  done
+  [ -n "$newest" ] && basename "$newest" || printf unknown
 }
 tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000'; }
 status_line(){

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -u
+
+root=$(pwd)
+while [ "$#" -gt 0 ]; do
+  case "$1" in --repo-root) root=$2; shift 2;; *) shift;; esac
+done
+case "$root" in /*) ;; *) root="$(pwd)/$root";; esac
+[ -d "$root" ] || { printf 'unreadable repo: %s\n' "$root"; exit 1; }
+
+g_merged='✓'; g_judging='◐'; g_blocked='!'; g_reported='▣'; g_building='●'; g_queued='⊘'; g_ready='○'
+j(){ printf '%s/%s' "$1" "$2"; }
+newest_spec(){
+  spec=$(find "$root/docs/spec" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort | tail -n 1)
+  [ -n "$spec" ] && basename "$spec" || printf unknown
+}
+tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000'; }
+status_line(){
+  tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk '/^STATUS:/{sub(/^STATUS:[[:space:]]*/,""); s=$0} END{print s}'
+}
+last_command(){
+  ev="$root/.architect/wt/$1-01.events.jsonl"
+  cmd=$(tail_text "$ev" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | tail -n 1)
+  [ -n "$cmd" ] && printf '    last: %s age: unknown\n' "$cmd"
+}
+report_path(){
+  in_wt="$root/.architect/wt/$1-01/docs/jobs/$1-01.md"
+  in_repo="$root/docs/jobs/$1-01.md"
+  [ -f "$in_wt" ] && { printf '%s' "$in_wt"; return; }
+  printf '%s' "$in_repo"
+}
+slugify(){
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g;s/--*/-/g;s/^-//;s/-$//'
+}
+artifact_slugs(){
+  {
+    find "$root/.architect/wt" -maxdepth 1 -type d -name '*-01' 2>/dev/null | sed 's|.*/||;s/-01$//'
+    find "$root/.architect/wt" -maxdepth 1 -type f -name '*-01.events.jsonl' 2>/dev/null | sed 's|.*/||;s/-01\.events\.jsonl$//'
+    find "$root/.architect/wt" -maxdepth 1 -type f -name '*-01.judge*.md' 2>/dev/null | sed 's|.*/||;s/-01\.judge.*$//'
+    find "$root/.architect/wt" -path '*/docs/jobs/*-01.md' -type f 2>/dev/null | sed 's|.*/docs/jobs/||;s/-01\.md$//'
+    find "$root/docs/jobs" -maxdepth 1 -type f -name '*-01.md' 2>/dev/null | sed 's|.*/||;s/-01\.md$//'
+  } | sort -u
+}
+phase(){
+  slug=$1; state=${2:-}; blockers=${3:-}
+  [ "$state" = CLOSED ] && { printf '%s MERGED' "$g_merged"; return; }
+  rep=$(report_path "$slug")
+  judge=$(find "$root/.architect/wt" -maxdepth 1 -type f -name "$slug-01.judge*.md" 2>/dev/null | head -n 1)
+  [ -f "$rep" ] && [ -n "$judge" ] && { printf '%s JUDGING' "$g_judging"; return; }
+  st=$(status_line "$rep")
+  case "$st" in BLOCKED*) printf '%s BLOCKED' "$g_blocked"; return;; esac
+  [ -f "$rep" ] && { printf '%s REPORTED' "$g_reported"; return; }
+  [ -d "$root/.architect/wt/$slug-01" ] && { printf '%s BUILDING' "$g_building"; return; }
+  [ -n "$blockers" ] && { printf '%s QUEUED' "$g_queued"; return; }
+  printf '%s READY' "$g_ready"
+}
+
+branch=
+[ -e "$root/.git" ] && branch=$(git -C "$root" branch --show-current 2>/dev/null || true)
+[ -n "$branch" ] || branch=unknown
+gh_json=
+if command -v gh >/dev/null 2>&1; then gh_json=$(gh issue list --json number,title,state,parent,blockedBy,assignees 2>/dev/null || true); fi
+tracker=0
+[ -n "$gh_json" ] && tracker=1
+slugs=$(artifact_slugs)
+if [ "$tracker" -eq 0 ] && [ -z "$slugs" ]; then
+  printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
+  exit 0
+fi
+printf 'STATUS TREE spec: %s branch: %s\n' "$(newest_spec)" "$branch"
+[ "$tracker" -eq 1 ] && printf 'tracker: available\n' || printf 'tracker: unavailable (local view)\n'
+printf 'ORCHESTRATOR: local view\n'
+cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/null | wc -l | tr -d ' ')
+ps -eo args= 2>/dev/null | grep 'watchdog\.\(ps1\|sh\)' >/dev/null && proc=True || proc=False
+printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
+if [ "$tracker" -eq 1 ]; then
+  printf '%s\n' "$gh_json" | sed 's/^\[//;s/\]$//;s/},{/}\
+{/g' | while IFS= read -r obj; do
+    num=$(printf '%s' "$obj" | sed -n 's/.*"number":[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+    title=$(printf '%s' "$obj" | sed -n 's/.*"title":[[:space:]]*"\([^"]*\)".*/\1/p')
+    state=$(printf '%s' "$obj" | sed -n 's/.*"state":[[:space:]]*"\([^"]*\)".*/\1/p')
+    blockers=$(printf '%s' "$obj" | grep -o '"blockedBy":[^]]*' | grep -o '"number":[0-9]*' | sed 's/[^0-9]//g' | paste -sd, -)
+    [ -n "$num" ] || continue
+    slug=$(slugify "$title"); set -- $(phase "$slug" "$state" "$blockers")
+    extra=; [ "$2" = QUEUED ] && extra=" blocked-by: $blockers"
+    printf '%s #%s %s .architect/wt/%s-01%s\n' "$1" "$num" "$title" "$slug" "$extra"
+    [ "$2" = BUILDING ] && last_command "$slug"
+  done
+else
+  for slug in $slugs; do
+    set -- $(phase "$slug")
+    case "$2" in BUILDING|BLOCKED|JUDGING|REPORTED)
+      printf '%s %s .architect/wt/%s-01\n' "$1" "$slug" "$slug"
+      [ "$2" = BUILDING ] && last_command "$slug"
+    esac
+  done
+fi

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -30,18 +30,6 @@ tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000'; }
 status_line(){
   tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk '/^STATUS:/{sub(/^STATUS:[[:space:]]*/,""); s=$0} END{print s}'
 }
-json_objects(){
-  awk 'BEGIN{d=0;s=0;e=0;o=""}{for(i=1;i<=length($0);i++){c=substr($0,i,1);if(s){o=o c;if(e)e=0;else if(c=="\\")e=1;else if(c=="\"")s=0;continue}if(c=="\""){if(d>0)o=o c;s=1;continue}if(c=="{"){d++;o=o c;continue}if(d>0)o=o c;if(c=="}"){d--;if(d==0){print o;o=""}}}}'
-}
-issue_number(){ printf '%s' "$1" | grep -o '"number"[[:space:]]*:[[:space:]]*[0-9][0-9]*' | head -n 1 | sed 's/[^0-9]//g'; }
-issue_title(){ printf '%s' "$1" | grep -o '"title"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"title"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'; }
-issue_state(){ printf '%s' "$1" | grep -o '"state"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'; }
-parent_number(){ printf '%s' "$1" | sed -n 's/.*"parent"[[:space:]]*:[[:space:]]*{[^}]*"number"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1; }
-open_blockers(){
-  block=$(printf '%s' "$1" | sed -n 's/.*"blockedBy"[[:space:]]*:[[:space:]]*\[\(.*\)\][[:space:]]*}.*/\1/p')
-  [ -n "$block" ] || return
-  printf '[%s]\n' "$block" | json_objects | while IFS= read -r blocker; do [ "$(issue_state "$blocker")" = OPEN ] && issue_number "$blocker"; done | paste -sd, -
-}
 last_command(){
   ev="$root/.architect/wt/$1-01.events.jsonl"
   cmd=$(tail_text "$ev" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | tail -n 1)
@@ -57,17 +45,12 @@ slugify(){
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g;s/--*/-/g;s/^-//;s/-$//'
 }
 artifact_slugs(){
-  {
-    find "$root/.architect/wt" -maxdepth 1 -type d -name '*-01' 2>/dev/null | sed 's|.*/||;s/-01$//'
-    find "$root/.architect/wt" -maxdepth 1 -type f -name '*-01.events.jsonl' 2>/dev/null | sed 's|.*/||;s/-01\.events\.jsonl$//'
-    find "$root/.architect/wt" -maxdepth 1 -type f -name '*-01.judge*.md' 2>/dev/null | sed 's|.*/||;s/-01\.judge.*$//'
-    find "$root/.architect/wt" -path '*/docs/jobs/*-01.md' -type f 2>/dev/null | sed 's|.*/docs/jobs/||;s/-01\.md$//'
-    find "$root/docs/jobs" -maxdepth 1 -type f -name '*-01.md' 2>/dev/null | sed 's|.*/||;s/-01\.md$//'
-  } | sort -u
+  find "$root/.architect/wt" -maxdepth 1 -type d -name '*-01' 2>/dev/null | sed 's|.*/||;s/-01$//' | sort -u
 }
 phase(){
   slug=$1; state=${2:-}; blockers=${3:-}
   [ "$state" = CLOSED ] && { printf '%s MERGED' "$g_merged"; return; }
+  [ "$state" = OPEN ] && [ -n "$blockers" ] && { printf '%s QUEUED' "$g_queued"; return; }
   rep=$(report_path "$slug")
   judge=$(find "$root/.architect/wt" -maxdepth 1 -type f -name "$slug-01.judge*.md" 2>/dev/null | head -n 1)
   [ -f "$rep" ] && [ -n "$judge" ] && { printf '%s JUDGING' "$g_judging"; return; }
@@ -75,40 +58,29 @@ phase(){
   case "$st" in BLOCKED*) printf '%s BLOCKED' "$g_blocked"; return;; esac
   [ -f "$rep" ] && { printf '%s REPORTED' "$g_reported"; return; }
   [ -d "$root/.architect/wt/$slug-01" ] && { printf '%s BUILDING' "$g_building"; return; }
-  [ -n "$blockers" ] && { printf '%s QUEUED' "$g_queued"; return; }
   printf '%s READY' "$g_ready"
+}
+tracker_lines(){
+  jq_expr='. as $all | ([ $all[] | select(.parent != null) | .parent.number ] | unique) as $pnums | ([ $all[] | select(.state == "OPEN") | select(.number as $n | $pnums | index($n)) ] | map(.number) | max) as $t | if $t == null then "NOOPENRUN" else ("TRACK\t\($t)", ($all[] | select(.parent != null and .parent.number == $t) | [ "SUB", (.number|tostring), .state, ((.blockedBy.nodes // []) | map(select(.state == "OPEN") | (.number|tostring)) | join(",")), .title ] | @tsv)) end'
+  if [ -n "${STATUS_GH_STUB:-}" ] && [ -r "$STATUS_GH_STUB" ]; then
+    cat "$STATUS_GH_STUB"
+    return 0
+  fi
+  command -v gh >/dev/null 2>&1 || return 1
+  gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy --jq "$jq_expr"
 }
 
 branch=
 [ -e "$root/.git" ] && branch=$(git -C "$root" branch --show-current 2>/dev/null || true)
 [ -n "$branch" ] || branch=unknown
-gh_json=
 tracker=0
-if command -v gh >/dev/null 2>&1; then
-  if gh_json=$(gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>/dev/null); then
-    tracker=1
-  fi
-fi
-issue_objs=
+tracker_tsv=
+if tracker_tsv=$(tracker_lines 2>/dev/null); then tracker=1; fi
 tracking=
 if [ "$tracker" -eq 1 ]; then
-  issue_objs=$(printf '%s\n' "$gh_json" | json_objects)
-  parent_refs=' '
-  while IFS= read -r obj; do
-    p=$(parent_number "$obj")
-    [ -n "$p" ] && parent_refs="$parent_refs$p "
-  done <<< "$issue_objs"
-  highest=0
-  while IFS= read -r obj; do
-    num=$(issue_number "$obj")
-    state=$(issue_state "$obj")
-    [ -n "$num" ] || continue
-    [ "$state" = OPEN ] || continue
-    case "$parent_refs" in *" $num "*)
-      if [ "$num" -gt "$highest" ]; then highest=$num; tracking=$num; fi
-      ;;
-    esac
-  done <<< "$issue_objs"
+  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+    [ "$kind" = TRACK ] && tracking=$num
+  done <<< "$tracker_tsv"
 fi
 slugs=$(artifact_slugs)
 if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
@@ -128,18 +100,13 @@ cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/n
 ps -eo args= 2>/dev/null | grep 'watchdog\.\(ps1\|sh\)' >/dev/null && proc=True || proc=False
 printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
 if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
-  while IFS= read -r obj; do
-    [ "$(parent_number "$obj")" = "$tracking" ] || continue
-    num=$(issue_number "$obj")
-    title=$(issue_title "$obj")
-    state=$(issue_state "$obj")
-    blockers=$(open_blockers "$obj")
-    [ -n "$num" ] || continue
+  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+    [ "$kind" = SUB ] || continue
     slug=$(slugify "$title"); set -- $(phase "$slug" "$state" "$blockers")
     extra=; [ "$2" = QUEUED ] && extra=" blocked-by: $blockers"
     printf '%s #%s %s .architect/wt/%s-01%s\n' "$1" "$num" "$title" "$slug" "$extra"
     [ "$2" = BUILDING ] && last_command "$slug"
-  done <<< "$issue_objs"
+  done <<< "$tracker_tsv"
 else
   for slug in $slugs; do
     set -- $(phase "$slug")

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -30,6 +30,18 @@ tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000'; }
 status_line(){
   tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk '/^STATUS:/{sub(/^STATUS:[[:space:]]*/,""); s=$0} END{print s}'
 }
+json_objects(){
+  awk 'BEGIN{d=0;s=0;e=0;o=""}{for(i=1;i<=length($0);i++){c=substr($0,i,1);if(s){o=o c;if(e)e=0;else if(c=="\\")e=1;else if(c=="\"")s=0;continue}if(c=="\""){if(d>0)o=o c;s=1;continue}if(c=="{"){d++;o=o c;continue}if(d>0)o=o c;if(c=="}"){d--;if(d==0){print o;o=""}}}}'
+}
+issue_number(){ printf '%s' "$1" | grep -o '"number"[[:space:]]*:[[:space:]]*[0-9][0-9]*' | head -n 1 | sed 's/[^0-9]//g'; }
+issue_title(){ printf '%s' "$1" | grep -o '"title"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"title"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'; }
+issue_state(){ printf '%s' "$1" | grep -o '"state"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'; }
+parent_number(){ printf '%s' "$1" | sed -n 's/.*"parent"[[:space:]]*:[[:space:]]*{[^}]*"number"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1; }
+open_blockers(){
+  block=$(printf '%s' "$1" | sed -n 's/.*"blockedBy"[[:space:]]*:[[:space:]]*\[\(.*\)\][[:space:]]*}.*/\1/p')
+  [ -n "$block" ] || return
+  printf '[%s]\n' "$block" | json_objects | while IFS= read -r blocker; do [ "$(issue_state "$blocker")" = OPEN ] && issue_number "$blocker"; done | paste -sd, -
+}
 last_command(){
   ev="$root/.architect/wt/$1-01.events.jsonl"
   cmd=$(tail_text "$ev" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | tail -n 1)
@@ -71,33 +83,63 @@ branch=
 [ -e "$root/.git" ] && branch=$(git -C "$root" branch --show-current 2>/dev/null || true)
 [ -n "$branch" ] || branch=unknown
 gh_json=
-if command -v gh >/dev/null 2>&1; then gh_json=$(gh issue list --json number,title,state,parent,blockedBy,assignees 2>/dev/null || true); fi
 tracker=0
-[ -n "$gh_json" ] && tracker=1
+if command -v gh >/dev/null 2>&1; then
+  if gh_json=$(gh issue list --state all --limit 200 --json number,title,state,parent,blockedBy 2>/dev/null); then
+    tracker=1
+  fi
+fi
+issue_objs=
+tracking=
+if [ "$tracker" -eq 1 ]; then
+  issue_objs=$(printf '%s\n' "$gh_json" | json_objects)
+  parent_refs=' '
+  while IFS= read -r obj; do
+    p=$(parent_number "$obj")
+    [ -n "$p" ] && parent_refs="$parent_refs$p "
+  done <<< "$issue_objs"
+  highest=0
+  while IFS= read -r obj; do
+    num=$(issue_number "$obj")
+    state=$(issue_state "$obj")
+    [ -n "$num" ] || continue
+    [ "$state" = OPEN ] || continue
+    case "$parent_refs" in *" $num "*)
+      if [ "$num" -gt "$highest" ]; then highest=$num; tracking=$num; fi
+      ;;
+    esac
+  done <<< "$issue_objs"
+fi
 slugs=$(artifact_slugs)
-if [ "$tracker" -eq 0 ] && [ -z "$slugs" ]; then
+if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
   printf 'NO ACTIVE FACTORY RUN\nspec: %s\n' "$(newest_spec)"
   exit 0
 fi
 printf 'STATUS TREE spec: %s branch: %s\n' "$(newest_spec)" "$branch"
-[ "$tracker" -eq 1 ] && printf 'tracker: available\n' || printf 'tracker: unavailable (local view)\n'
+if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+  printf 'tracker: #%s\n' "$tracking"
+elif [ "$tracker" -eq 1 ]; then
+  printf 'tracker: no open run\n'
+else
+  printf 'tracker: unavailable (local view)\n'
+fi
 printf 'ORCHESTRATOR: local view\n'
 cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/null | wc -l | tr -d ' ')
 ps -eo args= 2>/dev/null | grep 'watchdog\.\(ps1\|sh\)' >/dev/null && proc=True || proc=False
 printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
-if [ "$tracker" -eq 1 ]; then
-  printf '%s\n' "$gh_json" | sed 's/^\[//;s/\]$//;s/},{/}\
-{/g' | while IFS= read -r obj; do
-    num=$(printf '%s' "$obj" | sed -n 's/.*"number":[[:space:]]*\([0-9][0-9]*\).*/\1/p')
-    title=$(printf '%s' "$obj" | sed -n 's/.*"title":[[:space:]]*"\([^"]*\)".*/\1/p')
-    state=$(printf '%s' "$obj" | sed -n 's/.*"state":[[:space:]]*"\([^"]*\)".*/\1/p')
-    blockers=$(printf '%s' "$obj" | grep -o '"blockedBy":[^]]*' | grep -o '"number":[0-9]*' | sed 's/[^0-9]//g' | paste -sd, -)
+if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
+  while IFS= read -r obj; do
+    [ "$(parent_number "$obj")" = "$tracking" ] || continue
+    num=$(issue_number "$obj")
+    title=$(issue_title "$obj")
+    state=$(issue_state "$obj")
+    blockers=$(open_blockers "$obj")
     [ -n "$num" ] || continue
     slug=$(slugify "$title"); set -- $(phase "$slug" "$state" "$blockers")
     extra=; [ "$2" = QUEUED ] && extra=" blocked-by: $blockers"
     printf '%s #%s %s .architect/wt/%s-01%s\n' "$1" "$num" "$title" "$slug" "$extra"
     [ "$2" = BUILDING ] && last_command "$slug"
-  done
+  done <<< "$issue_objs"
 else
   for slug in $slugs; do
     set -- $(phase "$slug")

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -79,9 +79,11 @@ tracker_tsv=
 if tracker_tsv=$(tracker_lines 2>/dev/null); then tracker=1; fi
 tracking=
 if [ "$tracker" -eq 1 ]; then
-  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+  # Tab is whitespace to bash IFS: runs collapse and empty TSV fields shift
+  # later columns (run #43 live evidence). Translate to unit separators.
+  while IFS="$(printf '\037')" read -r kind num state blockers title; do
     [ "$kind" = TRACK ] && tracking=$num
-  done <<< "$tracker_tsv"
+  done <<< "$(printf '%s\n' "$tracker_tsv" | tr '\t' '\037')"
 fi
 slugs=$(artifact_slugs)
 if { [ "$tracker" -eq 0 ] || [ -z "$tracking" ]; } && [ -z "$slugs" ]; then
@@ -101,13 +103,13 @@ cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/n
 ps -eo args= 2>/dev/null | grep 'watchdog\.\(ps1\|sh\)' >/dev/null && proc=True || proc=False
 printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
 if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
-  while IFS="$(printf '\t')" read -r kind num state blockers title; do
+  while IFS="$(printf '\037')" read -r kind num state blockers title; do
     [ "$kind" = SUB ] || continue
     slug=$(slugify "$title"); set -- $(phase "$slug" "$state" "$blockers")
     extra=; [ "$2" = QUEUED ] && extra=" blocked-by: $blockers"
     printf '%s #%s %s .architect/wt/%s-01%s\n' "$1" "$num" "$title" "$slug" "$extra"
     [ "$2" = BUILDING ] && last_command "$slug"
-  done <<< "$tracker_tsv"
+  done <<< "$(printf '%s\n' "$tracker_tsv" | tr '\t' '\037')"
 else
   for slug in $slugs; do
     set -- $(phase "$slug")

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -412,6 +412,11 @@ def check_status_contract() -> None:
                 errors.append(f"skills/architect/{name}: missing {marker}")
         if name == "status.sh" and not text.startswith("#!"):
             errors.append("skills/architect/status.sh: missing shebang")
+        if name == "status.sh":
+            if "stat -c %Y" not in text or "stat -f %m" not in text:
+                errors.append("skills/architect/status.sh: NewestSpec must use mtime with stat -c/stat -f fallback")
+            if re.search(r'find "\$root/docs/spec".*\|\s*sort', text):
+                errors.append("skills/architect/status.sh: NewestSpec must not select spec by lexical sort")
 
 
 def check_retired_loop_terms() -> None:

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -407,7 +407,14 @@ def check_status_contract() -> None:
             glyph = chr(codepoint)
             if glyph not in text and ps_code not in text:
                 errors.append(f"skills/architect/{name}: missing {label} glyph marker")
-        for marker in ("NO ACTIVE FACTORY RUN", "tracker: unavailable (local view)"):
+        for marker in (
+            "NO ACTIVE FACTORY RUN",
+            "tracker: unavailable (local view)",
+            "tracker: no open run",
+            "STATUS_GH_STUB",
+            "--jq",
+            "blockedBy.nodes",
+        ):
             if marker not in text:
                 errors.append(f"skills/architect/{name}: missing {marker}")
         if name == "status.sh" and not text.startswith("#!"):

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -24,7 +24,15 @@ ROOT = Path(__file__).resolve().parent.parent
 SKILLS = ROOT / "skills"
 MAX_DESC = 1024
 REQUIRED_SIBLINGS = {
-    "architect": ["dispatch.md", "research.md", "loop.md", "watchdog.ps1", "watchdog.sh"],
+    "architect": [
+        "dispatch.md",
+        "research.md",
+        "loop.md",
+        "watchdog.ps1",
+        "watchdog.sh",
+        "status.ps1",
+        "status.sh",
+    ],
     "architect-research": ["tactics.md"],
 }
 ARCHITECT_HANDOFF_FREE_FILES = [
@@ -379,6 +387,33 @@ def check_watchdog_contract() -> None:
         errors.append("skills/architect/watchdog.ps1: missing ConvertFrom-Json")
 
 
+def check_status_contract() -> None:
+    required = (
+        ("MERGED", 0x2713, "[char]0x2713"),
+        ("JUDGING", 0x25D0, "[char]0x25D0"),
+        ("BLOCKED", 0x21, '"!"'),
+        ("REPORTED", 0x25A3, "[char]0x25A3"),
+        ("BUILDING", 0x25CF, "[char]0x25CF"),
+        ("QUEUED", 0x2298, "[char]0x2298"),
+        ("READY", 0x25CB, "[char]0x25CB"),
+    )
+    for name in ("status.ps1", "status.sh"):
+        path = SKILLS / "architect" / name
+        if not path.exists():
+            errors.append(f"skills/architect/{name}: missing status script")
+            continue
+        text = read_text(path)
+        for label, codepoint, ps_code in required:
+            glyph = chr(codepoint)
+            if glyph not in text and ps_code not in text:
+                errors.append(f"skills/architect/{name}: missing {label} glyph marker")
+        for marker in ("NO ACTIVE FACTORY RUN", "tracker: unavailable (local view)"):
+            if marker not in text:
+                errors.append(f"skills/architect/{name}: missing {marker}")
+        if name == "status.sh" and not text.startswith("#!"):
+            errors.append("skills/architect/status.sh: missing shebang")
+
+
 def check_retired_loop_terms() -> None:
     for path in SKILLS.rglob("*.md"):
         text = read_text(path)
@@ -410,6 +445,7 @@ def main() -> int:
     check_agent_definitions()
     check_codex_install_step()
     check_watchdog_contract()
+    check_status_contract()
     check_architect_handoff_free()
     check_retired_loop_terms()
     check_skill_text_size()


### PR DESCRIPTION
Factory run #43: the conversational status tree. Closes #43.

## What it does
Ask the orchestrator "status" / "how's it going" mid-run and it prints a live tree — tracking issue, per-issue phase glyphs (✓ merged, ◐ judging, ! blocked, ▣ reported, ● building with last command, ⊘ queued with blockers, ○ ready), watchdog state — alongside a prose answer. The scripts (`skills/architect/status.ps1|.sh`) are also directly runnable; color on a TTY, plain text when piped, degraded local-artifact view when gh is unavailable.

## Shipped issues
- #44 — status scripts + validator contract (7 judgments; see below)
- #45 — skill wiring, +5 net lines against the 794/800 size guard
- #46 — docs closure (README sample tree, CONTEXT glossary, DESIGN decision entry citing the evidence and the rulings trail)

## The #44 story (the system working as designed)
Three builder defects → oddity rule fired on the third (live-confirmed by the orchestrator) → re-architecture: all issue-graph logic collapsed into ONE pinned `gh --jq` expression, live-verified before freezing, with a STATUS_GH_STUB seam making tracker rendering sandbox-testable → two live-only platform defects remained (PS5.1 native-arg quote stripping masked by a stderr redirect; bash whitespace-IFS collapsing empty TSV fields) → stop rail fired, human ruled a diagnosis-guided orchestrator fix (recorded exception; a fresh judge still passed the result) → judgment 7 PASS. Full trail: docs/jobs/status-scripts-rulings.md.

## Verification
- 9 judgments across the run, every merge behind a fresh-judge PASS
- Composite: validator OK; live renders byte-identical across ps1/sh against this very run; size guard 794/800; piped output ESC-free; degraded mode silent with failing gh
- Stress-test caught 5 pre-dispatch defects (including degraded-mode phases that were tracker-impossible); PHASE 0 and judges caught the rest

## After merge
Re-run `./install.ps1` (or install.sh) to sync the scripts + wiring into live skill trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
