### PR TITLE
Loop tuning: watchdog done-signal, 5-minute autonomy, oddity research, parallel rules (factory run #48)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,8 @@ Glossary only. No implementation details, no spec content.
   capability as the orchestrator, none of its conversation. Not a config key.
 - **Watchdog** - a deterministic script that sweeps in-flight jobs and exits
   with typed evidence (`ALL_DONE`, `INTEGRATED`, `STALL`, `REPEAT`). It never
-  kills, nudges, or decides; the orchestrator rules on the evidence.
+  kills, nudges, or decides; the orchestrator rules on the evidence. A job is
+  done only when its report's final non-blank line starts with `STATUS:`.
 - **Monitor** - informal name for the watchdog. Historically an LLM subagent;
   now only a fallback template for harnesses without background-exit
   notifications.
@@ -50,8 +51,10 @@ Glossary only. No implementation details, no spec content.
 - **Spec approval** - the one human step: review one spec document, edit or
   veto its recorded assumptions, approve in-session or by commenting
   `APPROVE` on the tracking issue. Verbatim pre-approval can authorize a run
-  at invocation; otherwise the factory parks with reminders and fails safe
-  after 7 days.
+  at invocation; otherwise the factory waits about 5 minutes, rules with the
+  orchestrator's best judgment, records the ruling for after-the-fact veto,
+  and continues. Irreversible or destructive silence takes the non-destructive
+  path; `docs/STOP` remains absolute.
 - **Check** - a frozen, committed, exact acceptance check
   (`docs/checks/<issue-slug>.md`). Read-only for everyone once frozen.
 - **Freeze commit** - the commit that locks a run's checks; it is pushed before

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,12 +164,17 @@ loop-hardening research ([docs/research/loop-improvements.md](docs/research/loop
 - **Approval is explicit, durable, and fail-safe.** The two approval forms
   are in-session approval or an `APPROVE` comment on the tracking issue;
   an invocation can also pre-authorize a run only when the exact
-  pre-authorization text is recorded verbatim. Otherwise the factory parks,
-  polls for approval, and stops after 7 days. The evidence is the same
-  shape across deployment systems and agent products: GitHub environments
-  auto-fail unapproved runs after 30 days, Azure timeout-rejects approvals,
-  OWASP fail-safe defaults ban inferred allow, and Copilot treats assignment
-  itself as authorization
+  pre-authorization text is recorded verbatim. The evidence is the same shape
+  across deployment systems and agent products: GitHub environments auto-fail
+  unapproved runs after 30 days, Azure timeout-rejects approvals, OWASP
+  fail-safe defaults ban inferred allow, and Copilot treats assignment itself
+  as authorization. The 2026-07-03 human directive in
+  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md) overrides the earlier
+  park-and-poll product behavior: absent a human answer, wait about 5 minutes,
+  rule with the orchestrator's best judgment, record the ruling for
+  after-the-fact veto, and continue. Carve-out: irreversible or destructive
+  choices resolve to the non-destructive path on silence; `docs/STOP` remains
+  absolute
   ([factory-hardening evidence](docs/research/factory-hardening-evidence.md)).
 - **Preflight has no fallback.** A GitHub remote, passing `gh auth status`,
   and `gh` ≥ 2.94.0 are hard preconditions; failing any of them fails
@@ -191,6 +196,13 @@ loop-hardening research ([docs/research/loop-improvements.md](docs/research/loop
   [Anthropic multi-agent](https://www.anthropic.com/engineering/multi-agent-research-system)).
   The parallel set is always the plan's ready issues, capped at five
   jobs plus one watchdog sweep.
+  Tracking issue #43's 2026-07-03 DIGEST comment, reflected in
+  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md) and
+  [docs/jobs/status-scripts-rulings.md](docs/jobs/status-scripts-rulings.md),
+  tightened run mechanics: judges dispatch concurrently for every DONE, the
+  ready-issue frontier recomputes on every merge, independent bookkeeping
+  batches into parallel calls, and merges, synthesis, and stress-testing stay
+  serial.
 - **Concurrently scheduled issues share nothing mutable.** Not files,
   migrations, lockfiles, generated artifacts, config, schemas, dev servers,
   or databases. Merge conflicts are the top reported multi-agent failure and
@@ -356,6 +368,10 @@ loop-hardening research ([docs/research/loop-improvements.md](docs/research/loop
   positives, and 2 false positives, so the LLM monitor survives only as a
   fallback template
   ([factory-hardening evidence](docs/research/factory-hardening-evidence.md)).
+  Done now means the report's last non-blank line starts with `STATUS:`; report
+  existence alone produced twice-observed false `ALL_DONE` evidence in the
+  run #36 respawn case and the run #43 incremental-write case recorded in
+  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md).
 - **Hard stops (D11).** the `docs/STOP` kill switch before any wave; irreversible actions;
   two consecutive KILLs; a blocker colliding with a recorded assumption
   (a spec-approval decision surfacing late); scope growth beyond the approved

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ to it. No API keys.
 
 That's the whole interface — no daemons, no extra windows. Your one job is
 approving the spec: in-session, or by commenting `APPROVE` on the tracking
-issue from your phone. If you're away, the factory parks with reminders and
-shuts itself down after 7 days rather than guessing. Everything else runs
-without you, and the run ends in a single PR plus a digest of what shipped.
+issue from your phone. If you're away, the factory waits about 5 minutes, then
+uses the orchestrator's best judgment, records the ruling for after-the-fact
+veto, and continues. Irreversible or destructive choices are the carve-out:
+silence resolves to the non-destructive path, and `docs/STOP` stays absolute.
+Everything else runs without you, and the run ends in a single PR plus a
+digest of what shipped.
 
 The build factory needs a GitHub repo: a remote, `gh auth status` passing,
 and `gh` ≥ 2.94.0 (native sub-issue and blocked-by flags). Missing
@@ -89,8 +92,11 @@ survives unless its URL was actually fetched. One author writes the report.
 2. **Spec approval — the only human step.** Approve in-session or comment
    `APPROVE` (or `APPROVE with edits: ...` / `REJECT ...`) on the tracking
    issue. A run can carry verbatim pre-approval from your invocation.
-   Absent a human: park, remind, fail-safe stop at 7 days. The factory never
-   infers a yes from earlier conversation.
+   Absent a human: wait about 5 minutes, rule with the orchestrator's best
+   judgment, record the ruling for after-the-fact veto, and continue. For
+   irreversible or destructive choices, silence resolves to the non-destructive
+   path; `docs/STOP` remains absolute. The factory never infers a yes from
+   earlier conversation.
 3. **The plan.** The spec compiles into sub-issues — vertical slices with
    acceptance criteria, may-touch/must-not-touch file boundaries, and native
    blocked-by links. Issues scheduled in parallel share no files, schemas,
@@ -108,8 +114,9 @@ survives unless its URL was actually fetched. One author writes the report.
      compliance is a defect. Each ruling gets an explicit accept/reject.
    - **A deterministic watchdog** — a ~70-line script, not a model — sweeps
      for stalls (output-byte growth, process CPU, repeated-command tails)
-     and exits with typed evidence. It never kills and never decides; the
-     orchestrator rules on what it reports.
+     and exits with typed evidence. Done means the job report's final
+     non-blank line starts with `STATUS:`. It never kills and never decides;
+     the orchestrator rules on what it reports.
    - **Stuck builders stop instead of thrashing.** A blocker is posted on
      the issue; the orchestrator answers durably there and respawns a fresh
      builder with the answer in its starting context.
@@ -121,7 +128,9 @@ survives unless its URL was actually fetched. One author writes the report.
    - **Failures fix inputs, not models.** First failure: diagnose from the
      judge's evidence, amend the issue, respawn at the same tier. Second:
      re-plan or escalate. A merge conflict means the plan was wrong — kill
-     the job and re-slice, never hand-merge builder work.
+     the job and re-slice, never hand-merge builder work. Oddity re-planning
+     is orchestrator-owned and may fan out researchers before the orchestrator
+     updates the plan, issues, and checks.
 5. **Finish.** A docs job consumes the run's documentation debt and codifies
    reusable diagnoses into `docs/solutions/` (read back at the start of
    every future run). One PR closes the tracking issue; the digest lists

--- a/docs/checks/tuning-docs.md
+++ b/docs/checks/tuning-docs.md
@@ -1,0 +1,37 @@
+# Checks: tuning-docs
+
+Purpose: verify the docs closure for the loop-tuning run.
+Spec (fix contract): `docs/spec/loop-tuning.md` A2.
+Files owned: `README.md`, `DESIGN.md`, `CONTEXT.md`.
+
+Executor: PowerShell primary; native git fine. Orchestrator bookkeeping
+commits exempt.
+
+## TD1 — README
+
+- `git grep -ciE "5 minutes|five minutes" -- README.md` → count ≥ 1
+- `git grep -ci "STATUS" -- README.md` → count ≥ 1 near the watchdog bullet — quote it.
+- The after-the-fact-veto phrasing and destructive carve-out present — quote.
+- No sentence still claims a 7-day park: `git grep -ciE "7 days|7-day" -- README.md` → no output.
+
+## TD2 — DESIGN
+
+- The approval entry retains the default-deny evidence AND records the
+  2026-07-03 human directive as overriding, with the carve-out — quote both
+  parts.
+- The watchdog entry cites the twice-observed done-signal evidence and the
+  STATUS-line fix — quote.
+- One parallel-rules sentence citing run #43's digest — quote.
+- `git grep -c "loop-tuning" -- DESIGN.md` → count ≥ 1 (spec cited).
+
+## TD3 — CONTEXT
+
+- Spec approval and Watchdog glossary entries updated — quote each changed line.
+- Glossary above retired terms stays clean: PowerShell `sed`-equivalent
+  slice piped to word-boundary grep for
+  `gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag` → no output.
+
+## TD4 — link integrity self-check
+
+`git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md` — `Test-Path`
+each target, paste results. Full validator at composite.

--- a/docs/checks/tuning-policy.md
+++ b/docs/checks/tuning-policy.md
@@ -1,0 +1,50 @@
+# Checks: tuning-policy
+
+Purpose: verify the 5-minute autonomy policy, orchestrator-owned oddity
+research, and parallel dispatch rules in the skill text.
+Spec (fix contract): `docs/spec/loop-tuning.md` — Interface contract and
+the verbatim approval record.
+Files owned: `skills/architect/SKILL.md`, `skills/architect/loop.md`.
+
+Executor: PowerShell primary; native git fine. Orchestrator bookkeeping
+commits exempt from touch-set checks.
+
+## TP1 — 5-minute policy present, park machinery gone
+
+(`git grep -c` prints `<path>:<count>`)
+- `git grep -ciE "5 minutes|five minutes|~5 min" -- skills/architect/SKILL.md` → count ≥ 1
+- `git grep -ci "best judgment\|best judgement" -- skills/architect/SKILL.md` → count ≥ 1
+- `git grep -ci "AWAITING APPROVAL" -- skills/architect/SKILL.md` → no output
+- `git grep -ciE "7 days|7-day" -- skills/architect/SKILL.md` → no output
+- The every-question extension sentence and the destructive carve-out are
+  both present — quote each.
+
+## TP2 — oddity re-planning ownership
+
+- `git grep -ci "research.md" -- skills/architect/SKILL.md` → count ≥ 1
+  in/near the oddity text — quote the amended oddity sentence(s) showing:
+  orchestrator owns re-planning, may fan out researchers, updates
+  spec/issue/checks, respawns a fresh builder; builders never re-plan.
+
+## TP3 — parallel rules in loop.md
+
+- `git grep -ci "concurrent" -- skills/architect/loop.md` → count ≥ 1
+- Quote the lines covering: judges never queued; frontier recomputed on
+  EVERY merge; merges/synthesis/stress-test stay serial.
+- Failure ladder mentions the researcher fan-out option — quote it.
+
+## TP4 — size guard (PS-native)
+
+```powershell
+$files='skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'
+$total=($files | ForEach-Object { (Get-Content $_ | Where-Object { $_.Trim() }).Count } | Measure-Object -Sum).Sum
+"TOTAL $total"
+```
+PASS: TOTAL ≤ 800.
+
+## TP5 — no collateral damage
+
+- Pointer integrity: every `dispatch.md section` / `loop.md section` pointer
+  named in SKILL.md resolves — list each with heading grep count 1.
+- `git grep -inwE "gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag" -- skills/architect/SKILL.md skills/architect/loop.md` → no output.
+- Final `git status --short` shows only the two owned files + exempt report — paste.

--- a/docs/checks/tuning-watchdog.md
+++ b/docs/checks/tuning-watchdog.md
@@ -41,6 +41,18 @@ same tiny thresholds. Run watchdog.ps1.
 PASS: exit `3` (`WATCHDOG: STALL` — the job kept sweeping and hit the
 no-growth rule) and NO `ALL_DONE` anywhere in the output.
 
+## TW4b — functional: a GROWING report is growth evidence
+
+Fixture: `twfix/growing/` with a static events file and no process match;
+start a background writer (PowerShell `Start-Job` is fine) that appends a
+prose line to the report every ~1s for ~6s and THEN appends
+`STATUS: COMPLETE`. Run watchdog.ps1 with `sweep_sec:1,
+stall_after_min:0.03` concurrently.
+PASS: exit `0` with `WATCHDOG: ALL_DONE` — never exit 3. (If report growth
+were not counted as liveness, the ~2s stall threshold would fire during the
+~6s growing phase before the STATUS line appears.) Paste verbatim output
+and the writer's timeline.
+
 ## TW5 — regressions: STALL and INTEGRATED unchanged
 
 - Re-run the prior STALL fixture shape (no report at all, static events, no

--- a/docs/checks/tuning-watchdog.md
+++ b/docs/checks/tuning-watchdog.md
@@ -1,0 +1,53 @@
+# Checks: tuning-watchdog
+
+Purpose: verify the done-signal fix — done = terminal `STATUS:` line, not
+report existence.
+Spec (fix contract): `docs/spec/loop-tuning.md` Interface contract.
+Files owned: `skills/architect/watchdog.ps1`, `skills/architect/watchdog.sh`.
+
+Executor: PowerShell primary; native git fine. The sh cannot execute in
+this sandbox (MSYS death): static checks only for sh; the orchestrator runs
+its functional pass at composite. Fixtures under `.architect/tmp/twfix/`.
+Orchestrator bookkeeping commits exempt from touch-set checks.
+
+## TW1 — contract markers unchanged
+
+- `(Select-String -Path skills/architect/watchdog.ps1 -Pattern 'WATCHDOG: (ALL_DONE|INTEGRATED|STALL|REPEAT)').Count` → ≥4
+- `(Select-String -Path skills/architect/watchdog.sh -Pattern 'WATCHDOG: (ALL_DONE|INTEGRATED|STALL|REPEAT)').Count` → ≥4
+- Both scripts reference `STATUS:` (the new done test) → Select-String count ≥1 each.
+
+## TW2 — ps1 parses
+
+In-session PowerShell (never nested `powershell -Command`):
+```powershell
+$e = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'skills/architect/watchdog.ps1').Path, [ref]$null, [ref]$e) | Out-Null
+if ($e.Count -eq 0) { 'TW2_OK' } else { $e }
+```
+PASS: `TW2_OK`.
+
+## TW3 — functional: finished report → ALL_DONE
+
+Fixture: `twfix/done/` with events file (any content) and a report whose
+last non-blank line is `STATUS: COMPLETE`; config `sweep_sec:1,
+stall_after_min:0.05`. Run watchdog.ps1.
+PASS: exit 0; `WATCHDOG: ALL_DONE`; evidence line has path + bytes.
+
+## TW4 — functional: mid-write report is NOT done
+
+Fixture: `twfix/midwrite/` with a static events file, a report containing
+prose but NO line starting `STATUS:`, worktree path matching no process,
+same tiny thresholds. Run watchdog.ps1.
+PASS: exit `3` (`WATCHDOG: STALL` — the job kept sweeping and hit the
+no-growth rule) and NO `ALL_DONE` anywhere in the output.
+
+## TW5 — regressions: STALL and INTEGRATED unchanged
+
+- Re-run the prior STALL fixture shape (no report at all, static events, no
+  process) → exit 3, `WATCHDOG: STALL`.
+- Nonexistent events file AND worktree → exit 2, `WATCHDOG: INTEGRATED`.
+
+## TW6 — line budget and never-act guard
+
+- `(Get-Content skills/architect/watchdog.ps1 | Where-Object { $_.Trim() }).Count` → ≤ 95; same for `.sh` → ≤ 95
+- `Select-String -Path skills/architect/watchdog.ps1,skills/architect/watchdog.sh -Pattern 'Stop-Process|taskkill|Remove-Item|rm -|git (add|commit|push)'` → no matches

--- a/docs/jobs/tuning-docs-01.md
+++ b/docs/jobs/tuning-docs-01.md
@@ -1,0 +1,304 @@
+# tuning-docs-01
+
+## PHASE 0
+
+Plan:
+- Verify `HEAD` and `docs/checks/tuning-docs.md`.
+- Verify freeze commit `6214c29` is an ancestor of `HEAD`.
+- Read `docs/checks/tuning-docs.md`, `docs/spec/loop-tuning.md`, `README.md`, `DESIGN.md`, `CONTEXT.md`, and cited evidence files.
+- Edit only `README.md`, `DESIGN.md`, and `CONTEXT.md`.
+- Run every check in `docs/checks/tuning-docs.md` sequentially.
+- Record verbatim command output.
+
+Disagreements:
+- `C:\Users\danhm\.agents\skills\implement\SKILL.md` says "Commit your work to the current branch." The job instruction says "Do NOT commit and do NOT run git add / git mv"; this report follows the job instruction.
+
+Checked before concluding issue/spec sound:
+- `docs/spec/loop-tuning.md` A2 requires updating `DESIGN.md` approval entry without deleting default-deny evidence.
+- `docs/checks/tuning-docs.md` owns `README.md`, `DESIGN.md`, and `CONTEXT.md`.
+- `README.md` has old 7-day approval language.
+- `DESIGN.md` has the existing default-deny approval entry and watchdog entry to update.
+- `CONTEXT.md` has the Spec approval glossary entry to update.
+
+MIRROR: ORCHESTRATOR
+
+## Input Verification
+
+Command:
+```powershell
+git log -1 --oneline
+```
+Output:
+```text
+c2f1da3 merge job tuning-watchdog-01 (judge PASS, #49)
+```
+
+Command:
+```powershell
+Test-Path -LiteralPath docs/checks/tuning-docs.md; if (Test-Path -LiteralPath docs/checks/tuning-docs.md) { Get-Item -LiteralPath docs/checks/tuning-docs.md | Select-Object -ExpandProperty FullName }
+```
+Output:
+```text
+True
+C:\Users\danhm\architect-loop\.architect\wt\tuning-docs-01\docs\checks\tuning-docs.md
+```
+
+Command:
+```powershell
+git merge-base --is-ancestor 6214c29 HEAD; if ($LASTEXITCODE -eq 0) { '6214c29 is ancestor of HEAD' } else { "6214c29 ancestor check failed: exit $LASTEXITCODE"; exit $LASTEXITCODE }
+```
+Output:
+```text
+6214c29 is ancestor of HEAD
+```
+
+## TD1
+
+Command:
+```powershell
+git grep -ciE "5 minutes|five minutes" -- README.md
+```
+Output:
+```text
+README.md:2
+```
+
+Command:
+```powershell
+git grep -ci "STATUS" -- README.md
+```
+Output:
+```text
+README.md:14
+```
+
+Command:
+```powershell
+git grep -n -C 2 "STATUS" -- README.md
+```
+Output:
+```text
+README.md-116-     for stalls (output-byte growth, process CPU, repeated-command tails)
+README.md-117-     and exits with typed evidence. Done means the job report's final
+README.md:118:     non-blank line starts with `STATUS:`. It never kills and never decides;
+README.md-119-     the orchestrator rules on what it reports.
+README.md-120-   - **Stuck builders stop instead of thrashing.** A blocker is posted on
+```
+
+Command:
+```powershell
+git grep -n -C 2 "after-the-fact" -- README.md
+```
+Output:
+```text
+README.md-40-approving the spec: in-session, or by commenting `APPROVE` on the tracking
+README.md-41-issue from your phone. If you're away, the factory waits about 5 minutes, then
+README.md:42:uses the orchestrator's best judgment, records the ruling for after-the-fact
+README.md-43-veto, and continues. Irreversible or destructive choices are the carve-out:
+README.md-44-silence resolves to the non-destructive path, and `docs/STOP` stays absolute.
+--
+README.md-94-   issue. A run can carry verbatim pre-approval from your invocation.
+README.md-95-   Absent a human: wait about 5 minutes, rule with the orchestrator's best
+README.md:96:   judgment, record the ruling for after-the-fact veto, and continue. For
+README.md-97-   irreversible or destructive choices, silence resolves to the non-destructive
+README.md-98-   path; `docs/STOP` remains absolute. The factory never infers a yes from
+```
+
+Command:
+```powershell
+git grep -ciE "7 days|7-day" -- README.md
+```
+Exit code: 1
+Output:
+```text
+```
+
+## TD2
+
+Command:
+```powershell
+git grep -n -C 4 "OWASP" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md-165-  are in-session approval or an `APPROVE` comment on the tracking issue;
+DESIGN.md-166-  an invocation can also pre-authorize a run only when the exact
+DESIGN.md-167-  pre-authorization text is recorded verbatim. The evidence is the same shape
+DESIGN.md-168-  across deployment systems and agent products: GitHub environments auto-fail
+DESIGN.md:169:  unapproved runs after 30 days, Azure timeout-rejects approvals, OWASP
+DESIGN.md-170-  fail-safe defaults ban inferred allow, and Copilot treats assignment itself
+DESIGN.md-171-  as authorization. The 2026-07-03 human directive in
+DESIGN.md-172-  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md) overrides the earlier
+DESIGN.md-173-  park-and-poll product behavior: absent a human answer, wait about 5 minutes,
+```
+
+Command:
+```powershell
+git grep -n -C 4 "2026-07-03 human directive" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md-167-  pre-authorization text is recorded verbatim. The evidence is the same shape
+DESIGN.md-168-  across deployment systems and agent products: GitHub environments auto-fail
+DESIGN.md-169-  unapproved runs after 30 days, Azure timeout-rejects approvals, OWASP
+DESIGN.md-170-  fail-safe defaults ban inferred allow, and Copilot treats assignment itself
+DESIGN.md:171:  as authorization. The 2026-07-03 human directive in
+DESIGN.md-172-  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md) overrides the earlier
+DESIGN.md-173-  park-and-poll product behavior: absent a human answer, wait about 5 minutes,
+DESIGN.md-174-  rule with the orchestrator's best judgment, record the ruling for
+DESIGN.md-175-  after-the-fact veto, and continue. Carve-out: irreversible or destructive
+```
+
+Command:
+```powershell
+git grep -n -C 3 "twice-observed false" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md-369-  fallback template
+DESIGN.md-370-  ([factory-hardening evidence](docs/research/factory-hardening-evidence.md)).
+DESIGN.md-371-  Done now means the report's last non-blank line starts with `STATUS:`; report
+DESIGN.md:372:  existence alone produced twice-observed false `ALL_DONE` evidence in the
+DESIGN.md-373-  run #36 respawn case and the run #43 incremental-write case recorded in
+DESIGN.md-374-  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md).
+DESIGN.md-375-- **Hard stops (D11).** the `docs/STOP` kill switch before any wave; irreversible actions;
+```
+
+Command:
+```powershell
+git grep -n -A 7 "Tracking issue #43" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:199:  Tracking issue #43's 2026-07-03 DIGEST comment, reflected in
+DESIGN.md-200-  [docs/spec/loop-tuning.md](docs/spec/loop-tuning.md) and
+DESIGN.md-201-  [docs/jobs/status-scripts-rulings.md](docs/jobs/status-scripts-rulings.md),
+DESIGN.md-202-  tightened run mechanics: judges dispatch concurrently for every DONE, the
+DESIGN.md-203-  ready-issue frontier recomputes on every merge, independent bookkeeping
+DESIGN.md-204-  batches into parallel calls, and merges, synthesis, and stress-testing stay
+DESIGN.md-205-  serial.
+DESIGN.md-206-- **Concurrently scheduled issues share nothing mutable.** Not files,
+```
+
+Command:
+```powershell
+git grep -c "loop-tuning" -- DESIGN.md
+```
+Output:
+```text
+DESIGN.md:3
+```
+
+## TD3
+
+Command:
+```powershell
+git grep -n -A 7 "Spec approval" -- CONTEXT.md
+```
+Output:
+```text
+CONTEXT.md:51:- **Spec approval** - the one human step: review one spec document, edit or
+CONTEXT.md-52-  veto its recorded assumptions, approve in-session or by commenting
+CONTEXT.md-53-  `APPROVE` on the tracking issue. Verbatim pre-approval can authorize a run
+CONTEXT.md-54-  at invocation; otherwise the factory waits about 5 minutes, rules with the
+CONTEXT.md-55-  orchestrator's best judgment, records the ruling for after-the-fact veto,
+CONTEXT.md-56-  and continues. Irreversible or destructive silence takes the non-destructive
+CONTEXT.md-57-  path; `docs/STOP` remains absolute.
+CONTEXT.md-58-- **Check** - a frozen, committed, exact acceptance check
+```
+
+Command:
+```powershell
+git grep -n -A 3 "Watchdog" -- CONTEXT.md
+```
+Output:
+```text
+CONTEXT.md:19:- **Watchdog** - a deterministic script that sweeps in-flight jobs and exits
+CONTEXT.md-20-  with typed evidence (`ALL_DONE`, `INTEGRATED`, `STALL`, `REPEAT`). It never
+CONTEXT.md-21-  kills, nudges, or decides; the orchestrator rules on the evidence. A job is
+CONTEXT.md-22-  done only when its report's final non-blank line starts with `STATUS:`.
+```
+
+Command:
+```powershell
+$lines = Get-Content -LiteralPath CONTEXT.md; $end = ($lines | Select-String -Pattern '^## Retired terms').LineNumber; $lines[0..($end - 2)] | Select-String -Pattern '\b(gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag)\b'
+```
+Output:
+```text
+```
+
+## TD4
+
+Command:
+```powershell
+git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md
+```
+Output:
+```text
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/adr/0001-in-session-loop-replaces-external-driver.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/spec/architect-v5.1.md)
+DESIGN.md:](docs/research/loop-improvements.md)
+DESIGN.md:](docs/research/autonomous-software-factory.md)
+DESIGN.md:](docs/spec/loop-tuning.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/spec/loop-tuning.md)
+DESIGN.md:](docs/jobs/status-scripts-rulings.md)
+DESIGN.md:](docs/solutions/worktree-stale-snapshot.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/spec/loop-tuning.md)
+DESIGN.md:](docs/research/status-display-evidence.md)
+DESIGN.md:](docs/jobs/status-scripts-rulings.md)
+DESIGN.md:](docs/research/lesson-store-evidence.md)
+DESIGN.md:](docs/research/loop-improvements.md)
+DESIGN.md:](docs/research/agent-pipeline-patterns.md)
+DESIGN.md:](docs/adr/0001-in-session-loop-replaces-external-driver.md)
+DESIGN.md:](docs/spec/architect-v5.md)
+DESIGN.md:](docs/solutions/subagent-shell-strip-codex-fallback.md)
+DESIGN.md:](docs/research/factory-hardening-evidence.md)
+DESIGN.md:](docs/solutions/git-bash-msys-codex-sandbox.md)
+DESIGN.md:](docs/solutions/uv-cache-sandbox-redirect.md)
+```
+
+Command:
+```powershell
+$matches = git grep -oE "\]\((docs/[^)#]+)\)" -- DESIGN.md README.md; $targets = $matches | ForEach-Object { if ($_ -match '\]\((docs/[^)#]+)\)') { $Matches[1] } } | Sort-Object -Unique; $targets | ForEach-Object { "$_ => $(Test-Path -LiteralPath $_)" }
+```
+Output:
+```text
+docs/adr/0001-in-session-loop-replaces-external-driver.md => True
+docs/jobs/status-scripts-rulings.md => True
+docs/research/agent-pipeline-patterns.md => True
+docs/research/autonomous-software-factory.md => True
+docs/research/factory-hardening-evidence.md => True
+docs/research/lesson-store-evidence.md => True
+docs/research/loop-improvements.md => True
+docs/research/status-display-evidence.md => True
+docs/solutions/git-bash-msys-codex-sandbox.md => True
+docs/solutions/subagent-shell-strip-codex-fallback.md => True
+docs/solutions/uv-cache-sandbox-redirect.md => True
+docs/solutions/worktree-stale-snapshot.md => True
+docs/spec/architect-v5.1.md => True
+docs/spec/architect-v5.md => True
+docs/spec/loop-tuning.md => True
+```
+
+## Final State
+
+Command:
+```powershell
+git status --short
+```
+Output:
+```text
+ M CONTEXT.md
+ M DESIGN.md
+ M README.md
+?? docs/jobs/tuning-docs-01.md
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/tuning-policy-01.md
+++ b/docs/jobs/tuning-policy-01.md
@@ -1,0 +1,255 @@
+# tuning-policy-01
+
+## PHASE 0
+
+Plan:
+- Verify freeze input.
+- Read `docs/checks/tuning-policy.md`, `docs/spec/loop-tuning.md`, `skills/architect/SKILL.md`, `skills/architect/loop.md`, `skills/architect/dispatch.md`.
+- Edit only `skills/architect/SKILL.md` and `skills/architect/loop.md`.
+- Run every check in `docs/checks/tuning-policy.md` sequentially.
+- Write `docs/jobs/tuning-policy-01.md`.
+
+Disagreements:
+- None.
+
+Checked before concluding sound:
+- `docs/spec/loop-tuning.md` Approval record and Interface contract.
+- `docs/checks/tuning-policy.md`.
+- `skills/architect/SKILL.md`.
+- `skills/architect/loop.md`.
+- `skills/architect/dispatch.md`.
+
+MIRROR: ORCHESTRATOR
+
+## Input Verification
+
+Command:
+```powershell
+git log -1 --oneline
+```
+Output:
+```text
+6214c29 re-freeze: TW4b growing-report liveness check; concrete digest citation (stress-test amendments)
+```
+
+Command:
+```powershell
+Test-Path -LiteralPath docs/checks/tuning-policy.md
+```
+Output:
+```text
+True
+```
+
+## TP1
+
+Command:
+```powershell
+git grep -ciE "5 minutes|five minutes|~5 min" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:1
+```
+
+Command:
+```powershell
+git grep -ci "best judgment\|best judgement" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:1
+```
+
+Command:
+```powershell
+git grep -ci "AWAITING APPROVAL" -- skills/architect/SKILL.md
+```
+Exit code: 1
+Output:
+```text
+```
+
+Command:
+```powershell
+git grep -ciE "7 days|7-day" -- skills/architect/SKILL.md
+```
+Exit code: 1
+Output:
+```text
+```
+
+Command:
+```powershell
+$i=0; Get-Content -LiteralPath skills/architect/SKILL.md | ForEach-Object { $i++; if($i -ge 128 -and $i -le 133){ '{0}: {1}' -f $i,$_ } }
+```
+Output:
+```text
+128: If the human is absent, ask in-session and wait about 5 minutes: use the
+129: harness ~60s prompt, schedule one ~4-minute recheck, then rule with the
+130: orchestrator's best judgment, record the ruling and reasoning on the tracking
+131: issue for after-the-fact veto, and continue. This applies to every human question
+132: in the loop, including spec approval, oddity escalations, and rail rulings. For irreversible or destructive choices, silence resolves to the
+133: non-destructive path; `docs/STOP` remains absolute.
+```
+
+## TP2
+
+Command:
+```powershell
+git grep -ci "research.md" -- skills/architect/SKILL.md
+```
+Output:
+```text
+skills/architect/SKILL.md:2
+```
+
+Command:
+```powershell
+$i=0; Get-Content -LiteralPath skills/architect/SKILL.md | ForEach-Object { $i++; if($i -ge 165 -and $i -le 174){ '{0}: {1}' -f $i,$_ } }
+```
+Output:
+```text
+165: - Oddity rule: when reality resists the plan, classify before dispatch. A
+166:   local wart gets a local patch and issue note. A recurring variation gets a
+167:   structural issue that blocks the behavioral issue. One adapter is a
+168:   hypothetical seam; two is real. Three failed fixes on the same point means
+169:   stop and question the architecture. Re-planning is orchestrator-owned: on
+170:   an oddity or failure diagnosis the orchestrator may fan out researcher agents
+171:   using `research.md` inline mechanics to inform the new plan, then updates the
+172:   spec, issue, and checks in git and the tracker, then respawns a fresh
+173:   builder; builders never re-plan.
+174: - Structural and behavioral changes are separate issues with a blocking edge.
+```
+
+## TP3
+
+Command:
+```powershell
+git grep -ci "concurrent" -- skills/architect/loop.md
+```
+Output:
+```text
+skills/architect/loop.md:1
+```
+
+Command:
+```powershell
+$i=0; Get-Content -LiteralPath skills/architect/loop.md | ForEach-Object { $i++; if($i -ge 3 -and $i -le 8){ '{0}: {1}' -f $i,$_ } }
+```
+Output:
+```text
+3: The loop is one orchestrator session that runs the factory to completion after
+4: the spec approval approves the issue plan. GitHub issues carry coordination
+5: state; git carries specs and frozen checks. The orchestrator dispatches the
+6: ready issues, sleeps, and wakes only on an event.
+7: Parallel rules: judges dispatch immediately and run concurrently for every DONE, never queued behind another judgment; the ready-issue frontier recomputes on EVERY merge, not at wave boundaries; independent orchestrator bookkeeping batches into parallel calls; merges, synthesis, and the stress-test stay serial by design.
+8: 
+```
+
+Command:
+```powershell
+$i=0; Get-Content -LiteralPath skills/architect/loop.md | ForEach-Object { $i++; if($i -ge 76 -and $i -le 84){ '{0}: {1}' -f $i,$_ } }
+```
+Output:
+```text
+76: ## Failure ladder
+77: 
+78: First FAIL on an issue: the orchestrator diagnoses from the judge's evidence (not
+79: the full diff), may fan out researcher agents to inform the diagnosis, fixes
+80: the input â€” issue text, missing context, or a forbidden-pattern note â€” and
+81: respawns a fresh builder job at the same tier.
+82: The tier is set once, at decomposition (config plus dispatch rules), and
+83: never changes because a job failed; a failure is a spec or context problem
+84: the orchestrator fixes, never a signal to move the tier. Second FAIL on the same
+```
+
+## TP4
+
+Command:
+```powershell
+$files='skills/architect/SKILL.md','skills/architect/loop.md','skills/architect/dispatch.md'
+$total=($files | ForEach-Object { (Get-Content $_ | Where-Object { $_.Trim() }).Count } | Measure-Object -Sum).Sum
+"TOTAL $total"
+```
+Output:
+```text
+TOTAL 800
+```
+
+## TP5
+
+Command:
+```powershell
+git grep -c "^## Model alias table" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -c "^## Issue conventions" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -c "^## Monitor dispatch" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -c "^## Respawn-with-answer template" -- skills/architect/dispatch.md
+```
+Output:
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -c "^## Factory block procedure" -- skills/architect/loop.md
+```
+Output:
+```text
+skills/architect/loop.md:1
+```
+
+Command:
+```powershell
+git grep -inwE "gate|gates|lane|lanes|brain|brawn|cold|epic|grill|dag" -- skills/architect/SKILL.md skills/architect/loop.md
+```
+Exit code: 1
+Output:
+```text
+```
+
+Command:
+```powershell
+git diff -- docs/checks
+```
+Output:
+```text
+```
+
+Command:
+```powershell
+git status --short
+```
+Output:
+```text
+ M skills/architect/SKILL.md
+ M skills/architect/loop.md
+?? docs/jobs/tuning-policy-01.md
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/tuning-watchdog-01.md
+++ b/docs/jobs/tuning-watchdog-01.md
@@ -1,0 +1,126 @@
+# tuning-watchdog-01
+
+MIRROR: ORCHESTRATOR
+
+## Phase 0 Plan
+
+| # | Step |
+|---|---|
+| 1 | Verify HEAD and frozen check file. |
+| 2 | Read `docs/spec/loop-tuning.md`, `docs/checks/tuning-watchdog.md`, `skills/architect/watchdog.ps1`, `skills/architect/watchdog.sh`. |
+| 3 | Change done detection to terminal status-line detection in both watchdogs. |
+| 4 | Count report-file byte growth as liveness in both watchdogs. |
+| 5 | Run TW1, TW2, TW3, TW4, TW4b, TW5, TW6 sequentially. |
+| 6 | Write `docs/jobs/tuning-watchdog-01.md`. |
+
+## Phase 0 Disagreements
+
+| Item | Result | Files checked |
+|---|---|---|
+| Issue/spec disagreements | none | `docs/spec/loop-tuning.md`; `docs/checks/tuning-watchdog.md`; `skills/architect/watchdog.ps1`; `skills/architect/watchdog.sh` |
+
+## Input Verification
+
+```text
+6214c29 re-freeze: TW4b growing-report liveness check; concrete digest citation (stress-test amendments)
+CHECK_FILE_EXISTS: yes
+```
+
+## Pre-Edit Status
+
+```text
+```
+
+## TW1
+
+```text
+ps1 markers: 4
+sh markers: 4
+ps1 STATUS: 1
+sh STATUS: 1
+```
+
+## TW2
+
+```text
+TW2_OK
+```
+
+## TW3
+
+```text
+WATCHDOG: ALL_DONE
+done1 C:\Users\danhm\architect-loop\.architect\wt\tuning-watchdog-01\.architect\tmp\twfix\done-run2\report.md 70 bytes
+PROCESS_EXIT_CODE=0
+```
+
+## TW4
+
+```text
+WATCHDOG: STALL mid1 minutes_since_growth=0.053 cpu_delta=0
+?{"command":"build"}
+
+PROCESS_EXIT_CODE=3
+```
+
+## TW4b
+
+```text
+WATCHDOG: ALL_DONE
+grow1 C:\Users\danhm\architect-loop\.architect\wt\tuning-watchdog-01\.architect\tmp\twfix\growing-run\report.md 120 bytes
+PROCESS_EXIT_CODE=0
+WRITER_TIMELINE:
+2026-07-03T16:06:21.6654151-04:00 appended prose line 1
+2026-07-03T16:06:22.6783322-04:00 appended prose line 2
+2026-07-03T16:06:23.6874175-04:00 appended prose line 3
+2026-07-03T16:06:24.6959029-04:00 appended prose line 4
+2026-07-03T16:06:25.7059265-04:00 appended prose line 5
+2026-07-03T16:06:26.7155150-04:00 appended prose line 6
+2026-07-03T16:06:26.7285371-04:00 appended STATUS: COMPLETE
+```
+
+## TW5 STALL
+
+```text
+WATCHDOG: STALL stall1 minutes_since_growth=0.053 cpu_delta=0
+?{"command":"build"}
+
+PROCESS_EXIT_CODE=3
+```
+
+## TW5 INTEGRATED
+
+```text
+WATCHDOG: INTEGRATED int1
+PROCESS_EXIT_CODE=2
+```
+
+## TW6
+
+```text
+ps1 nonblank: 86
+sh nonblank: 72
+```
+
+## Changed Files
+
+```text
+skills/architect/watchdog.ps1
+skills/architect/watchdog.sh
+warning: in the working copy of 'skills/architect/watchdog.ps1', LF will be replaced by CRLF the next time Git touches it
+```
+
+## docs/checks Diff
+
+```text
+```
+
+## Final Worktree Status
+
+```text
+ M skills/architect/watchdog.ps1
+ M skills/architect/watchdog.sh
+?? docs/jobs/tuning-watchdog-01.md
+```
+
+STATUS: COMPLETE

--- a/docs/spec/loop-tuning.md
+++ b/docs/spec/loop-tuning.md
@@ -1,0 +1,106 @@
+# Spec: loop-tuning — watchdog done-signal, 5-minute autonomy, oddity research, parallel rules
+
+Four small policy/mechanism changes from the status-tree retro and human
+directives.
+
+## Approval record
+
+Pre-approved at invocation, 2026-07-03 (verbatim): "yes, do the watchdog
+done signal fix. does the oddities rule let the orchestrator agent figure
+out a new plan? ... It should be orchestrator who then updates the plan and
+issues and checks then respawns a builder to implement the orchestrator's
+new plan (track everything in git issues smoothly). Second, when you pause
+to ask the human a question, wait 5m then if no answer, use the
+orchestrator's best judgement and continue. If the orchestrator determines
+it may need some web research done to help figure it out, then the
+orchestrator can spin up 1 or more builder agents to do the research and
+then figure out the best plan from there after an oddities trigger, update
+the issue and checks, and then launch a builder with the new plan. The 5m
+wait until it lets the orchestrator just answer the question goes for spec,
+or oddities, or anywhere it asks the user a question. Second, analyze the
+work you did in this pipeline. Do you see further simple parallelization
+optimizations you can implement?"
+
+Orchestrator carve-out, flagged in-session and unvetoed: for irreversible or
+destructive actions, 5-minute silence resolves to the NON-destructive path;
+`docs/STOP` remains absolute.
+
+## Goal
+
+1. **Watchdog done-signal:** a job is done when its report file ENDS with a
+   `STATUS:` line, not when the file exists (twice-observed false ALL_DONE:
+   run #36 respawn case, run #43 incremental write).
+2. **5-minute autonomy:** every human question anywhere in the loop — spec
+   approval, oddity escalations, rail rulings — waits ~5 minutes, then the
+   orchestrator rules with recorded reasoning and continues; the ruling is
+   posted on the tracking issue for after-the-fact veto. Replaces the
+   park-and-poll + 7-day fail-safe machinery. Carve-out: irreversible/
+   destructive choices resolve to the non-destructive option on silence;
+   `docs/STOP` absolute.
+3. **Oddity → research → re-plan, orchestrator-owned:** codify that oddity
+   and failure re-planning belongs to the orchestrator, which MAY fan out
+   one or more researcher agents (web research) to inform the new plan,
+   then updates the spec/issue/checks in git and the tracker, then respawns
+   a fresh builder to implement it. Builders never re-plan.
+4. **Parallel dispatch rules:** judges dispatch immediately and run
+   concurrently for every DONE; the ready-issue frontier recomputes on
+   EVERY merge, not at wave boundaries; independent orchestrator
+   bookkeeping batches into parallel calls. Merges, synthesis, and the
+   stress-test stay serial by design.
+
+## Non-goals
+
+No changes to builder flow, check freezing, judging, tiering, status tree,
+or config. No new files beyond docs.
+
+## Interface contract
+
+- Watchdog: done test = last non-blank line of the report file starts with
+  `STATUS:` (encoding-aware read). `INTEGRATED`/`STALL`/`REPEAT` semantics
+  unchanged. Both scripts identical in behavior; markers unchanged
+  (validator contract untouched).
+- SKILL.md carries the 5-minute policy as the Spec Approval text (replacing
+  the park/7-day block) plus one sentence extending it to all human
+  questions, with the destructive carve-out; and the oddity bullet gains
+  the research-then-re-plan sentence pointing at `research.md`.
+- loop.md carries the parallel rules (three short lines) and the failure
+  ladder gains the researcher-fan-out option.
+- Combined SKILL.md+loop.md+dispatch.md non-blank total stays ≤ 800
+  (measured 794; the replaced park block frees ~5).
+
+## Scope: three issues
+
+| Issue | Files |
+|---|---|
+| A `tuning-watchdog` | `skills/architect/watchdog.ps1`, `skills/architect/watchdog.sh` |
+| B `tuning-policy` | `skills/architect/SKILL.md`, `skills/architect/loop.md` |
+| C `tuning-docs` (blocked by A, B) | `README.md`, `DESIGN.md`, `CONTEXT.md` |
+
+## Assumptions (pre-approved unless vetoed)
+
+- **A1.** The 5-minute wait is implemented as: in-session ask (~60s harness
+  prompt) then one scheduled ~4-minute recheck, then the recorded ruling —
+  total ≈5 minutes.
+- **A2.** DESIGN's approval-decision entry is updated (not deleted): the
+  GH-30-day/OWASP default-deny evidence stands, with the human's 2026-07-03
+  directive recorded as the overriding product decision and the carve-out
+  noted.
+- **A3.** Oddity-research uses the existing inline fan-out mechanics
+  (`research.md`); no new researcher machinery.
+- **A4.** Tier: builders `codex/tier-down` (gpt-5.5 high); judges
+  `codex/best` (xhigh). Checks under `docs/checks/`, reports under
+  `docs/jobs/`, branch `factory/loop-tuning`.
+
+## Validation strategy
+
+A: functional fixture tests — report absent → not done; report mid-write
+(no STATUS line) → not done (no ALL_DONE within a short window); report
+ending `STATUS: COMPLETE` → ALL_DONE with evidence; STALL/INTEGRATED paths
+regression. B: contract greps + size guard with the PS-native count. C:
+mention checks + link integrity. Composite: validator green; live watchdog
+smoke on a synthetic config; size guard ≤800.
+
+## Preflight evidence
+
+Same-session: gh 2.96.0 auth OK; codex 0.139.0 canary SHELLS_OK; size
+guard 794/800 at branch cut.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -125,12 +125,12 @@ Approval has exactly two explicit forms:
 Prior conversation is never approval unless it is an explicit authorization
 quoted in the approval record; the fail-safe default is no approval.
 
-If the human is absent, PARK: post `AWAITING APPROVAL` on the tracking issue
-with the spec pointer and assumptions digest, schedule periodic wakeups about
-every 20-30 minutes to poll for the approval comment, and take no build action
-while parked. Stop polling immediately on `REJECT <reason>` or `docs/STOP`.
-After 7 days without approval, post a fail-safe closing digest on the tracking
-issue and stop.
+If the human is absent, ask in-session and wait about 5 minutes: use the
+harness ~60s prompt, schedule one ~4-minute recheck, then rule with the
+orchestrator's best judgment, record the ruling and reasoning on the tracking
+issue for after-the-fact veto, and continue. This applies to every human question
+in the loop, including spec approval, oddity escalations, and rail rulings. For irreversible or destructive choices, silence resolves to the
+non-destructive path; `docs/STOP` remains absolute.
 
 On approval, cut `factory/<run>`. ALL run commits after approval, including
 spec amendments, checks, freeze, and job merges, land on that branch. Main stays
@@ -166,7 +166,11 @@ Embed D9 in the issue graph:
   local wart gets a local patch and issue note. A recurring variation gets a
   structural issue that blocks the behavioral issue. One adapter is a
   hypothetical seam; two is real. Three failed fixes on the same point means
-  stop and question the architecture.
+  stop and question the architecture. Re-planning is orchestrator-owned: on
+  an oddity or failure diagnosis the orchestrator may fan out researcher agents
+  using `research.md` inline mechanics to inform the new plan, then updates the
+  spec, issue, and checks in git and the tracker, then respawns a fresh
+  builder; builders never re-plan.
 - Structural and behavioral changes are separate issues with a blocking edge.
   Structural checks prove existing behavior remains green.
 - Run design-it-twice only for new load-bearing abstractions. Use two or three

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -4,6 +4,7 @@ The loop is one orchestrator session that runs the factory to completion after
 the spec approval approves the issue plan. GitHub issues carry coordination
 state; git carries specs and frozen checks. The orchestrator dispatches the
 ready issues, sleeps, and wakes only on an event.
+Parallel rules: judges dispatch immediately and run concurrently for every DONE, never queued behind another judgment; the ready-issue frontier recomputes on EVERY merge, not at wave boundaries; independent orchestrator bookkeeping batches into parallel calls; merges, synthesis, and the stress-test stay serial by design.
 
 ## Factory block procedure
 
@@ -75,8 +76,9 @@ verdict from memory.
 ## Failure ladder
 
 First FAIL on an issue: the orchestrator diagnoses from the judge's evidence (not
-the full diff), fixes the input — issue text, missing context, or a
-forbidden-pattern note — and respawns a fresh builder job at the same tier.
+the full diff), may fan out researcher agents to inform the diagnosis, fixes
+the input — issue text, missing context, or a forbidden-pattern note — and
+respawns a fresh builder job at the same tier.
 The tier is set once, at decomposition (config plus dispatch rules), and
 never changes because a job failed; a failure is a spec or context problem
 the orchestrator fixes, never a signal to move the tier. Second FAIL on the same

--- a/skills/architect/watchdog.ps1
+++ b/skills/architect/watchdog.ps1
@@ -5,8 +5,31 @@ function TailText($Path) {
     $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
     try { $len = [Math]::Min([int64]4096, $fs.Length); [void]$fs.Seek(-$len, [System.IO.SeekOrigin]::End); $buf = New-Object byte[] $len; [void]$fs.Read($buf, 0, $len) }
     finally { $fs.Close() }
+    return DecodeBytes $buf
+}
+
+function DecodeBytes($Buf) {
+    if ($Buf.Length -ge 2 -and $Buf[0] -eq 255 -and $Buf[1] -eq 254) { return [System.Text.Encoding]::Unicode.GetString($Buf) }
+    if ($Buf.Length -ge 2 -and $Buf[0] -eq 254 -and $Buf[1] -eq 255) { return [System.Text.Encoding]::BigEndianUnicode.GetString($Buf) }
     $utf8 = New-Object System.Text.UTF8Encoding($false, $true)
     try { return $utf8.GetString($buf) } catch { return [System.Text.Encoding]::Unicode.GetString($buf) }
+}
+
+function ReadText($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try { $buf = New-Object byte[] $fs.Length; [void]$fs.Read($buf, 0, $buf.Length) }
+    finally { $fs.Close() }
+    return DecodeBytes $buf
+}
+
+function HasTerminalStatus($Path) {
+    $lines = (ReadText $Path) -split "`r?`n"
+    for ($i = $lines.Count - 1; $i -ge 0; $i--) {
+        $t = $lines[$i].Trim()
+        if ($t.Length -gt 0) { return $t.StartsWith("STATUS:", [StringComparison]::Ordinal) }
+    }
+    return $false
 }
 
 function FileSize($Path) { if (Test-Path -LiteralPath $Path) { return (Get-Item -LiteralPath $Path).Length }; return 0 }
@@ -26,7 +49,7 @@ $sweep = [int]$cfg.sweep_sec
 $stall = [double]$cfg.stall_after_min
 $state = @{}
 foreach ($j in $cfg.jobs) {
-    $state[$j.id] = @{ Done = $false; Size = (FileSize $j.events_file); Growth = (Get-Date); Cpu = (CpuTotal $j.worktree) }
+    $state[$j.id] = @{ Done = $false; Size = ((FileSize $j.events_file) + (FileSize $j.report_path)); Growth = (Get-Date); Cpu = (CpuTotal $j.worktree) }
 }
 
 while ($true) {
@@ -34,12 +57,12 @@ while ($true) {
         $id = [string]$j.id
         $s = $state[$id]
         if ($s.Done) { continue }
-        if (Test-Path -LiteralPath $j.report_path) { $s.Done = $true; continue }
+        if (HasTerminalStatus $j.report_path) { $s.Done = $true; continue }
         if ((-not (Test-Path -LiteralPath $j.events_file)) -and (-not (Test-Path -LiteralPath $j.worktree))) {
             Write-Output "WATCHDOG: INTEGRATED $id"
             exit 2
         }
-        $size = FileSize $j.events_file
+        $size = (FileSize $j.events_file) + (FileSize $j.report_path)
         $cpu = CpuTotal $j.worktree
         if ($size -gt $s.Size) { $s.Size = $size; $s.Growth = Get-Date }
         $mins = ((Get-Date) - $s.Growth).TotalMinutes

--- a/skills/architect/watchdog.sh
+++ b/skills/architect/watchdog.sh
@@ -14,7 +14,8 @@ field(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]
 numfield(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p"; }
 fsize(){ stat -c %s "$1" 2>/dev/null || stat -f %z "$1" 2>/dev/null || printf 0; }
 now(){ date +%s; }
-tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000'; }
+tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000\377\376'; }
+report_done(){ [ -f "$1" ] || return 1; last=$(tail_text "$1" | awk 'NF{line=$0} END{gsub(/^[[:space:]]+|[[:space:]]+$/,"",line); print line}'); case "$last" in STATUS:*) return 0;; *) return 1;; esac; }
 cpu_sum(){
   w=$1
   if [ -d /proc ]; then
@@ -36,7 +37,7 @@ while IFS= read -r job; do
   ids[$i]=$(field "$job" id); events[$i]=$(field "$job" events_file)
   reports[$i]=$(field "$job" report_path); trees[$i]=$(field "$job" worktree)
   hints[$i]=$(numfield "$job" duration_hint_min); done[$i]=0
-  sizes[$i]=$(fsize "${events[$i]}"); growth[$i]=$(now); cpus[$i]=$(cpu_sum "${trees[$i]}")
+  ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sizes[$i]=$((ev+rp)); growth[$i]=$(now); cpus[$i]=$(cpu_sum "${trees[$i]}")
   i=$((i+1))
 done <<EOF
 $jobs
@@ -46,12 +47,12 @@ while :; do
   all=1
   for i in "${!ids[@]}"; do
     [ "${done[$i]}" = 1 ] && continue
-    [ -f "${reports[$i]}" ] && { done[$i]=1; continue; }
+    report_done "${reports[$i]}" && { done[$i]=1; continue; }
     all=0
     if [ ! -e "${events[$i]}" ] && [ ! -e "${trees[$i]}" ]; then
       printf 'WATCHDOG: INTEGRATED %s\n' "${ids[$i]}"; exit 2
     fi
-    sz=$(fsize "${events[$i]}"); cpu=$(cpu_sum "${trees[$i]}")
+    ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sz=$((ev+rp)); cpu=$(cpu_sum "${trees[$i]}")
     [ "$sz" -gt "${sizes[$i]}" ] && { sizes[$i]=$sz; growth[$i]=$(now); }
     mins=$(awk -v a="$(now)" -v b="${growth[$i]}" 'BEGIN{printf "%.3f",(a-b)/60}')
     delta=$((cpu-cpus[$i])); cpus[$i]=$cpu


### PR DESCRIPTION
Factory run #48: loop tuning. Closes #48.

## Shipped issues
- #49 — watchdog done-signal: done = report's terminal `STATUS:` line (not file existence); report-file growth now counts as liveness. Proven by the new TW4b concurrent-writer check, judge-rerun, and composite smokes in BOTH scripts (finished → ALL_DONE; mid-write → STALL, never done). Closes the twice-observed false-ALL_DONE class.
- #50 — skill policy: (1) 5-minute autonomy — every human question (spec approval, oddity escalations, rail rulings) waits ~5 minutes, then the orchestrator rules with recorded, after-the-fact-vetoable reasoning; destructive/irreversible choices resolve to the NON-destructive path on silence; docs/STOP stays absolute. Replaces park-and-poll + 7-day fail-safe. (2) Oddity/failure re-planning codified as orchestrator-owned, with optional researcher fan-out (research.md mechanics) before updating spec/issue/checks and respawning a fresh builder — builders never re-plan. (3) Parallel rules: judges dispatch immediately and run concurrently; the ready frontier recomputes on every merge; bookkeeping batches; merges/synthesis/stress-test stay serial.
- #51 — docs closure (README, DESIGN with the default-deny evidence retained + the human directive recorded as overriding, CONTEXT).

## Verification
- 3 fresh-judge PASSes (judges ran concurrently — the rule this run codifies, practiced live); stress-test caught 2 real defects pre-dispatch (TW4's growing-report blind spot; an unresolvable citation)
- Composite: validator OK; live watchdog smokes green in both scripts; size guard exactly 800/800 — the budget is now fully spent; future skill-text changes must trim before adding

## After merge
Re-run `./install.ps1` (or install.sh) to sync live skill trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
