### PR TITLE
skill: timed-ruling protocol - no more permanent hangs on human questions

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -74,9 +74,11 @@ known from tool evidence.
 
 Orchestrator explores the request and repo, then asks at most about five questions in
 one batch. Each question must pass the materiality test: would the answer
-change implementation or validation strategy? Unanswered questions become
-recorded `## Assumptions` in the spec, using the orchestrator's recommended
-option.
+change implementation or validation strategy? Ask the batch through the
+timed-ruling protocol (`### 2. Spec Approval`) — plaintext options plus the
+5-minute timer, never a blocking question UI. Questions unanswered at timer
+expiry become recorded `## Assumptions` in the spec, using the orchestrator's
+recommended option.
 
 Preflight is tracker-conditional (see `tracker.md` `## Preflight per mode`):
 github mode requires a GitHub remote, passing `gh auth status`, and `gh` >=
@@ -111,7 +113,7 @@ or vetoes assumptions, and approves or rejects the plan. Approval authorizes
 the whole issue plan; after approval, contact the human only through the
 tracking issue digest or hard stops.
 
-Approval has exactly two explicit forms:
+Approval has exactly three forms:
 
 - In-session approval: the human explicitly authorizes the run in the current
   session, including the invocation itself. Record that authorization VERBATIM
@@ -119,23 +121,45 @@ Approval has exactly two explicit forms:
 - Tracking-issue approval: the repo owner comments on the tracking issue with
   exactly `APPROVE`, or `APPROVE with edits: <text>`. A repo-owner comment
   beginning exactly `REJECT <reason>` rejects the plan.
+- Timer approval: the approval request was asked through the timed-ruling
+  protocol and the timer expired with no reply in-session or on the tracker;
+  the orchestrator proceeds with the recommended plan and records
+  `APPROVE (auto, 5m silence)` plus its reasoning in the approval record for
+  after-the-fact veto.
 
-Prior conversation is never approval unless it is an explicit authorization
-quoted in the approval record; the fail-safe default is no approval.
+Approval is never inferred from prior conversation or context; only these
+three recorded forms count.
 
-If the human is absent, ask in-session and wait about 5 minutes: use the
-harness ~60s prompt, schedule one ~4-minute recheck, then rule with the
-orchestrator's best judgment, record the ruling and reasoning on the tracking
-issue for after-the-fact veto, and continue. This applies to every human question
-in the loop, including spec approval, oddity escalations, and rail rulings. For irreversible or destructive choices, silence resolves to the
-non-destructive path; `docs/STOP` remains absolute.
+Every question the loop asks a human uses the timed-ruling protocol, whether
+or not the human seems present. Never ask through a blocking question UI
+(AskUserQuestion / ask_user_question): no harness times those out, so an
+absent human hangs the factory permanently. Instead:
+
+1. Print the question, numbered options, and the recommended default as plain
+   text in-session, and record the same text as a `RULING PENDING` tracker
+   comment naming the default.
+2. Arm a ~5-minute timer and end the turn: on the Claude harness a detached
+   background `sleep 300` whose exit wakes the orchestrator (the watchdog
+   primitive); on backends without background-exit wakes, a foreground sleep
+   with the shell timeout raised above 300s.
+3. Human answer first: apply it and kill the timer; a timer wake for an
+   already-resolved ruling is a no-op. Timer first, with no answer in-session
+   or on the tracker: apply the recommended default, record
+   `RULING (auto, 5m silence): <decision> - <why>` on the tracking issue for
+   after-the-fact veto, and continue.
+
+This applies to every human question in the loop: intake questions, spec
+approval, oddity escalations, and rail rulings. For irreversible or
+destructive choices, silence resolves to the non-destructive path;
+`docs/STOP` remains absolute.
 
 On approval, cut `factory/<run>`. ALL run commits after approval, including
 spec amendments, checks, freeze, and job merges, land on that branch. Main stays
 untouched until the single closing PR.
 
-Done when the approved spec and assumption rulings are committed, the approval
-record quotes the explicit authorization, or rejection is recorded.
+Done when the approved spec and assumption rulings are committed and the
+approval record quotes the explicit authorization or the timer-approval
+entry, or rejection is recorded.
 
 ### 3. Decompose
 

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -36,6 +36,10 @@ Parallel rules: harness-native judge subagents (Claude Agent tool) dispatch sync
      healthy-long-run (redispatch the monitor, sleep again), needs a nudge
      or answer, or wedged (kill the job, discard its worktree, respawn
      from the frozen check with a route-around).
+   - **Ruling timer expiry.** A pending timed ruling's timer exit is a wake:
+     if the ruling is still unanswered in-session and on the tracker, apply
+     the recommended default and record the auto-ruling (timed-ruling
+     protocol, SKILL.md "### 2. Spec Approval"); already resolved is a no-op.
 4. **Recompute the ready issues.** Closing an issue may unblock others;
    recompute and dispatch the next wave.
 5. **Repeat** until no issues remain open, then post the escalation


### PR DESCRIPTION
## Problem

The orchestrator hangs permanently when it asks a mid-run ruling via the harness question UI (AskUserQuestion) and the human is away. Research across both harnesses confirmed no native timeout exists:

- **Claude Code** (terminal + desktop): AskUserQuestion never times out; hooks cannot answer it (feature requests #12605/#15872/#28273 closed not-planned); only the Agent SDK `canUseTool` callback can answer programmatically.
- **Codex**: `ask_user_question`/`request_user_input` are Plan-mode-only and stripped entirely from `codex exec`; no timeout config; `notify` is one-way.

The old SKILL.md text relied on a "harness ~60s prompt" that does not exist.

## Change

Timed-ruling protocol, applied to EVERY human question in the loop (intake batch, spec approval, oddity escalations, rail rulings), whether or not the human seems present:

1. Ask as plaintext options + recommended default, mirrored as a `RULING PENDING` tracker comment. Blocking question UIs are banned.
2. Arm a ~5-minute timer and end the turn: detached background `sleep 300` whose exit wakes the orchestrator (same primitive as the watchdog); backends without background-exit wakes use a foreground sleep with a raised shell timeout.
3. Human answer first: apply it, kill the timer; a stale timer wake is a no-op. Timer first: apply the recommended default and record `RULING (auto, 5m silence): <decision> - <why>` for after-the-fact veto.

Spec approval gains an explicit third form — **Timer approval**: silence past the timer proceeds with the recommended plan, recorded as `APPROVE (auto, 5m silence)` in the approval record. Approval is still never inferred from prior conversation; irreversible/destructive choices still resolve to the non-destructive path; `docs/STOP` remains absolute.

`loop.md` registers **Ruling timer expiry** as a wake event with the idempotence rule.

## Validation

- `uv run python tests/validate_skills.py` → `OK - 2 skills validated, v4 contracts clean`
- `install.ps1` re-run; live Claude and Codex skill trees synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
