### PR TITLE
check-runner: deterministic check execution; judge grades evidence (factory run #62)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -309,6 +309,30 @@ loop-hardening research ([docs/research/loop-improvements.md](docs/research/loop
 
 ### Judging and integration
 
+#### Check-runner offload (2026-07-04)
+
+The measured motivation was 135 mechanical `command → expected` items across
+15 frozen check files, about 9 per file, with `tracker-adapter.md` 17-of-18
+mechanical. Those commands were consuming frontier-priced judge turns on work
+that required no judgment, while the useful judge work remained evidence
+grading, checks-integrity review, and diff-vs-intent.
+
+The check-runner is a deterministic script, not an LLM, because a script
+cannot fabricate an exit code; an LLM runner is an unaudited junior judge. The
+check-runner executes frozen RUN commands outside subagent sandboxes and
+records raw evidence, while the fresh judge grades that evidence, performs
+diff-vs-intent, and re-runs at least one RUN command as the spot-check honesty
+guard. D12 consequence: shell-dependent checks no longer force cross-family
+codex judges just to get a shell; cross-family review returns to a high-stakes
+review choice rather than a workaround for stripped tools.
+
+The RUN grammar came from the design-it-twice record in
+[spec D1](docs/spec/judge-runner.md#d1-run-grammar-for-check-files-design-it-twice-record):
+heuristic backtick-span parsing was rejected for structural false positives in
+prose, fenced run blocks were rejected for authoring churn and for separating
+the command from its inline expected outcome, and explicit `- RUN:` markers
+were chosen.
+
 - **Nobody grades their own work.** The builder reports evidence; a fresh
   orchestrator-tier judge runs the frozen checks itself (builder claims are
   hearsay) and returns per-check **PASS / FAIL / INVALID** — INVALID meaning

--- a/README.md
+++ b/README.md
@@ -138,11 +138,12 @@ survives unless its URL was actually fetched. One author writes the report.
    - **Stuck builders stop instead of thrashing.** A blocker is posted on
      the issue; the orchestrator answers durably there and respawns a fresh
      builder with the answer in its starting context.
-   - **A fresh judge owns every merge.** It reruns the frozen checks itself
-     (builder claims are hearsay) and reads the diff against the spec's
-     intent — passing checks with wrong code still fails. Verdicts land as
-     issue comments: PASS / FAIL / INVALID. The orchestrator cannot overrule
-     a FAIL.
+   - **A fresh judge owns every merge.** A deterministic check-runner script
+     executes the frozen checks exactly as written and records the evidence;
+     the judge grades that evidence, spot-checks at least one command, and
+     reads the diff against the spec's intent — passing checks with wrong code
+     still fails. Verdicts land as issue comments: PASS / FAIL / INVALID. The
+     orchestrator cannot overrule a FAIL.
    - **Failures fix inputs, not models.** First failure: diagnose from the
      judge's evidence, amend the issue, respawn at the same tier. Second:
      re-plan or escalate. A merge conflict means the plan was wrong — kill

--- a/docs/checks/jr-docs.md
+++ b/docs/checks/jr-docs.md
@@ -1,0 +1,33 @@
+# Checks: jr-docs
+
+Purpose: verify product docs and solutions debt for the check-runner ship.
+Spec (fix contract): `docs/spec/judge-runner.md`.
+Files owned: `README.md`, `DESIGN.md`, `docs/solutions/**`.
+
+Executor: PowerShell primary; native `git.exe` fine. `uv` uses fresh cache
+`.architect/tmp/uv-cache-jr`. Orchestrator bookkeeping commits exempt from
+touch-set checks.
+
+## D1 — README names the runner where it describes judging
+
+- RUN: `git grep -c "check-runner" -- README.md` → ≥ 1
+
+## D2 — DESIGN.md records the evidence
+
+- RUN: `git grep -c "check-runner" -- DESIGN.md` → ≥ 2
+- RUN: `git grep -c "135" -- DESIGN.md` → ≥ 1 (the measured mechanical-item count that motivated the split)
+
+## D3 — solutions debt consumed
+
+- RUN: `Test-Path docs/solutions/judge-checkrun-offload.md` → True
+- RUN: `git grep -c "2026-07-04" -- docs/solutions/judge-checkrun-offload.md` → ≥ 1 (timestamped per convention)
+
+## D4 — validator still green
+
+- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py` → output contains `OK`
+
+## D5 — judge-only
+
+- Quote, file:line, the DESIGN.md paragraph recording why the runner is a
+  script and not an LLM (the no-fabricated-exit-codes rationale) and the D12
+  consequence (shell checks no longer force cross-family judges).

--- a/docs/checks/jr-docs.md
+++ b/docs/checks/jr-docs.md
@@ -15,7 +15,7 @@ touch-set checks.
 ## D2 — DESIGN.md records the evidence
 
 - RUN: `git grep -c "check-runner" -- DESIGN.md` → ≥ 2
-- RUN: `git grep -c "135" -- DESIGN.md` → ≥ 1 (the measured mechanical-item count that motivated the split)
+- RUN: `git grep -c "135 mechanical" -- DESIGN.md` → ≥ 1 (the exact phrase; the measured count that motivated the split)
 
 ## D3 — solutions debt consumed
 
@@ -31,3 +31,5 @@ touch-set checks.
 - Quote, file:line, the DESIGN.md paragraph recording why the runner is a
   script and not an LLM (the no-fabricated-exit-codes rationale) and the D12
   consequence (shell checks no longer force cross-family judges).
+- Verify README's check-runner mention sits inside the judging-flow
+  description, not an unrelated section; quote the surrounding sentence.

--- a/docs/checks/jr-runner.md
+++ b/docs/checks/jr-runner.md
@@ -25,6 +25,9 @@ from touch-set checks.
 - RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^exit: 3').Count` → 1
 - RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'truncated').Count` → ≥ 1
 - RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'check_file_matches_freeze=true').Count` → 1
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^# Checkrun: ').Count` → 1 (D3 header shape)
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^\$ ').Count` → 3 (one command block per RUN item)
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'docs_checks_touched=').Count` → 1
 - RUN: `Test-Path tests/fixtures/checkrun/TRAP.txt` → False (the fixture's
   markerless backtick span must never execute)
 
@@ -41,7 +44,15 @@ from touch-set checks.
 - RUN: `powershell -NoProfile -File skills/architect/check-runner.ps1 -Config tests/fixtures/checkrun/config-missing.json; $LASTEXITCODE` → stdout contains `CHECKRUN: ERROR`, last line `5`
 - RUN: `Test-Path .architect/tmp/checkrun-missing.md` → False
 
-## CR5 — judge-only
+## CR5 — non-grading and PS 5.1 discipline
+
+- RUN: `git grep -cE "PASS|FAIL|INVALID" -- skills/architect/check-runner.ps1` → no stdout, exits 1 (the runner grades nothing)
+- RUN: `git grep -cE "PASS|FAIL|INVALID" -- skills/architect/check-runner.sh` → no stdout, exits 1
+- RUN: `git grep -c "&&" -- skills/architect/check-runner.ps1` → no stdout, exits 1 (PS 5.1: no pipeline chains)
+
+## CR6 — judge-only
 
 - Quote, file:line, the runner's evidence-write logic showing temp-write-then-move
   (no partial evidence file on failure), in both scripts.
+- Quote, file:line, where the ps1 avoids ternary/null-coalescing operators
+  (PS 5.1) and where reads are encoding-aware.

--- a/docs/checks/jr-runner.md
+++ b/docs/checks/jr-runner.md
@@ -1,0 +1,47 @@
+# Checks: jr-runner
+
+Purpose: verify the deterministic check-runner scripts against pinned fixtures.
+Spec (fix contract): `docs/spec/judge-runner.md` — Interface contract + D2/D3.
+Files owned: `skills/architect/check-runner.ps1`, `skills/architect/check-runner.sh`,
+`tests/fixtures/checkrun/**`.
+
+Executor: PowerShell primary; native `git.exe` fine. Judge for THIS slice is
+non-codex-sandbox (Git Bash needed for CR3; codex sandbox kills it, Win32 err 5).
+Run every command from the worktree root, sequentially, in the order written.
+Orchestrator bookkeeping commits (reports under `docs/jobs/`, rulings) exempt
+from touch-set checks.
+
+## CR1 — scripts exist, lean
+
+- RUN: `Test-Path skills/architect/check-runner.ps1` → True
+- RUN: `Test-Path skills/architect/check-runner.sh` → True
+- RUN: `(Get-Content skills/architect/check-runner.ps1 | Where-Object { $_.Trim() }).Count` → ≤ 220
+- RUN: `(Get-Content skills/architect/check-runner.sh | Where-Object { $_.Trim() }).Count` → ≤ 220
+
+## CR2 — PowerShell fixture: evidence, exits, trap, truncation, integrity
+
+- RUN: `powershell -NoProfile -File skills/architect/check-runner.ps1 -Config tests/fixtures/checkrun/config-ps.json; $LASTEXITCODE` → last line `0`
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^exit: ').Count` → 3
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^exit: 3').Count` → 1
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'truncated').Count` → ≥ 1
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'check_file_matches_freeze=true').Count` → 1
+- RUN: `Test-Path tests/fixtures/checkrun/TRAP.txt` → False (the fixture's
+  markerless backtick span must never execute)
+
+## CR3 — bash fixture: same contract via check-runner.sh
+
+- RUN: `bash skills/architect/check-runner.sh tests/fixtures/checkrun/config-bash.json; $LASTEXITCODE` → last line `0`
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-bash.md -Pattern '^exit: ').Count` → 3
+- RUN: `(Select-String -Path .architect/tmp/checkrun-fixture-bash.md -Pattern '^exit: 3').Count` → 1
+- RUN: `Test-Path tests/fixtures/checkrun/TRAP.txt` → False (bash trap span
+  also never executed)
+
+## CR4 — error path: typed exit 5, no partial evidence
+
+- RUN: `powershell -NoProfile -File skills/architect/check-runner.ps1 -Config tests/fixtures/checkrun/config-missing.json; $LASTEXITCODE` → stdout contains `CHECKRUN: ERROR`, last line `5`
+- RUN: `Test-Path .architect/tmp/checkrun-missing.md` → False
+
+## CR5 — judge-only
+
+- Quote, file:line, the runner's evidence-write logic showing temp-write-then-move
+  (no partial evidence file on failure), in both scripts.

--- a/docs/checks/jr-validator.md
+++ b/docs/checks/jr-validator.md
@@ -1,0 +1,34 @@
+# Checks: jr-validator
+
+Purpose: verify `tests/validate_skills.py` enforces the new check-runner
+contracts and stays green end-to-end.
+Spec (fix contract): `docs/spec/judge-runner.md` — D2/D5; consumes JR1+JR2 artifacts.
+Files owned: `tests/validate_skills.py`.
+
+Executor: PowerShell primary; native `git.exe` fine. `uv` uses fresh cache
+`.architect/tmp/uv-cache-jr`. Orchestrator bookkeeping commits exempt from
+touch-set checks.
+
+## V1 — validator green end-to-end
+
+- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py` → output contains `OK`
+
+## V2 — contracts reference the new artifacts
+
+- RUN: `(Select-String -Path tests/validate_skills.py -Pattern 'check-runner.ps1').Count` → ≥ 1
+- RUN: `(Select-String -Path tests/validate_skills.py -Pattern 'check-runner.sh').Count` → ≥ 1
+- RUN: `(Select-String -Path tests/validate_skills.py -Pattern 'Check-runner dispatch').Count` → ≥ 1
+- RUN: `(Select-String -Path tests/validate_skills.py -Pattern 're-run at least one RUN command').Count` → ≥ 1
+
+## V3 — syntax
+
+- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('V3_OK')"` → `V3_OK`
+
+## V4 — falsifiability of the new contract (negative test)
+
+- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python -c "import sys,subprocess,shutil,os; shutil.copy('skills/architect/check-runner.ps1','.architect/tmp/cr-backup.ps1'); os.remove('skills/architect/check-runner.ps1'); r=subprocess.run([sys.executable,'tests/validate_skills.py'],capture_output=True); shutil.copy('.architect/tmp/cr-backup.ps1','skills/architect/check-runner.ps1'); print('V4_OK' if r.returncode!=0 else 'V4_VACUOUS')"` → `V4_OK` (validator actually fails when a runner script is missing; file restored after)
+
+## V5 — judge-only
+
+- Quote, file:line, the validator function(s) implementing the check-runner
+  sibling requirement and the dispatch-section anchor assertion.

--- a/docs/checks/jr-validator.md
+++ b/docs/checks/jr-validator.md
@@ -24,9 +24,15 @@ touch-set checks.
 
 - RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('V3_OK')"` → `V3_OK`
 
-## V4 — falsifiability of the new contract (negative test)
+## V4 — falsifiability of the new contract (negative test, judge-executed)
 
-- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python -c "import sys,subprocess,shutil,os; shutil.copy('skills/architect/check-runner.ps1','.architect/tmp/cr-backup.ps1'); os.remove('skills/architect/check-runner.ps1'); r=subprocess.run([sys.executable,'tests/validate_skills.py'],capture_output=True); shutil.copy('.architect/tmp/cr-backup.ps1','skills/architect/check-runner.ps1'); print('V4_OK' if r.returncode!=0 else 'V4_VACUOUS')"` → `V4_OK` (validator actually fails when a runner script is missing; file restored after)
+Judge-executed sequence with mandatory restore — run these four steps in
+order and paste the full transcript; the mutation is temporary by contract:
+
+1. `Move-Item skills/architect/check-runner.ps1 .architect/tmp/cr-bak.ps1`
+2. `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py; $LASTEXITCODE` → nonzero exit AND an error naming the missing runner script (green here = V4 VACUOUS = FAIL)
+3. `Move-Item .architect/tmp/cr-bak.ps1 skills/architect/check-runner.ps1` (MANDATORY, run even if step 2 errored unexpectedly)
+4. `git status --porcelain skills/architect/` → empty (tree restored; a non-empty result is an automatic INVALID until restored)
 
 ## V5 — judge-only
 

--- a/docs/checks/jr-wiring.md
+++ b/docs/checks/jr-wiring.md
@@ -1,0 +1,48 @@
+# Checks: jr-wiring
+
+Purpose: verify the skill-text wiring — RUN grammar, check-runner dispatch
+section, judge templates consuming evidence, loop and SKILL.md updates.
+Spec (fix contract): `docs/spec/judge-runner.md` — D1, D4, D5.
+Files owned: `skills/architect/SKILL.md`, `skills/architect/loop.md`,
+`skills/architect/dispatch.md`.
+
+Executor: PowerShell primary; native `git.exe` fine. Orchestrator bookkeeping
+commits (reports under `docs/jobs/`, rulings) exempt from touch-set checks.
+
+## W1 — dispatch.md: section, grammar, contract
+
+- RUN: `git grep -c "## Check-runner dispatch" -- skills/architect/dispatch.md` → 1
+- RUN: `git grep -c -- "- RUN:" skills/architect/dispatch.md` → ≥ 2 (grammar stated with the literal marker)
+- RUN: `git grep -c "max_output_lines" -- skills/architect/dispatch.md` → ≥ 1
+- RUN: `git grep -c "CHECKRUN: ERROR" -- skills/architect/dispatch.md` → ≥ 1
+
+## W2 — judge templates grade evidence and spot-check
+
+- RUN: `git grep -c "checkrun" -- skills/architect/dispatch.md` → ≥ 3
+- RUN: `git grep -c "re-run at least one RUN command" -- skills/architect/dispatch.md` → 2 (once inside each judge template's marker block)
+- RUN: `git grep -c "architect-judge-template:start" -- skills/architect/dispatch.md` → 1 (markers intact)
+- RUN: `git grep -c "architect-codex-judge-template:start" -- skills/architect/dispatch.md` → 1 (markers intact)
+
+## W3 — grill clause in the stress-test template
+
+- RUN: `git grep -c "MUST use" -- skills/architect/dispatch.md` → ≥ 1 (mechanical checks MUST use RUN form)
+
+## W4 — loop.md and SKILL.md wiring
+
+- RUN: `git grep -c "check-runner" -- skills/architect/loop.md` → ≥ 1
+- RUN: `git grep -c "checkrun" -- skills/architect/loop.md` → ≥ 1
+- RUN: `git grep -c "check-runner" -- skills/architect/SKILL.md` → ≥ 1
+
+## W5 — size guards (non-blank lines)
+
+- RUN: `(Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() }).Count` → ≤ 800
+- RUN: `(Get-Content skills/architect/loop.md | Where-Object { $_.Trim() }).Count` → ≤ 800
+- RUN: `(Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() }).Count` → ≤ 800
+
+## W6 — judge-only
+
+- Quote, file:line: (a) the Hard Rule 3 clause naming the check-runner and the
+  judge's grade-plus-spot-check duty; (b) loop.md's On-DONE ordering: runner
+  config written → check-runner launched → evidence committed → judge
+  dispatched with the evidence path; (c) the stress-test template's grill
+  clause. Each must match the spec's D4/D5 intent, not merely contain keywords.

--- a/docs/checks/jr-wiring.md
+++ b/docs/checks/jr-wiring.md
@@ -20,6 +20,9 @@ commits (reports under `docs/jobs/`, rulings) exempt from touch-set checks.
 
 - RUN: `git grep -c "checkrun" -- skills/architect/dispatch.md` → ≥ 3
 - RUN: `git grep -c "re-run at least one RUN command" -- skills/architect/dispatch.md` → 2 (once inside each judge template's marker block)
+- RUN: `git grep -c "Source: evidence-file" -- skills/architect/dispatch.md` → 2 (per-check verdict lines in both templates)
+- RUN: `git grep -c "never FAIL" -- skills/architect/dispatch.md` → 2 (missing/stale evidence → INVALID, in both templates)
+- RUN: `git grep -c "evidence_out" -- skills/architect/dispatch.md` → ≥ 1 (config contract verbatim)
 - RUN: `git grep -c "architect-judge-template:start" -- skills/architect/dispatch.md` → 1 (markers intact)
 - RUN: `git grep -c "architect-codex-judge-template:start" -- skills/architect/dispatch.md` → 1 (markers intact)
 
@@ -45,4 +48,7 @@ commits (reports under `docs/jobs/`, rulings) exempt from touch-set checks.
   judge's grade-plus-spot-check duty; (b) loop.md's On-DONE ordering: runner
   config written → check-runner launched → evidence committed → judge
   dispatched with the evidence path; (c) the stress-test template's grill
-  clause. Each must match the spec's D4/D5 intent, not merely contain keywords.
+  clause; (d) SKILL.md step 4's updated On-DONE sentence; (e) the
+  `## Check-runner dispatch` section sits between the judge templates and the
+  stress-test template. Each must match the spec's D4/D5 intent, not merely
+  contain keywords.

--- a/docs/jobs/jr-docs-01.md
+++ b/docs/jobs/jr-docs-01.md
@@ -1,0 +1,145 @@
+# jr-docs-01 report
+
+## PHASE 0
+
+First action evidence:
+
+```text
+Test-Path docs/checks/jr-docs.md
+True
+
+Test-Path skills/architect/check-runner.ps1
+True
+
+Test-Path skills/architect/dispatch.md
+True
+
+Select-String -Path skills/architect/dispatch.md -Pattern '^## Check-runner dispatch$'
+skills/architect/dispatch.md:132:## Check-runner dispatch
+```
+
+Plan:
+
+- Edit `README.md` only at the existing judging-flow bullet.
+- Add one evidence-backed `DESIGN.md` subsection under `### Judging and integration`.
+- Add `docs/solutions/judge-checkrun-offload.md`.
+- Do not edit `skills/**`, `tests/**`, `docs/checks/**`, or `docs/spec/**`.
+- Run `docs/checks/jr-docs.md` commands with PowerShell, native `git.exe`, and `UV_CACHE_DIR=.architect/tmp/uv-cache-jr`.
+- Report raw evidence only. Do not commit.
+
+Disagreements:
+
+- None with issue #66 or the frozen contract.
+
+File evidence checked:
+
+```text
+docs/checks/jr-docs.md:3:Purpose: verify product docs and solutions debt for the check-runner ship.
+docs/checks/jr-docs.md:5:Files owned: `README.md`, `DESIGN.md`, `docs/solutions/**`.
+docs/checks/jr-docs.md:13:- RUN: `git grep -c "check-runner" -- README.md` → ≥ 1
+docs/checks/jr-docs.md:17:- RUN: `git grep -c "check-runner" -- DESIGN.md` → ≥ 2
+docs/checks/jr-docs.md:18:- RUN: `git grep -c "135 mechanical" -- DESIGN.md` → ≥ 1
+docs/checks/jr-docs.md:22:- RUN: `Test-Path docs/solutions/judge-checkrun-offload.md` → True
+docs/checks/jr-docs.md:23:- RUN: `git grep -c "2026-07-04" -- docs/solutions/judge-checkrun-offload.md` → ≥ 1
+docs/checks/jr-docs.md:27:- RUN: `$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py` → output contains `OK`
+```
+
+```text
+docs/spec/judge-runner.md:9:Evidence base: 135 `command → expected` items across the 15 frozen check
+docs/spec/judge-runner.md:20:Judging conflates two different kinds of work: (a) executing frozen check
+docs/spec/judge-runner.md:30:Split them. A deterministic script (`check-runner`) executes every runnable
+docs/spec/judge-runner.md:42:- No LLM check-runner. A builder-tier agent costs tokens and can misreport;
+docs/spec/judge-runner.md:43:  a script cannot fabricate an exit code. (Design-it-twice, sketch B.)
+docs/spec/judge-runner.md:55:### D1. RUN grammar for check files (design-it-twice record)
+docs/spec/judge-runner.md:120:### D4. Judge consumes evidence; spot-check guard
+```
+
+```text
+docs/jobs/jr-wiring-rulings.md:5:Fresh codex judge: checks integrity PASS, W1-W6 all PASS, diff-vs-intent
+docs/jobs/jr-wiring-rulings.md:6:FAIL. Defect: `skills/architect/dispatch.md` codex-judge intro enumerates
+docs/jobs/jr-wiring-rulings.md:9:`<docs/jobs/<issue-slug>-checkrun.md>`; a dispatcher following the intro
+docs/jobs/jr-wiring-rulings.md:10:verbatim sends it unresolved - spec D5 evidence-path wiring violated.
+docs/jobs/jr-runner-01.md:136:UNEXECUTED: bash skills/architect/check-runner.sh tests/fixtures/checkrun/config-bash.json
+docs/jobs/jr-runner-01.md:137:Reason: issue #63 executor truth says Git Bash dies under this Codex Windows sandbox with Win32 err 5; the .sh script is to be executed by the judge elsewhere.
+docs/checks/jr-runner.md:8:Executor: PowerShell primary; native `git.exe` fine. Judge for THIS slice is
+docs/checks/jr-runner.md:9:non-codex-sandbox (Git Bash needed for CR3; codex sandbox kills it, Win32 err 5).
+```
+
+## Edited Files
+
+```text
+README.md
+DESIGN.md
+docs/solutions/judge-checkrun-offload.md
+docs/jobs/jr-docs-01.md
+```
+
+## Check Evidence
+
+```text
+git.exe grep -c "check-runner" -- README.md; $LASTEXITCODE
+README.md:1
+0
+```
+
+```text
+git.exe grep -c "check-runner" -- DESIGN.md; $LASTEXITCODE
+DESIGN.md:2
+0
+```
+
+```text
+git.exe grep -c "135 mechanical" -- DESIGN.md; $LASTEXITCODE
+DESIGN.md:1
+0
+```
+
+```text
+Test-Path docs/solutions/judge-checkrun-offload.md
+True
+```
+
+```text
+git.exe grep -c "2026-07-04" -- docs/solutions/judge-checkrun-offload.md; "LASTEXITCODE=$LASTEXITCODE"
+LASTEXITCODE=1
+```
+
+```text
+git.exe add -N docs/solutions/judge-checkrun-offload.md
+fatal: Unable to create 'C:/Users/danhm/tools/architect-loop/.git/worktrees/jr-docs-01/index.lock': Permission denied
+```
+
+```text
+Select-String -Path 'docs/solutions/judge-checkrun-offload.md' -Pattern '2026-07-04'
+docs\solutions\judge-checkrun-offload.md:2:Recorded: 2026-07-04
+```
+
+```text
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py; $LASTEXITCODE
+OK - 2 skills validated, v4 contracts clean
+0
+```
+
+## Judge-Only Evidence
+
+```text
+DESIGN.md:320:The check-runner is a deterministic script, not an LLM, because a script
+DESIGN.md:321:cannot fabricate an exit code; an LLM runner is an unaudited junior judge. The
+DESIGN.md:322:check-runner executes frozen RUN commands outside subagent sandboxes and
+DESIGN.md:323:records raw evidence, while the fresh judge grades that evidence, performs
+DESIGN.md:324:diff-vs-intent, and re-runs at least one RUN command as the spot-check honesty
+DESIGN.md:325:guard. D12 consequence: shell-dependent checks no longer force cross-family
+DESIGN.md:326:codex judges just to get a shell; cross-family review returns to a high-stakes
+DESIGN.md:327:review choice rather than a workaround for stripped tools.
+```
+
+```text
+README.md:141:   - **A fresh judge owns every merge.** A deterministic check-runner script
+README.md:142:     executes the frozen checks exactly as written and records the evidence;
+README.md:143:     the judge grades that evidence, spot-checks at least one command, and
+README.md:144:     reads the diff against the spec's intent — passing checks with wrong code
+README.md:145:     still fails. Verdicts land as issue comments: PASS / FAIL / INVALID. The
+README.md:146:     orchestrator cannot overrule a FAIL.
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/jr-runner-01.md
+++ b/docs/jobs/jr-runner-01.md
@@ -1,0 +1,206 @@
+# jr-runner-01 report
+
+## PHASE 0
+
+First action evidence:
+
+```text
+git rev-parse HEAD
+1473c78cf443f2c0876bfc058b934e1bec7a7a48
+Test-Path docs/checks/jr-runner.md
+true
+```
+
+Plan:
+- Implement only `skills/architect/check-runner.ps1`, `skills/architect/check-runner.sh`, and the five files under `tests/fixtures/checkrun/`.
+- Keep `docs/checks/**` read-only.
+- Implement D1 parsing: only lines whose first non-whitespace is `- RUN:` execute; use the first single-backtick span as the complete command; preserve current `## ` section and file line number.
+- Implement D2 integrity facts and execution: config path argument, path resolution from process CWD, `git` facts, sequential commands in `workdir`, authoritative config `executor`, capped output, nonzero command exits as evidence, and exit 5 only for unreadable config, missing check file, or git unavailable.
+- Implement D3 evidence temp-write-then-move format with `# Checkrun: ` first line, `docs_checks_touched=` in the changed-files header, one `$ ` block per RUN item, and no grading strings in either script.
+- Create the exact five fixture files specified by issue #63.
+- Verify PowerShell runner and frozen PowerShell checks locally; record Bash runner as UNEXECUTED in this sandbox because Git Bash/MSYS is documented to die under the Codex Windows sandbox with Win32 error 5.
+
+Disagreement check:
+- `docs/spec/judge-runner.md` D1-D3 and Interface contract checked.
+- `docs/checks/jr-runner.md` checked.
+- `docs/solutions/git-bash-msys-codex-sandbox.md` checked for the Git Bash sandbox limitation.
+- `docs/solutions/subagent-shell-strip-codex-fallback.md` checked for shell-tool limitation reporting.
+- No disagreements found between issue #63, `docs/spec/judge-runner.md`, and `docs/checks/jr-runner.md`.
+
+## Files
+
+```text
+git status --short
+?? docs/jobs/jr-runner-01.md
+?? skills/architect/check-runner.ps1
+?? skills/architect/check-runner.sh
+?? tests/fixtures/
+```
+
+```text
+Get-ChildItem tests/fixtures/checkrun | Select-Object Name,Length
+config-bash.json          195
+config-missing.json       191
+config-ps.json            197
+fixture-checks-bash.md    305
+fixture-checks-ps.md      389
+```
+
+```text
+git status --short docs/checks
+<no output>
+
+git diff -- docs/checks
+<no output>
+```
+
+## CR1
+
+```text
+Test-Path skills/architect/check-runner.ps1
+True
+Test-Path skills/architect/check-runner.sh
+True
+(Get-Content skills/architect/check-runner.ps1 | Where-Object { $_.Trim() }).Count
+154
+(Get-Content skills/architect/check-runner.sh | Where-Object { $_.Trim() }).Count
+106
+```
+
+## CR2
+
+```text
+powershell -NoProfile -File skills/architect/check-runner.ps1 -Config tests/fixtures/checkrun/config-ps.json; $LASTEXITCODE
+0
+```
+
+```text
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^exit: ').Count
+3
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^exit: 3').Count
+1
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'truncated').Count
+1
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'check_file_matches_freeze=true').Count
+0
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^# Checkrun: ').Count
+1
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern '^\$ ').Count
+3
+(Select-String -Path .architect/tmp/checkrun-fixture-ps.md -Pattern 'docs_checks_touched=').Count
+1
+Test-Path tests/fixtures/checkrun/TRAP.txt
+False
+```
+
+```text
+Local integrity note:
+check_file_matches_freeze=true count is 0 in this uncommitted builder worktree.
+Fixture configs use "freeze_sha":"HEAD"; docs/spec/judge-runner.md validation strategy states fixture integrity is true after the orchestrator commits the job to its branch, and builders never commit.
+Generated evidence line:
+integrity: check_file_matches_freeze=false head=1473c78cf443f2c0876bfc058b934e1bec7a7a48
+```
+
+```text
+Evidence excerpt:
+# Checkrun: checkrun-fixture-ps
+generated: 2026-07-04T19:22:02.2145902Z  runner: ps1  config: tests/fixtures/checkrun/config-ps.json
+check_file: tests/fixtures/checkrun/fixture-checks-ps.md  freeze_sha: HEAD
+Executor: powershell
+executor_config: powershell
+integrity: check_file_matches_freeze=false head=1473c78cf443f2c0876bfc058b934e1bec7a7a48
+changed_files: 0 listed below; docs_checks_touched=false
+
+## Fixture line 7
+$ git --version
+exit: 0  ms: 196  bytes: 29
+git version 2.51.2.windows.1
+
+## Fixture line 8
+$ 1..100 | ForEach-Object { $_ }
+exit: 0  ms: 200  bytes: 392 truncated
+1
+2
+3
+...
+60
+
+## Fixture line 9
+$ powershell -NoProfile -Command "exit 3"
+exit: 3  ms: 354  bytes: 0
+```
+
+## CR3
+
+```text
+UNEXECUTED: bash skills/architect/check-runner.sh tests/fixtures/checkrun/config-bash.json
+Reason: issue #63 executor truth says Git Bash dies under this Codex Windows sandbox with Win32 err 5; the .sh script is to be executed by the judge elsewhere.
+```
+
+## CR4
+
+```text
+powershell -NoProfile -File skills/architect/check-runner.ps1 -Config tests/fixtures/checkrun/config-missing.json; $LASTEXITCODE; Test-Path .architect/tmp/checkrun-missing.md
+CHECKRUN: ERROR missing check file
+5
+False
+```
+
+## CR5
+
+```text
+Direct filesystem scan of untracked scripts:
+Select-String PASS|FAIL|INVALID over skills/architect/check-runner.ps1, skills/architect/check-runner.sh
+NO_MATCH
+
+Select-String -SimpleMatch '&&' over skills/architect/check-runner.ps1
+NO_ANDAND
+
+Select-String '\?\?|\?\s*[^\r\n:]+\s*:' over skills/architect/check-runner.ps1
+<no output>
+```
+
+```text
+Frozen git-grep commands before orchestrator commit:
+git grep -cE "PASS|FAIL|INVALID" -- skills/architect/check-runner.ps1; $LASTEXITCODE
+1
+git grep -cE "PASS|FAIL|INVALID" -- skills/architect/check-runner.sh; $LASTEXITCODE
+1
+git grep -c "&&" -- skills/architect/check-runner.ps1; $LASTEXITCODE
+1
+```
+
+## CR6
+
+```text
+PowerShell evidence-write temp path then move:
+166: $tmpEvidence = $evidenceOut + ".tmp." + ([System.Guid]::NewGuid().ToString("N"))
+167: Set-Content -LiteralPath $tmpEvidence -Value $e -Encoding utf8
+168: Move-Item -LiteralPath $tmpEvidence -Destination $evidenceOut -Force
+
+PowerShell removes evidence output on typed error:
+21:     if ($evidenceOut) { Remove-Item -LiteralPath $evidenceOut -Force -ErrorAction SilentlyContinue }
+22:     if ($tmpEvidence) { Remove-Item -LiteralPath $tmpEvidence -Force -ErrorAction SilentlyContinue }
+
+PowerShell encoding-aware read and UTF-8 write:
+7: function DecodeBytes($Bytes) {
+17:     return DecodeBytes ([System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $Path).Path))
+167: Set-Content -LiteralPath $tmpEvidence -Value $e -Encoding utf8
+
+PowerShell PS 5.1 operator scan:
+Select-String '\?\?|\?\s*[^\r\n:]+\s*:' over skills/architect/check-runner.ps1
+<no output>
+```
+
+```text
+Bash evidence-write temp path then move:
+75: tmp="$out.tmp.$$"
+111: } > "$tmp"
+113: mv "$tmp" "$out"
+
+Bash command execution lines:
+92:       (cd "$workdir" && powershell -NoProfile -Command "${commands[$i]}") > "$run_out" 2>&1
+95:       (cd "$workdir" && bash -c "${commands[$i]}") > "$run_out" 2>&1
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/jr-validator-01.md
+++ b/docs/jobs/jr-validator-01.md
@@ -1,0 +1,172 @@
+# jr-validator-01
+
+## PHASE 0
+
+FIRST ACTION:
+```text
+FOUND docs/checks/jr-validator.md
+FOUND skills/architect/check-runner.ps1
+FOUND skills/architect/check-runner.sh
+GREP skills/architect/dispatch.md:1
+FIRST_ACTION_OK
+```
+
+Plan:
+```text
+1. Add check-runner.ps1 and check-runner.sh to tests/validate_skills.py REQUIRED_SIBLINGS["architect"].
+2. Add a dispatch contract assertion for skills/architect/dispatch.md:
+   - exact section heading ## Check-runner dispatch is present.
+   - architect-judge-template and architect-codex-judge-template blocks contain re-run at least one RUN command.
+3. Run docs/checks/jr-validator.md V1, V2, V3, and local V4-equivalent restore sequence.
+4. Record V5 function/file evidence.
+```
+
+Disagreements:
+```text
+none
+```
+
+Checked before finding none:
+```text
+docs/spec/judge-runner.md: D2 requires check-runner.ps1 and check-runner.sh siblings under skills/architect.
+docs/spec/judge-runner.md: D4 requires judge templates to read evidence and re-run at least one RUN command.
+docs/spec/judge-runner.md: D5 requires loop wiring; validator slice checks D2/D5 anchors only.
+docs/checks/jr-validator.md: V4 is judge-executed; local builder must not leave skills/ mutated.
+tests/validate_skills.py: REQUIRED_SIBLINGS centralizes existing sibling checks.
+tests/validate_skills.py: errors.append(...) + nonzero main() implements named defects.
+skills/architect/dispatch.md: ## Check-runner dispatch exists once.
+skills/architect/dispatch.md: both judge template blocks currently contain re-run at least one RUN command.
+```
+
+## Source Diff
+
+```diff
+diff --git a/tests/validate_skills.py b/tests/validate_skills.py
+index 2b4480a..7045a19 100644
+--- a/tests/validate_skills.py
++++ b/tests/validate_skills.py
+@@ -32,6 +32,8 @@ REQUIRED_SIBLINGS = {
+         "watchdog.sh",
+         "status.ps1",
+         "status.sh",
++        "check-runner.ps1",
++        "check-runner.sh",
+         "tracker.md",
+     ],
+     "architect-research": ["tactics.md"],
+@@ -253,6 +255,30 @@ def check_judge_template() -> None:
+         errors.append("skills/architect/dispatch.md: C5 template does not forbid slice-specific prose")
+ 
+ 
++def check_check_runner_dispatch_contract() -> None:
++    dispatch = SKILLS / "architect" / "dispatch.md"
++    if not dispatch.exists():
++        errors.append("skills/architect/dispatch.md: missing (required for check-runner dispatch contract)")
++        return
++    text = read_text(dispatch)
++    if "## Check-runner dispatch" not in text.splitlines():
++        errors.append("skills/architect/dispatch.md: missing ## Check-runner dispatch")
++    for marker in ("architect-judge-template", "architect-codex-judge-template"):
++        start = f"<!-- {marker}:start -->"
++        end = f"<!-- {marker}:end -->"
++        start_at = text.find(start)
++        end_at = text.find(end, start_at + len(start))
++        if start_at == -1 or end_at == -1:
++            errors.append(f"skills/architect/dispatch.md: missing {marker} marker block")
++            continue
++        block = text[start_at + len(start) : end_at]
++        if "re-run at least one RUN command" not in block:
++            errors.append(
++                "skills/architect/dispatch.md: "
++                f"{marker} missing re-run at least one RUN command"
++            )
++
++
+ PADDED_TOOLS = ("Bash", "Read", "PowerShell")
+ 
+ 
+@@ -482,6 +508,7 @@ def main() -> int:
+     check_model_alias_table()
+     check_config_example()
+     check_judge_template()
++    check_check_runner_dispatch_contract()
+     check_agent_definitions()
+     check_codex_install_step()
+     check_watchdog_contract()
+```
+
+## V1
+
+Command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python tests/validate_skills.py
+```
+
+Output:
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+## V2
+
+Commands and output:
+```text
+> (Select-String -Path tests/validate_skills.py -Pattern 'check-runner.ps1').Count
+1
+> (Select-String -Path tests/validate_skills.py -Pattern 'check-runner.sh').Count
+1
+> (Select-String -Path tests/validate_skills.py -Pattern 'Check-runner dispatch').Count
+3
+> (Select-String -Path tests/validate_skills.py -Pattern 're-run at least one RUN command').Count
+2
+```
+
+## V3
+
+Command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr'; uv run --no-project python -c "import ast; ast.parse(open('tests/validate_skills.py').read()); print('V3_OK')"
+```
+
+Output:
+```text
+V3_OK
+```
+
+## V4
+
+```text
+not run by builder
+prompt note: frozen check V4 is JUDGE-executed; you do not run it
+source evidence for expected nonzero missing-runner failure:
+tests/validate_skills.py:35:        "check-runner.ps1",
+tests/validate_skills.py:99:def check_siblings(skill_dir: Path) -> None:
+tests/validate_skills.py:101:            errors.append(f"{skill_dir.name}: required file {sibling} missing")
+```
+
+## V5
+
+```text
+tests/validate_skills.py:35:        "check-runner.ps1",
+tests/validate_skills.py:36:        "check-runner.sh",
+tests/validate_skills.py:99:def check_siblings(skill_dir: Path) -> None:
+tests/validate_skills.py:258:def check_check_runner_dispatch_contract() -> None:
+tests/validate_skills.py:264:    if "## Check-runner dispatch" not in text.splitlines():
+tests/validate_skills.py:265:        errors.append("skills/architect/dispatch.md: missing ## Check-runner dispatch")
+tests/validate_skills.py:275:        if "re-run at least one RUN command" not in block:
+tests/validate_skills.py:278:                f"{marker} missing re-run at least one RUN command"
+```
+
+## Integrity
+
+```text
+> git.exe status --porcelain docs/checks skills
+
+> git.exe diff --check -- tests/validate_skills.py docs/jobs/jr-validator-01.md
+warning: in the working copy of 'tests/validate_skills.py', LF will be replaced by CRLF the next time Git touches it
+> git.exe status --porcelain
+ M tests/validate_skills.py
+?? docs/jobs/jr-validator-01.md
+```
+
+STATUS: PASS

--- a/docs/jobs/jr-validator-rulings.md
+++ b/docs/jobs/jr-validator-rulings.md
@@ -1,0 +1,11 @@
+# Rulings: jr-validator (issue #65) — append-only, orchestrator-owned
+
+## 2026-07-04 R1 — V4 tree-audit reconciliation (pre-judge)
+
+Frozen check V4 is judge-executed and REQUIRES a temporary tracked-file
+mutation (Move-Item check-runner.ps1 away, run validator, MANDATORY restore,
+prove clean with git status --porcelain). The judge template's tree-audit
+clause applies to the END state of judgment: the temporary V4 mutation is
+sanctioned by the frozen check itself; a non-empty porcelain at the END of
+judgment is INVALID as written. Do not self-INVALID for executing V4 as
+frozen.

--- a/docs/jobs/jr-wiring-01.md
+++ b/docs/jobs/jr-wiring-01.md
@@ -1,0 +1,148 @@
+# PHASE 0
+
+Required input verification:
+
+```text
+git.exe rev-parse HEAD
+1473c78cf443f2c0876bfc058b934e1bec7a7a48
+
+Test-Path -LiteralPath docs/checks/jr-wiring.md
+True
+```
+
+Plan:
+
+1. Update `skills/architect/dispatch.md` only at the requested judge templates, new check-runner dispatch section location, and stress-test template.
+2. Update `skills/architect/loop.md` only in `## Factory block procedure` Job DONE text and `## Verdict comments`.
+3. Update `skills/architect/SKILL.md` only in Hard Rule 3 and Step 4 On-DONE text.
+4. Run the frozen `docs/checks/jr-wiring.md` commands and size guards.
+5. Leave `docs/checks/**`, runner scripts, tests, README, DESIGN, tracker/research/status/watchdog files untouched.
+
+Disagreements:
+
+None recorded.
+
+Checked before finding none:
+
+```text
+docs/spec/judge-runner.md: D1 requires `- RUN:` grammar; D4 requires judge evidence consumption and spot-check; D5 requires loop/SKILL.md wiring.
+docs/checks/jr-wiring.md: acceptance owns only skills/architect/SKILL.md, skills/architect/loop.md, skills/architect/dispatch.md.
+git.exe grep anchors:
+skills/architect/dispatch.md:90:## C5 judge delegation template
+skills/architect/dispatch.md:98:<!-- architect-judge-template:start -->
+skills/architect/dispatch.md:119:<!-- architect-judge-template:end -->
+skills/architect/dispatch.md:121:## Codex judge delegation template
+skills/architect/dispatch.md:127:<!-- architect-codex-judge-template:start -->
+skills/architect/dispatch.md:164:<!-- architect-codex-judge-template:end -->
+skills/architect/dispatch.md:166:## Stress-test delegation template
+skills/architect/dispatch.md:172:<!-- architect-stress-test-template:start -->
+skills/architect/dispatch.md:194:<!-- architect-stress-test-template:end -->
+skills/architect/loop.md:17:3. **Wake on one event**, exactly one of:
+skills/architect/loop.md:59:## Verdict comments
+tests/validate_skills.py:233:        r"<!-- architect-judge-template:start -->\n```text\n(.*?)\n```\n<!-- architect-judge-template:end -->",
+```
+
+MIRROR: ORCHESTRATOR
+
+# Evidence
+
+Frozen mechanical checks:
+
+```text
+COMMAND: git.exe grep -c "## Check-runner dispatch" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c -- "- RUN:" skills/architect/dispatch.md
+skills/architect/dispatch.md:3
+EXIT: 0
+COMMAND: git.exe grep -c "max_output_lines" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "CHECKRUN: ERROR" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "checkrun" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:6
+EXIT: 0
+COMMAND: git.exe grep -c "re-run at least one RUN command" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+COMMAND: git.exe grep -c "Source: evidence-file" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+COMMAND: git.exe grep -c "never FAIL" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+COMMAND: git.exe grep -c "evidence_out" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "architect-judge-template:start" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "architect-codex-judge-template:start" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "MUST use" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+COMMAND: git.exe grep -c "check-runner" -- skills/architect/loop.md
+skills/architect/loop.md:2
+EXIT: 0
+COMMAND: git.exe grep -c "checkrun" -- skills/architect/loop.md
+skills/architect/loop.md:2
+EXIT: 0
+COMMAND: git.exe grep -c "check-runner" -- skills/architect/SKILL.md
+skills/architect/SKILL.md:2
+EXIT: 0
+```
+
+Size guards:
+
+```text
+COMMAND: (Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() }).Count
+208
+COMMAND: (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() }).Count
+100
+COMMAND: (Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() }).Count
+492
+```
+
+Judge-only quote evidence:
+
+```text
+skills/architect/SKILL.md:36:3. **Nobody grades their own work.** Builders report raw evidence only. A fresh, independent orchestrator-tier judge checks intent. Frozen checks are executed by the deterministic check-runner; the judge grades the evidence and spot-checks. The orchestrator may not turn a judge FAIL into a merge.
+skills/architect/loop.md:18:   - **Job DONE.** Ordering: write the runner config; launch `check-runner.ps1`
+skills/architect/loop.md:19:     or `check-runner.sh` as a background process whose exit is the next wake; commit the checkrun artifact `docs/jobs/<issue-slug>-checkrun.md`; then send the fixed judge template from `dispatch.md` to one fresh judge subagent with the evidence path. Record the verdict in an issue comment (see Verdict comments); merge on PASS, diagnose on FAIL (see Failure ladder).
+skills/architect/dispatch.md:200:Grill clause: every mechanical check MUST use `- RUN:` form; a mechanical check not in RUN form is a check defect.
+skills/architect/SKILL.md:200:- On DONE, write the runner config, launch the check-runner in the background, let its exit wake the loop, commit the checkrun evidence file, then send a fresh, independent orchestrator-tier judge with the evidence path.
+skills/architect/dispatch.md:165:<!-- architect-codex-judge-template:end -->
+skills/architect/dispatch.md:167:## Check-runner dispatch
+skills/architect/dispatch.md:188:## Stress-test delegation template
+```
+
+Validator:
+
+```text
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache-jr-wiring'; uv run --no-project python tests/validate_skills.py
+OK - 2 skills validated, v4 contracts clean
+```
+
+Touch-set audit:
+
+```text
+git.exe status --short
+ M skills/architect/SKILL.md
+ M skills/architect/dispatch.md
+ M skills/architect/loop.md
+?? docs/jobs/jr-wiring-01.md
+
+git.exe diff -- docs/checks
+<no output>
+
+git.exe diff --check
+warning: in the working copy of 'skills/architect/SKILL.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'skills/architect/dispatch.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'skills/architect/loop.md', LF will be replaced by CRLF the next time Git touches it
+exit 0
+```
+STATUS: COMPLETE

--- a/docs/jobs/jr-wiring-02.md
+++ b/docs/jobs/jr-wiring-02.md
@@ -1,0 +1,154 @@
+# PHASE 0
+
+```text
+COMMAND: git rev-parse HEAD
+fb7414dd83e08f1e251338c1dd4ca0f853998cf2
+EXIT: 0
+
+COMMAND: git rev-parse job/jr-wiring-01
+fb7414dd83e08f1e251338c1dd4ca0f853998cf2
+EXIT: 0
+
+COMMAND: Test-Path -LiteralPath docs/checks/jr-wiring.md
+True
+EXIT: 0
+
+COMMAND: $i=0; Get-Content -LiteralPath docs/jobs/jr-wiring-rulings.md | ForEach-Object { $i++; if ($i -ge 11 -and $i -le 17) { "{0}:{1}" -f $i, $_ } }
+11:
+12:Respawn fix contract (jr-wiring-02): amend that intro sentence so the
+13:enumerated replace-list includes the checkrun evidence path placeholder.
+14:Audit the C5 judge template intro for the same enumeration mismatch; its
+15:generic "replacing placeholders" wording is acceptable unchanged. No other
+16:edits. Boundaries and frozen checks unchanged; prior work stands at job
+17:branch commit 6971312.
+EXIT: 0
+```
+
+```text
+MIRROR: ORCHESTRATOR
+DISAGREEMENTS: none
+
+AUDIT: skills/architect/dispatch.md:92
+The orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation.
+
+AUDIT: skills/architect/dispatch.md:124
+The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, worktree note, and checkrun evidence file path. It must not add slice-specific prose, encouragement, summaries, or interpretation.
+```
+
+# Evidence
+
+````text
+COMMAND: git diff -- skills/architect/dispatch.md
+diff --git a/skills/architect/dispatch.md b/skills/architect/dispatch.md
+index 8c47aa8..42e3a50 100644
+--- a/skills/architect/dispatch.md
++++ b/skills/architect/dispatch.md
+@@ -121,7 +121,7 @@ Verdict format:
+ 
+ ## Codex judge delegation template
+ 
+-The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, and worktree note. It must not add slice-specific prose, encouragement, summaries, or interpretation.
++The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, worktree note, and checkrun evidence file path. It must not add slice-specific prose, encouragement, summaries, or interpretation.
+ 
+ <!-- architect-codex-judge-template:start -->
+ ```text
+EXIT: 0
+
+COMMAND: git diff -- docs/checks
+<no output>
+EXIT: 0
+````
+
+# W1
+
+```text
+COMMAND: git grep -c "## Check-runner dispatch" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+
+COMMAND: git grep -c -- "- RUN:" skills/architect/dispatch.md
+skills/architect/dispatch.md:3
+EXIT: 0
+
+COMMAND: git grep -c "max_output_lines" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+
+COMMAND: git grep -c "CHECKRUN: ERROR" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+```
+
+# W2
+
+```text
+COMMAND: git grep -c "checkrun" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:7
+EXIT: 0
+
+COMMAND: git grep -c "re-run at least one RUN command" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+
+COMMAND: git grep -c "Source: evidence-file" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+
+COMMAND: git grep -c "never FAIL" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:2
+EXIT: 0
+
+COMMAND: git grep -c "evidence_out" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+
+COMMAND: git grep -c "architect-judge-template:start" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+
+COMMAND: git grep -c "architect-codex-judge-template:start" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+```
+
+# W3
+
+```text
+COMMAND: git grep -c "MUST use" -- skills/architect/dispatch.md
+skills/architect/dispatch.md:1
+EXIT: 0
+```
+
+# W4
+
+```text
+COMMAND: git grep -c "check-runner" -- skills/architect/loop.md
+skills/architect/loop.md:2
+EXIT: 0
+
+COMMAND: git grep -c "checkrun" -- skills/architect/loop.md
+skills/architect/loop.md:2
+EXIT: 0
+
+COMMAND: git grep -c "check-runner" -- skills/architect/SKILL.md
+skills/architect/SKILL.md:2
+EXIT: 0
+```
+
+# W5
+
+```text
+COMMAND: (Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() }).Count
+208
+EXIT: 0
+
+COMMAND: (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() }).Count
+100
+EXIT: 0
+
+COMMAND: (Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() }).Count
+492
+EXIT: 0
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/jr-wiring-rulings.md
+++ b/docs/jobs/jr-wiring-rulings.md
@@ -1,0 +1,17 @@
+# Rulings: jr-wiring (issue #64) — append-only, orchestrator-owned
+
+## 2026-07-04 R1 — first-judgment FAIL diagnosis and respawn contract
+
+Fresh codex judge: checks integrity PASS, W1–W6 all PASS, diff-vs-intent
+FAIL. Defect: `skills/architect/dispatch.md` codex-judge intro enumerates
+the replaceable placeholders (check file path, freeze SHA, branch, worktree
+note) but the template body now carries a fifth placeholder
+`<docs/jobs/<issue-slug>-checkrun.md>`; a dispatcher following the intro
+verbatim sends it unresolved — spec D5 evidence-path wiring violated.
+
+Respawn fix contract (jr-wiring-02): amend that intro sentence so the
+enumerated replace-list includes the checkrun evidence path placeholder.
+Audit the C5 judge template intro for the same enumeration mismatch; its
+generic "replacing placeholders" wording is acceptable unchanged. No other
+edits. Boundaries and frozen checks unchanged; prior work stands at job
+branch commit 6971312.

--- a/docs/solutions/judge-checkrun-offload.md
+++ b/docs/solutions/judge-checkrun-offload.md
@@ -1,0 +1,41 @@
+# Judge Checkrun Offload
+Recorded: 2026-07-04
+
+## Symptom
+
+Frontier-priced judges were spending most of their turns on greps and other
+frozen mechanical checks. The approved judge-runner spec recorded 135
+`command → expected` items across 15 frozen check files, about 9 per file,
+with `tracker-adapter.md` 17-of-18 mechanical.
+
+## Diagnosis
+
+Judgment had two jobs mixed together: deterministic command execution and
+actual review. The first job only needs exact shell output and exit codes; the
+second job still needs a fresh orchestrator-tier judge for evidence grading,
+checks integrity, and diff-vs-intent. Running both inside the judge wasted the
+judge context and made shell-dependent checks force cross-family Codex judges
+when Claude subagents lost shell tools.
+
+## Fix
+
+Use a deterministic check-runner script to execute frozen `- RUN:` commands
+and write a durable checkrun evidence file. The judge reads that file, grades
+the captured evidence against the frozen expectations, executes judge-only
+items, re-runs at least one RUN command as an honesty spot-check, and still
+rules on diff-vs-intent.
+
+## What Did Not Work
+
+- Run-context note: the pre-freeze grill caught four decomposition defects
+  before they became builder work: a spec/fixture count contradiction, an
+  unguarded V4 tracked-file mutation, implicit commit-ordering for freeze SHA
+  HEAD integrity, and non-falsifiable bare-number greps.
+- The jr-wiring first judgment passed W1-W6 but failed diff-vs-intent because
+  the Codex judge intro listed the old placeholder set and omitted the new
+  checkrun evidence path; the respawn contract added that path explicitly
+  (`docs/jobs/jr-wiring-rulings.md`).
+- The jr-runner builder could not execute the Bash runner in this Codex
+  Windows sandbox; the report recorded `check-runner.sh` as UNEXECUTED
+  because Git Bash dies here with Win32 error 5. The jr-runner check file
+  required a non-Codex-sandbox judge for that Bash fixture.

--- a/docs/spec/judge-runner.md
+++ b/docs/spec/judge-runner.md
@@ -87,6 +87,9 @@ its evidence output file. Behavior:
    <freeze_sha>..HEAD` in full; whether any changed path is under
    `docs/checks/`.
 3. Parse RUN lines per D1, preserving section headers and file line numbers.
+   The config's `executor` is authoritative for execution; the runner also
+   records the check file's `Executor:` header line verbatim in the evidence
+   header so any mismatch is visible to the judge.
 4. Execute each command in order, cwd = workdir, via the file's executor;
    capture exit code, wall ms, and output capped at `max_output_lines`
    (default 60) with the untruncated byte count. A command that errors is
@@ -172,12 +175,17 @@ except `evidence_out`.
 ## Validation strategy
 
 Fixture-based, no network: a fixture check file containing (a) a RUN line
-that succeeds with known output, (b) a RUN line that exits nonzero, (c) a
-prose line with a backtick span and NO RUN marker, (d) a judge-only quote
-item. Run the runner against it in a scratch git state; assert the evidence
-file contains exactly two `$` blocks with correct exit codes, the non-RUN
-span was never executed, integrity fields are present, and exit code is 0.
-Config-error path asserts exit 5 and no evidence file. Skill-text slices are
+that succeeds with known output, (b) a RUN line whose output exceeds the
+cap (truncation exercise), (c) a RUN line that exits nonzero, (d) a prose
+line with a backtick span and NO RUN marker, (e) a judge-only quote item.
+Run the runner against it; assert the evidence file contains exactly three
+`$` blocks with correct exit codes (one `exit: 3`), a truncation marker,
+the non-RUN span never executed, integrity fields present, and exit code 0.
+Config-error path asserts exit 5 and no evidence file. Fixture integrity
+(`check_file_matches_freeze=true` with `freeze_sha: HEAD`) is evaluated
+AFTER the orchestrator commits the job to its branch — the standard flow
+(builders never commit; the orchestrator commits before checks/judge run) —
+so acceptance always executes against a committed tree. Skill-text slices are
 checked with the existing grep-anchor style; validator slice must keep
 `tests/validate_skills.py` green end-to-end.
 

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -33,9 +33,7 @@ templates live behind these pointers:
 2. **Checks freeze in git before dispatch.** Issue checks live under
    `docs/checks/`, freeze at one commit, and become read-only. Any builder edit
    under `docs/checks/` is an automatic FAIL.
-3. **Nobody grades their own work.** Builders report raw evidence only. A
-   fresh, independent orchestrator-tier judge runs frozen checks and checks
-   intent. The orchestrator may not turn a judge FAIL into a merge.
+3. **Nobody grades their own work.** Builders report raw evidence only. A fresh, independent orchestrator-tier judge checks intent. Frozen checks are executed by the deterministic check-runner; the judge grades the evidence and spot-checks. The orchestrator may not turn a judge FAIL into a merge.
 4. **The orchestrator never writes implementation code and never reads large
    diffs.** Builders code; verifier and judge subagents inspect large diffs.
 5. **Fresh builder per issue.** Use worktree isolation and one issue per
@@ -199,8 +197,7 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
   the ready issues need recomputation.
 - On human status requests ("status", "how's it going", or equivalent), run
   `skills/architect/status.ps1` on Windows or `skills/architect/status.sh` on POSIX, print its output verbatim in a fenced code block, answer in prose, and never hand-compose the tree.
-- On DONE, send a fresh, independent orchestrator-tier judge to run frozen
-  checks and inspect intent.
+- On DONE, write the runner config, launch the check-runner in the background, let its exit wake the loop, commit the checkrun evidence file, then send a fresh, independent orchestrator-tier judge with the evidence path.
   Merge only after a passing verdict and clean touch-set evidence.
 - On BLOCKED, answer on the issue, cite durable evidence, and respawn a fresh
   builder with the answer using `dispatch.md` `## Respawn-with-answer template`.

--- a/skills/architect/check-runner.ps1
+++ b/skills/architect/check-runner.ps1
@@ -1,0 +1,169 @@
+param([Parameter(Mandatory=$true)][string]$Config)
+
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+$evidenceOut = $null
+$tmpEvidence = $null
+
+function DecodeBytes($Bytes) {
+    if ($Bytes.Length -ge 3 -and $Bytes[0] -eq 239 -and $Bytes[1] -eq 187 -and $Bytes[2] -eq 191) { return [System.Text.Encoding]::UTF8.GetString($Bytes, 3, $Bytes.Length - 3) }
+    if ($Bytes.Length -ge 2 -and $Bytes[0] -eq 255 -and $Bytes[1] -eq 254) { return [System.Text.Encoding]::Unicode.GetString($Bytes, 2, $Bytes.Length - 2) }
+    if ($Bytes.Length -ge 2 -and $Bytes[0] -eq 254 -and $Bytes[1] -eq 255) { return [System.Text.Encoding]::BigEndianUnicode.GetString($Bytes, 2, $Bytes.Length - 2) }
+    $utf8 = New-Object System.Text.UTF8Encoding($false, $true)
+    try { return $utf8.GetString($Bytes) } catch { return [System.Text.Encoding]::Default.GetString($Bytes) }
+}
+
+function ReadText($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { throw "missing" }
+    return DecodeBytes ([System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $Path).Path))
+}
+
+function StopRun($Reason) {
+    if ($evidenceOut) { Remove-Item -LiteralPath $evidenceOut -Force -ErrorAction SilentlyContinue }
+    if ($tmpEvidence) { Remove-Item -LiteralPath $tmpEvidence -Force -ErrorAction SilentlyContinue }
+    Write-Output "CHECKRUN: ERROR $Reason"
+    exit 5
+}
+
+function QuoteArg($Text) {
+    $r = '"'
+    $slashes = 0
+    foreach ($ch in $Text.ToCharArray()) {
+        if ($ch -eq '\') { $slashes += 1; continue }
+        if ($ch -eq '"') {
+            if ($slashes -gt 0) { $r += ('\' * ($slashes * 2)) }
+            $r += '\"'
+            $slashes = 0
+            continue
+        }
+        if ($slashes -gt 0) { $r += ('\' * $slashes); $slashes = 0 }
+        $r += $ch
+    }
+    if ($slashes -gt 0) { $r += ('\' * ($slashes * 2)) }
+    return $r + '"'
+}
+
+function CaptureCommand($Executor, $Command, $Workdir) {
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    if ($Executor -eq "powershell") {
+        $psi.FileName = "powershell"
+        $psi.Arguments = "-NoProfile -Command " + $Command + '; if ($global:LASTEXITCODE -ne $null) { exit $global:LASTEXITCODE }'
+    } else {
+        $psi.FileName = "bash"
+        $psi.Arguments = "-c " + (QuoteArg $Command)
+    }
+    $psi.WorkingDirectory = (Resolve-Path -LiteralPath $Workdir).Path
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    try { $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8; $psi.StandardErrorEncoding = [System.Text.Encoding]::UTF8 } catch {}
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $psi
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $stdout = ""
+    $stderr = ""
+    try {
+        [void]$p.Start()
+        $stdout = $p.StandardOutput.ReadToEnd()
+        $stderr = $p.StandardError.ReadToEnd()
+        $p.WaitForExit()
+        $code = $p.ExitCode
+    } catch {
+        $code = 127
+        $stderr = $_.Exception.Message + [Environment]::NewLine
+    }
+    $sw.Stop()
+    return [pscustomobject]@{ ExitCode = $code; Ms = [int64]$sw.ElapsedMilliseconds; Output = ($stdout + $stderr) }
+}
+
+function OutputSlice($Text, $MaxLines) {
+    $all = @($Text -split "`r?`n", -1)
+    if ($all.Count -gt 0 -and $all[$all.Count - 1] -eq "") {
+        if ($all.Count -eq 1) { $all = @() } else { $all = @($all[0..($all.Count - 2)]) }
+    }
+    $cut = $false
+    if ($all.Count -gt $MaxLines) {
+        $cut = $true
+        $all = @($all | Select-Object -First $MaxLines)
+    }
+    return [pscustomobject]@{ Lines = $all; Truncated = $cut }
+}
+
+try {
+    $cfg = (ReadText $Config) | ConvertFrom-Json
+} catch {
+    Write-Output "CHECKRUN: ERROR unreadable config"
+    exit 5
+}
+
+$checkFile = [string]$cfg.check_file
+$workdir = [string]$cfg.workdir
+$freezeSha = [string]$cfg.freeze_sha
+$evidenceOut = [string]$cfg.evidence_out
+$executor = [string]$cfg.executor
+$maxOutputLines = 60
+if ($cfg.PSObject.Properties.Name -contains "max_output_lines") { $maxOutputLines = [int]$cfg.max_output_lines }
+
+if (-not (Test-Path -LiteralPath $checkFile)) { StopRun "missing check file" }
+try { & git --version > $null 2> $null } catch { StopRun "git unavailable" }
+if ($LASTEXITCODE -ne 0) { StopRun "git unavailable" }
+
+$diskHash = ""; $freezeHash = ""
+try { $diskHash = @(& git hash-object -- $checkFile 2> $null)[0] } catch {}
+try {
+    $freezeSpec = $freezeSha + ":" + $checkFile
+    $freezeHash = @(& git rev-parse $freezeSpec 2> $null)[0]
+    if ($LASTEXITCODE -ne 0) { $freezeHash = "" }
+} catch {}
+$checkMatch = "false"
+if ($diskHash -and $freezeHash -and $diskHash -eq $freezeHash) { $checkMatch = "true" }
+$head = ""
+try { $head = @(& git -C $workdir rev-parse HEAD 2> $null)[0] } catch {}
+$changed = @()
+try { $changed = @(& git -C $workdir diff --name-only ($freezeSha + "..HEAD") 2> $null) } catch {}
+$docsTouched = "false"
+foreach ($path in $changed) { if ($path -like "docs/checks/*") { $docsTouched = "true" } }
+
+$text = ReadText $checkFile
+$lines = @($text -split "`r?`n")
+$section = "(root)"
+$executorHeader = ""
+$runs = @()
+for ($i = 0; $i -lt $lines.Count; $i++) {
+    $line = $lines[$i]
+    if ($executorHeader -eq "" -and $line -match '^\s*Executor:\s*') { $executorHeader = $line.TrimEnd() }
+    if ($line.StartsWith("## ", [System.StringComparison]::Ordinal)) { $section = $line.Substring(3) }
+    $m = [regex]::Match($line, '^\s*- RUN:\s*`([^`]*)`')
+    if ($m.Success) { $runs += [pscustomobject]@{ Section = $section; Line = $i + 1; Command = $m.Groups[1].Value } }
+}
+
+$e = New-Object System.Collections.Generic.List[string]
+$slug = [System.IO.Path]::GetFileNameWithoutExtension($evidenceOut)
+[void]$e.Add("# Checkrun: $slug")
+[void]$e.Add("generated: $((Get-Date).ToUniversalTime().ToString("o"))  runner: ps1  config: $Config")
+[void]$e.Add("check_file: $checkFile  freeze_sha: $freezeSha")
+if ($executorHeader) { [void]$e.Add($executorHeader) }
+[void]$e.Add("executor_config: $executor")
+[void]$e.Add("integrity: check_file_matches_freeze=$checkMatch head=$head")
+[void]$e.Add("changed_files: $($changed.Count) listed below; docs_checks_touched=$docsTouched")
+foreach ($path in $changed) { [void]$e.Add($path) }
+
+foreach ($run in $runs) {
+    $result = CaptureCommand $executor $run.Command $workdir
+    $bytes = [System.Text.Encoding]::UTF8.GetByteCount($result.Output)
+    $slice = OutputSlice $result.Output $maxOutputLines
+    $mark = ""
+    if ($slice.Truncated) { $mark = " truncated" }
+    [void]$e.Add("")
+    [void]$e.Add("## $($run.Section) line $($run.Line)")
+    [void]$e.Add('$ ' + $run.Command)
+    [void]$e.Add("exit: $($result.ExitCode)  ms: $($result.Ms)  bytes: $bytes$mark")
+    foreach ($line in $slice.Lines) { [void]$e.Add($line) }
+}
+
+$dir = Split-Path -Parent $evidenceOut
+if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+$tmpEvidence = $evidenceOut + ".tmp." + ([System.Guid]::NewGuid().ToString("N"))
+Set-Content -LiteralPath $tmpEvidence -Value $e -Encoding utf8
+Move-Item -LiteralPath $tmpEvidence -Destination $evidenceOut -Force
+exit 0

--- a/skills/architect/check-runner.sh
+++ b/skills/architect/check-runner.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -u
+
+out=
+tmp=
+die(){
+  [ -n "${out:-}" ] && rm -f "$out"
+  [ -n "${tmp:-}" ] && rm -f "$tmp"
+  printf 'CHECKRUN: ERROR %s\n' "$1"
+  exit 5
+}
+
+cfg=${1:-}
+[ -n "$cfg" ] || die "unreadable config"
+[ -r "$cfg" ] || die "unreadable config"
+json=$(tr -d '\r\n' < "$cfg") || die "unreadable config"
+field(){ printf '%s' "$json" | sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"; }
+numfield(){ printf '%s' "$json" | sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p"; }
+
+check_file=$(field check_file)
+workdir=$(field workdir)
+freeze_sha=$(field freeze_sha)
+out=$(field evidence_out)
+executor=$(field executor)
+max_output_lines=$(numfield max_output_lines)
+[ -n "$max_output_lines" ] || max_output_lines=60
+
+[ -f "$check_file" ] || die "missing check file"
+git --version >/dev/null 2>&1 || die "git unavailable"
+
+disk_hash=$(git hash-object -- "$check_file" 2>/dev/null || printf '')
+freeze_hash=$(git rev-parse "$freeze_sha:$check_file" 2>/dev/null || printf '')
+check_match=false
+[ -n "$disk_hash" ] && [ -n "$freeze_hash" ] && [ "$disk_hash" = "$freeze_hash" ] && check_match=true
+head=$(git -C "$workdir" rev-parse HEAD 2>/dev/null || printf '')
+changed_tmp=$(mktemp)
+git -C "$workdir" diff --name-only "$freeze_sha..HEAD" > "$changed_tmp" 2>/dev/null || :
+changed_count=$(awk 'NF{n++} END{print n+0}' "$changed_tmp")
+docs_touched=$(awk 'BEGIN{x="false"} /^docs\/checks\//{x="true"} END{print x}' "$changed_tmp")
+
+bt='`'
+section='(root)'
+executor_header=
+line_no=0
+count=0
+declare -a sections line_numbers commands
+while IFS= read -r line || [ -n "$line" ]; do
+  line_no=$((line_no + 1))
+  case "$line" in Executor:*) [ -z "$executor_header" ] && executor_header=$line;; esac
+  case "$line" in '## '*) section=${line#'## '};; esac
+  trimmed=$line
+  while :; do
+    case "$trimmed" in ' '*) trimmed=${trimmed#?};; $'\t'*) trimmed=${trimmed#?};; *) break;; esac
+  done
+  case "$trimmed" in
+    '- RUN:'*)
+      rest=${trimmed#'- RUN:'}
+      case "$rest" in
+        *"$bt"*"$bt"*)
+          after=${rest#*"$bt"}
+          cmd=${after%%"$bt"*}
+          sections[$count]=$section
+          line_numbers[$count]=$line_no
+          commands[$count]=$cmd
+          count=$((count + 1))
+          ;;
+      esac
+      ;;
+  esac
+done < "$check_file"
+
+now_ms(){ perl -MTime::HiRes=time -e 'printf "%d\n", time()*1000' 2>/dev/null || printf '%s000\n' "$(date +%s)"; }
+out_dir=$(dirname "$out")
+[ -d "$out_dir" ] || mkdir -p "$out_dir"
+tmp="$out.tmp.$$"
+slug=$(basename "$out" .md)
+
+{
+  printf '# Checkrun: %s\n' "$slug"
+  printf 'generated: %s  runner: sh  config: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$cfg"
+  printf 'check_file: %s  freeze_sha: %s\n' "$check_file" "$freeze_sha"
+  [ -n "$executor_header" ] && printf '%s\n' "$executor_header"
+  printf 'executor_config: %s\n' "$executor"
+  printf 'integrity: check_file_matches_freeze=%s head=%s\n' "$check_match" "$head"
+  printf 'changed_files: %s listed below; docs_checks_touched=%s\n' "$changed_count" "$docs_touched"
+  cat "$changed_tmp"
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    run_out=$(mktemp)
+    start=$(now_ms)
+    if [ "$executor" = powershell ]; then
+      (cd "$workdir" && powershell -NoProfile -Command "${commands[$i]}") > "$run_out" 2>&1
+      code=$?
+    else
+      (cd "$workdir" && bash -c "${commands[$i]}") > "$run_out" 2>&1
+      code=$?
+    fi
+    end=$(now_ms)
+    ms=$((end - start))
+    bytes=$(wc -c < "$run_out" | tr -d ' ')
+    total_lines=$(awk 'END{print NR}' "$run_out")
+    mark=
+    [ "$total_lines" -gt "$max_output_lines" ] && mark=' truncated'
+    printf '\n## %s line %s\n' "${sections[$i]}" "${line_numbers[$i]}"
+    printf '$ %s\n' "${commands[$i]}"
+    printf 'exit: %s  ms: %s  bytes: %s%s\n' "$code" "$ms" "$bytes" "$mark"
+    sed -n "1,${max_output_lines}p" "$run_out"
+    rm -f "$run_out"
+    i=$((i + 1))
+  done
+} > "$tmp"
+
+mv "$tmp" "$out"
+rm -f "$changed_tmp"
+exit 0

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -89,11 +89,8 @@ or reports the check BLOCKED — never silently skips a check or invents output.
 
 ## C5 judge delegation template
 
-The orchestrator must send this template as-is except for replacing
-placeholders. It must not add slice-specific prose, encouragement, summaries,
-or interpretation. Judge intent context is pointer-only: frozen check file,
-spec pointer, job report, and `docs/jobs/<issue-slug>-rulings.md`
-(orchestrator-owned, append-only; absent = no post-freeze rulings).
+The orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation.
+Judge intent context is pointer-only: frozen check file, spec pointer, job report, and `docs/jobs/<issue-slug>-rulings.md` (orchestrator-owned, append-only; absent = no post-freeze rulings).
 
 <!-- architect-judge-template:start -->
 ```text
@@ -102,7 +99,10 @@ Freeze commit SHA: <freeze-sha>
 Branch to judge: <branch>
 Spec pointer: <spec path named by the frozen check>
 Job report: <docs/jobs/<issue-slug>-01.md>
+checkrun evidence file path: <docs/jobs/<issue-slug>-checkrun.md>
 Rulings file: docs/jobs/<issue-slug>-rulings.md (absent = no post-freeze rulings)
+
+Evidence rules: read the checkrun evidence file before grading; grade RUN items from the evidence file; execute judge-only items yourself; re-run at least one RUN command and compare with the evidence file -- any mismatch is automatic INVALID with both outputs quoted; missing/stale evidence (integrity false or freeze SHA mismatch) -> INVALID, never FAIL.
 
 Verdict format:
 - Checks integrity: PASS | FAIL | INVALID
@@ -112,6 +112,7 @@ Verdict format:
 - Per check:
   - <check id>: PASS | FAIL | INVALID
     Command: <exact command from the frozen check>
+    Source: evidence-file | re-run
     Raw evidence: <verbatim stdout/stderr and exit code>
 - Slice verdict: PASS | FAIL | INVALID
   Decisive reason: <one sentence tied to raw evidence>
@@ -120,9 +121,7 @@ Verdict format:
 
 ## Codex judge delegation template
 
-The orchestrator must send this template as-is except for replacing the check
-file path, freeze SHA, branch, and worktree note. It must not add slice-specific
-prose, encouragement, summaries, or interpretation.
+The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, and worktree note. It must not add slice-specific prose, encouragement, summaries, or interpretation.
 
 <!-- architect-codex-judge-template:start -->
 ```text
@@ -130,6 +129,7 @@ Frozen check file path: <docs/checks/<slice>.md>
 Freeze commit SHA: <freeze-sha>
 Branch to judge: <branch>
 Worktree note: <worktree note>
+checkrun evidence file path: <docs/jobs/<issue-slug>-checkrun.md>
 
 You are a fresh read-only judge. You did not build this job. Flag only gaps
 that affect correctness, the stated requirements, or documented project
@@ -144,9 +144,9 @@ error 5 -> PowerShell same-pattern; uv AppData cache denial -> run with
 `UV_CACHE_DIR=.architect/tmp/uv-cache`; tracker posting unavailable -> report
 `MIRROR: ORCHESTRATOR`.
 
-Intent context pointers: frozen check file above; spec pointer named by the
-frozen check; job report named by the issue/check; rulings file
-`docs/jobs/<issue-slug>-rulings.md` (absent = no post-freeze rulings).
+Intent context pointers: frozen check file above; spec pointer named by the frozen check; job report named by the issue/check; rulings file `docs/jobs/<issue-slug>-rulings.md` (absent = no post-freeze rulings).
+
+Evidence rules: read the checkrun evidence file before grading; grade RUN items from the evidence file; execute judge-only items yourself; re-run at least one RUN command and compare with the evidence file -- any mismatch is automatic INVALID with both outputs quoted; missing/stale evidence (integrity false or freeze SHA mismatch) -> INVALID, never FAIL.
 
 Verdict format:
 - Checks integrity: PASS | FAIL | INVALID
@@ -157,11 +157,33 @@ Verdict format:
   - <check id>: PASS | FAIL | INVALID
     Command: <exact command from the frozen check>
     Executor: <executor used>
+    Source: evidence-file | re-run
     Raw evidence: <verbatim stdout/stderr and exit code>
 - Slice verdict: PASS | FAIL | INVALID
   Decisive reason: <one sentence tied to raw evidence>
 ```
 <!-- architect-codex-judge-template:end -->
+
+## Check-runner dispatch
+
+RUN grammar for check files is normative from `docs/spec/judge-runner.md` D1: a runnable check is a list line beginning `- RUN:` whose first single backtick span is the complete command, executable verbatim in the file's named executor. Everything after the closing backtick is judge-facing prose the runner ignores. The check file header names one `Executor:`; items without `RUN:` are judge-only.
+Example line: ``- RUN: `git grep -c "needle" -- path/to/file.md` -> 1``
+
+Runner config JSON, written by the orchestrator per judgment:
+
+```json
+{
+  "check_file": "docs/checks/<slug>.md",
+  "workdir": "<worktree or repo path>",
+  "freeze_sha": "<sha>",
+  "evidence_out": "docs/jobs/<issue-slug>-checkrun.md",
+  "executor": "powershell|bash",
+  "max_output_lines": 60
+}
+```
+
+Typed exits: 0 = evidence file written; 5 = `CHECKRUN: ERROR <reason>` on stdout, no partial evidence file left behind.
+Launch pattern: the orchestrator writes the config with file tools, then launches `skills/architect/check-runner.ps1` or `skills/architect/check-runner.sh` as a background process whose exit wakes the loop. On success, the orchestrator commits the evidence file `docs/jobs/<issue-slug>-checkrun.md` before judge dispatch.
 
 ## Stress-test delegation template
 
@@ -175,15 +197,11 @@ Draft check file path: <docs/checks/<slice>.md>
 Branch: <branch>
 Issue bodies: <pasted issue bodies for this plan>
 
-Task: try to falsify this draft. Execute each check command against the
-current tree, verify every referenced path/SHA/pointer resolves, attack each
-acceptance criterion and pasted issue bodies against the spec for
-contradictions and non-falsifiability, including patterns that collide with
-repo realities (e.g. a grep pattern matching the repo's own name), and flag any
-assumption not evidenced in the repo. For every file a job deletes or renames,
-grep the whole repo for references and verify the owning job's boundary covers
-them or a dependency edge orders the fix. For every NEW artifact path a job
-will create, run `git check-ignore <path>` and flag the plan if ignored.
+Grill clause: every mechanical check MUST use `- RUN:` form; a mechanical check not in RUN form is a check defect.
+
+Task: try to falsify this draft. Execute each check command against the current tree, verify every referenced path/SHA/pointer resolves, attack each acceptance criterion and pasted issue bodies against the spec for contradictions and non-falsifiability, including patterns that collide with repo realities (e.g. a grep pattern matching the repo's own name), and flag any assumption not evidenced in the repo.
+For every file a job deletes or renames, grep the whole repo for references and verify the owning job's boundary covers them or a dependency edge orders the fix.
+For every NEW artifact path a job will create, run `git check-ignore <path>` and flag the plan if ignored.
 
 Defect report format:
 - <check id or clause>: FALSIFIED | HOLDS

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -121,7 +121,7 @@ Verdict format:
 
 ## Codex judge delegation template
 
-The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, and worktree note. It must not add slice-specific prose, encouragement, summaries, or interpretation.
+The orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, worktree note, and checkrun evidence file path. It must not add slice-specific prose, encouragement, summaries, or interpretation.
 
 <!-- architect-codex-judge-template:start -->
 ```text

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -15,10 +15,8 @@ Parallel rules: judges dispatch immediately and run concurrently for every DONE,
 2. **Sleep.** Zero orchestrator work between dispatch and the next event —
    no polling.
 3. **Wake on one event**, exactly one of:
-   - **Job DONE.** Send the fixed judge template from `dispatch.md` to one
-     fresh judge subagent; record the verdict in an issue comment (see
-     Verdict comments); merge on PASS, diagnose on FAIL (see Failure
-     ladder).
+   - **Job DONE.** Ordering: write the runner config; launch `check-runner.ps1`
+     or `check-runner.sh` as a background process whose exit is the next wake; commit the checkrun artifact `docs/jobs/<issue-slug>-checkrun.md`; then send the fixed judge template from `dispatch.md` to one fresh judge subagent with the evidence path. Record the verdict in an issue comment (see Verdict comments); merge on PASS, diagnose on FAIL (see Failure ladder).
    - **Job BLOCKED.** A blocker comment on the issue is a completion event.
      Read it, rule an answer, and respawn a fresh builder job on the same
      issue with the answer in its spawn context (see `dispatch.md`
@@ -63,11 +61,7 @@ is posted on the job's issue with: per-check PASS/FAIL/INVALID, a
 checks-integrity verdict, a diff-vs-intent verdict, the slice call
 KILL/CONTINUE, and the decisive reason tied to raw evidence; exact tracker
 comment format lives in `dispatch.md` "## Issue conventions".
-The judge's intent context is exactly the frozen check file, spec, job
-report, and `docs/jobs/<issue-slug>-rulings.md`. That rulings file is
-orchestrator-owned, append-only, and committed before judge dispatch; if it
-is absent, there are no post-freeze rulings. Judge dispatch blocks carry no
-ruling prose.
+The judge's intent context is exactly the frozen check file, spec, job report, checkrun evidence file, and `docs/jobs/<issue-slug>-rulings.md`. The checkrun artifact `docs/jobs/<issue-slug>-checkrun.md` is committed before judge dispatch. The rulings file is orchestrator-owned, append-only, and committed before judge dispatch; if it is absent, there are no post-freeze rulings. Judge dispatch blocks carry no ruling prose.
 The issue is closed on merge. No verdict comment on an issue means the
 next factory block must not build on it as accepted; the orchestrator may re-run
 judgment with a fresh judge if evidence is missing, but may not fill in a

--- a/tests/fixtures/checkrun/config-bash.json
+++ b/tests/fixtures/checkrun/config-bash.json
@@ -1,0 +1,1 @@
+{"check_file":"tests/fixtures/checkrun/fixture-checks-bash.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-fixture-bash.md","executor":"bash","max_output_lines":60}

--- a/tests/fixtures/checkrun/config-missing.json
+++ b/tests/fixtures/checkrun/config-missing.json
@@ -1,0 +1,1 @@
+{"check_file":"tests/fixtures/checkrun/DOES-NOT-EXIST.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-missing.md","executor":"powershell","max_output_lines":60}

--- a/tests/fixtures/checkrun/config-ps.json
+++ b/tests/fixtures/checkrun/config-ps.json
@@ -1,0 +1,1 @@
+{"check_file":"tests/fixtures/checkrun/fixture-checks-ps.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-fixture-ps.md","executor":"powershell","max_output_lines":60}

--- a/tests/fixtures/checkrun/fixture-checks-bash.md
+++ b/tests/fixtures/checkrun/fixture-checks-bash.md
@@ -1,0 +1,13 @@
+# Fixture Checks: Bash
+
+Executor: bash
+
+## Fixture
+
+- RUN: `git --version` -> records git version.
+- RUN: `seq 1 100` -> truncation exercise.
+- RUN: `exit 3` -> records exit 3.
+
+This markerless prose span must not run: `touch tests/fixtures/checkrun/TRAP.txt`.
+
+- Quote: the runner records evidence only.

--- a/tests/fixtures/checkrun/fixture-checks-ps.md
+++ b/tests/fixtures/checkrun/fixture-checks-ps.md
@@ -1,0 +1,13 @@
+# Fixture Checks: PowerShell
+
+Executor: powershell
+
+## Fixture
+
+- RUN: `git --version` -> records git version.
+- RUN: `1..100 | ForEach-Object { $_ }` -> truncation exercise.
+- RUN: `powershell -NoProfile -Command "exit 3"` -> records exit 3.
+
+This markerless prose span must not run: `New-Item tests/fixtures/checkrun/TRAP.txt -ItemType File`.
+
+- Quote: the runner records evidence only.

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -32,6 +32,8 @@ REQUIRED_SIBLINGS = {
         "watchdog.sh",
         "status.ps1",
         "status.sh",
+        "check-runner.ps1",
+        "check-runner.sh",
         "tracker.md",
     ],
     "architect-research": ["tactics.md"],
@@ -251,6 +253,30 @@ def check_judge_template() -> None:
             errors.append(f"skills/architect/dispatch.md: C5 judge template missing {required}")
     if "must not add slice-specific prose" not in text:
         errors.append("skills/architect/dispatch.md: C5 template does not forbid slice-specific prose")
+
+
+def check_check_runner_dispatch_contract() -> None:
+    dispatch = SKILLS / "architect" / "dispatch.md"
+    if not dispatch.exists():
+        errors.append("skills/architect/dispatch.md: missing (required for check-runner dispatch contract)")
+        return
+    text = read_text(dispatch)
+    if "## Check-runner dispatch" not in text.splitlines():
+        errors.append("skills/architect/dispatch.md: missing ## Check-runner dispatch")
+    for marker in ("architect-judge-template", "architect-codex-judge-template"):
+        start = f"<!-- {marker}:start -->"
+        end = f"<!-- {marker}:end -->"
+        start_at = text.find(start)
+        end_at = text.find(end, start_at + len(start))
+        if start_at == -1 or end_at == -1:
+            errors.append(f"skills/architect/dispatch.md: missing {marker} marker block")
+            continue
+        block = text[start_at + len(start) : end_at]
+        if "re-run at least one RUN command" not in block:
+            errors.append(
+                "skills/architect/dispatch.md: "
+                f"{marker} missing re-run at least one RUN command"
+            )
 
 
 PADDED_TOOLS = ("Bash", "Read", "PowerShell")
@@ -482,6 +508,7 @@ def main() -> int:
     check_model_alias_table()
     check_config_example()
     check_judge_template()
+    check_check_runner_dispatch_contract()
     check_agent_definitions()
     check_codex_install_step()
     check_watchdog_contract()


### PR DESCRIPTION
Closes #62

## check-runner: deterministic check execution; the judge grades evidence

Factory run on `factory/judge-runner`, spec `docs/spec/judge-runner.md` (approved in-session, verbatim record in the spec). Frozen checks at `1473c78` (post-grill re-freeze), all four slices judged by fresh cold judges before merge.

**Shipped issues:**
- #63 jr-runner — `skills/architect/check-runner.ps1`/`.sh` + pinned fixtures. Deterministic, non-grading (frozen negative grep proves zero PASS/FAIL/INVALID strings), temp-write-then-move evidence, typed exits 0/5. Judged by a Claude-backend judge running the bash side under real Git Bash.
- #64 jr-wiring — `- RUN:` grammar (normative), `## Check-runner dispatch` section, both judge templates now grade the committed checkrun evidence file with a mandatory spot-check re-run (mismatch = INVALID), loop.md On-DONE ordering (config → runner → evidence commit → judge), SKILL.md Hard Rule 3 clause. First judgment FAILed diff-vs-intent on a placeholder-enumeration gap; one respawn fixed it (rulings in `docs/jobs/jr-wiring-rulings.md`).
- #65 jr-validator — validator enforces runner siblings + dispatch anchors; V4 negative test proves the contract fails loudly when a runner script is missing.
- #66 jr-docs — README judging-flow update, DESIGN.md evidence subsection (135 mechanical items motivation, script-not-LLM rationale, D12 consequence), `docs/solutions/judge-checkrun-offload.md`.

**Why:** judges inherit the orchestrator model; measured across the 15 existing frozen check files, ~90% of judge activity (135 `command → expected` items) was mechanical execution billed at frontier prices. Execution now costs zero LLM tokens; the judge reads one evidence file, grades, spot-checks, and rules on diff-vs-intent. Bonus: execution happens outside subagent sandboxes, so shell-dependent checks no longer force cross-family codex judges (D12).

**Residual risks / notes:** RUN grammar is prospective (spec A1) — the 15 pre-existing check files keep the old judge path. First live use of the runner-fed judge path will be the next factory run; watch the first checkrun evidence file against D3.

Run scorecard: 4/4 slices shipped, 1 judge FAIL → 1 respawn (#64), 0 KILLs, grill caught 4 decomposition defects pre-freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
