### PR TITLE
script-hardening: postflight lane commit, path anchoring, cleanup resilience

### DIFF
--- a/docs/checks/script-hardening/harden.md
+++ b/docs/checks/script-hardening/harden.md
@@ -1,0 +1,36 @@
+# Frozen check: script-hardening harden
+
+Purpose: postflight commits dirty lanes and refuses no-op merges on EVERY
+path (dirty worktree, clean worktree, no worktree); relative config paths
+anchor to repo_root; cleanup survives held directories with
+`cleanup=deferred` instead of a false exit 5; the solutions note records the
+unattributed cwd-drift cause and the new safety net.
+
+Spec pointer: docs/spec/script-hardening.md. Interface contract: issue body
+of the harden sub-issue under tracking issue #95.
+
+Fix contract: FAIL evidence routes to the orchestrator, who fixes the input
+and respawns; the builder never edits this file. Report path:
+docs/jobs/script-hardening/harden-01.md.
+
+Executor: PowerShell (primary; Windows codex sandbox kills Git Bash with
+Win32 error 5). Recorded same-pattern substitution is permitted per check.
+Sanctioned if the default uv cache is denied: PowerShell
+`$env:UV_CACHE_DIR='.architect/tmp/uv-cache'` (POSIX form
+`UV_CACHE_DIR=.architect/tmp/uv-cache`). Judges in a no-network sandbox pick
+network-free RUN items to re-run and record the substitution.
+
+- RUN: `uv run python tests/validate_skills.py` -> exit 0, output contains "OK". Duration hint ~1m (baseline ~2s; the new fixture builds throwaway git repos).
+- RUN: `git grep -F -c "check_postflight_lane_fixture" -- tests/validate_skills.py` -> matches >= 1 (the postflight fixture test exists under its pinned name).
+- RUN: `git grep -F -c "cleanup=deferred" -- skills/architect/postflight.ps1` -> matches >= 1.
+- RUN: `git grep -F -c "cleanup=deferred" -- skills/architect/postflight.sh` -> matches >= 1.
+- RUN: `git grep -F -c "cleanup=deferred" -- skills/architect/dispatch.md` -> matches >= 1 (typed-exit table documents the form).
+- RUN: `git grep -F -c "cleanup=deferred" -- docs/solutions/worktree-cleanup-locks.md` -> matches >= 1 (safety net documented for future operators).
+- RUN: `git grep -F -c "no commits beyond freeze" -- skills/architect/postflight.ps1 skills/architect/postflight.sh` -> matches in BOTH files; `git grep -c` exits 0 when only one file matches, so grade from the per-file output lines.
+- Judge-only: postflight (BOTH languages) commits a dirty configured worktree (`add -A` + commit with the `(lane)` message suffix) BEFORE the touch-set audit, and AFTER that step exits 5 with the no-commits-beyond-freeze error whenever the job tip still equals freeze_sha (covers clean-worktree and no-worktree paths — no silent no-op merge survives). Cite file:line in each.
+- Judge-only: `check_postflight_lane_fixture` proves (a) dirty lane -> lane committed, merged, exit 0, factory head advanced; (b) a RELATIVE worktree config path resolves against repo_root and the worktree is removed even when the test process cwd is elsewhere; (c) job tip == freeze_sha -> exit 5 with the pinned message. Cite the assertions by line.
+- Judge-only: FullPath (postflight.ps1, preflight.ps1) and abs_path (postflight.sh, preflight.sh) anchor relative paths to the resolved repo_root, not the caller cwd. Cite file:line in all four.
+- Judge-only: worktree removal path: retry after a delay, then `--force`, then `cleanup=deferred <path>` on the OK line with exit 0; a completed merge+push never exits 5 for cleanup alone. Cite file:line in both languages.
+- Judge-only: docs/solutions/worktree-cleanup-locks.md records the session-cwd drift cause as unattributed (scripts audited clean) and keeps the existing mitigations. Cite line.
+- Judge-only: loop.md close-out (or dispatch.md) names killing lingering codex children of a consumed exec before postflight. Cite file:line.
+- Judge-only: net non-blank additions across the five capped skill-text files (SKILL.md, tracker.md, dispatch.md, loop.md, research.md) <= 12 (measured 1088/1100 pre-build). Cite before/after counts from the job report.

--- a/docs/jobs/script-hardening/harden-01.md
+++ b/docs/jobs/script-hardening/harden-01.md
@@ -1,0 +1,173 @@
+# script-hardening/harden-01
+
+## PHASE 0
+
+Input verification command exit code: 0
+
+```text
+HEAD=10a73c755d0a9ef2dfca3b748bd34dc18c89eb94
+CHECK_EXISTS=True
+```
+
+Plan:
+
+1. Update only the allowed implementation/doc/test files plus the required report file.
+2. In both preflight scripts, change relative FullPath / abs_path anchoring to the resolved repo_root.
+3. In both postflight scripts, add dirty-lane git add -A and git commit -m "<merge_message> (lane)" before the freeze diff.
+4. In both postflight scripts, add the no-op guard after the lane commit and before the touch-set audit.
+5. In both postflight scripts, replace cleanup hard-fail with retry, delay, force remove, branch-delete best effort, and cleanup=deferred <path> in the OK line.
+6. Make in-place skill-text edits in dispatch.md and loop.md.
+7. Update docs/solutions/worktree-cleanup-locks.md without removing existing mitigations.
+8. Add check_postflight_lane_fixture to tests/validate_skills.py.
+9. Run the frozen RUN items sequentially and write this report.
+10. Resume fix: replace the postflight lane fixture's bare rmtree cleanup with a read-only-clearing rmtree handler, then rerun the validator.
+
+Disagreements / input conflicts:
+
+- BOUNDARIES omitted docs/jobs/script-hardening/harden-01.md, but docs/checks/script-hardening/harden.md requires that report path.
+- No other disagreements recorded.
+
+Resume validator fix:
+
+```text
+tests/validate_skills.py now deletes the postflight lane fixture with shutil.rmtree(..., onexc=handler). The handler chmods failed paths writable and retries the delete, covering read-only .git object files on Windows.
+```
+
+## Counts
+
+Before:
+
+```text
+skills/architect/SKILL.md	255
+skills/architect/tracker.md	66
+skills/architect/dispatch.md	572
+skills/architect/loop.md	120
+skills/architect/research.md	75
+TOTAL	1088
+```
+
+After:
+
+```text
+skills/architect/SKILL.md	255
+skills/architect/tracker.md	66
+skills/architect/dispatch.md	572
+skills/architect/loop.md	121
+skills/architect/research.md	75
+TOTAL	1089
+```
+
+## RUN git grep fixture name
+
+Command:
+
+```text
+git grep -F -c "check_postflight_lane_fixture" -- tests/validate_skills.py
+```
+
+Exit code: 0
+
+```text
+tests/validate_skills.py:2
+```
+
+## RUN grep cleanup ps1
+
+Command:
+
+```text
+git grep -F -c "cleanup=deferred" -- skills/architect/postflight.ps1
+```
+
+Exit code: 0
+
+```text
+skills/architect/postflight.ps1:1
+```
+
+## RUN grep cleanup sh
+
+Command:
+
+```text
+git grep -F -c "cleanup=deferred" -- skills/architect/postflight.sh
+```
+
+Exit code: 0
+
+```text
+skills/architect/postflight.sh:1
+```
+
+## RUN grep cleanup dispatch
+
+Command:
+
+```text
+git grep -F -c "cleanup=deferred" -- skills/architect/dispatch.md
+```
+
+Exit code: 0
+
+```text
+skills/architect/dispatch.md:1
+```
+
+## RUN grep cleanup solutions
+
+Command:
+
+```text
+git grep -F -c "cleanup=deferred" -- docs/solutions/worktree-cleanup-locks.md
+```
+
+Exit code: 0
+
+```text
+docs/solutions/worktree-cleanup-locks.md:1
+```
+
+## RUN grep no commits
+
+Command:
+
+```text
+git grep -F -c "no commits beyond freeze" -- skills/architect/postflight.ps1 skills/architect/postflight.sh
+```
+
+Exit code: 0
+
+```text
+skills/architect/postflight.ps1:1
+skills/architect/postflight.sh:1
+```
+
+## RUN validate skills
+
+Command:
+
+```text
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'
+uv run python tests/validate_skills.py
+```
+
+Exit code: 0
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+## Commands not run
+
+```text
+sh skills/architect/postflight.sh <validator fixture config>
+sh skills/architect/preflight.sh <config>
+```
+
+```text
+Windows sandbox policy forbids Git Bash/MSYS2 startup here; .sh pair authored by pattern parity and verified through the platform-native .ps1 fixture plus reading.
+```
+
+MIRROR: ORCHESTRATOR
+
+STATUS: COMPLETE_WITH_CONCERNS (validator passed after read-only rmtree retry; BOUNDARIES omitted the required report path; shell .sh execution not run in this Windows sandbox per policy)

--- a/docs/jobs/script-hardening/harden-checkrun.md
+++ b/docs/jobs/script-hardening/harden-checkrun.md
@@ -1,0 +1,59 @@
+﻿# Checkrun: harden-checkrun
+generated: 2026-07-05T19:07:36.8961844Z  runner: ps1  config: C:\Users\danhm\tools\architect-loop\.architect\checkrun-harden.json
+check_file: docs/checks/script-hardening/harden.md  freeze_sha: 10a73c755d0a9ef2dfca3b748bd34dc18c89eb94
+Executor: PowerShell (primary; Windows codex sandbox kills Git Bash with
+executor_config: powershell
+executor_resolved: powershell
+integrity: check_file_matches_freeze=true head=10a73c755d0a9ef2dfca3b748bd34dc18c89eb94
+changed_files: 0 listed below; docs_checks_touched=false
+
+## (root) line 23
+$ uv run python tests/validate_skills.py
+exit: 1  ms: 2312  bytes: 1333
+Traceback (most recent call last):
+  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 920, in <module>
+    sys.exit(main())
+             ^^^^^^
+  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 901, in main
+    check_postflight_lane_fixture()
+  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 724, in check_postflight_lane_fixture
+    shutil.rmtree(base)
+  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 781, in rmtree
+    return _rmtree_unsafe(path, onexc)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 635, in _rmtree_unsafe
+    onexc(os.unlink, fullname, err)
+  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 633, in _rmtree_unsafe
+    os.unlink(fullname)
+PermissionError: [WinError 5] Access is denied: 'C:\\Users\\danhm\\tools\\architect-loop\\.architect\\wt\\script-hardening\\harden-01\\.architect\\tmp\\postflight-lane-fixture\\lane\\repo\\.git\\objects\\06\\694fcf71ec9569e412d98748f4e9a53e0faf28'
+
+## (root) line 24
+$ git grep -F -c "check_postflight_lane_fixture" -- tests/validate_skills.py
+exit: 0  ms: 442  bytes: 27
+tests/validate_skills.py:2
+
+## (root) line 25
+$ git grep -F -c "cleanup=deferred" -- skills/architect/postflight.ps1
+exit: 0  ms: 370  bytes: 34
+skills/architect/postflight.ps1:1
+
+## (root) line 26
+$ git grep -F -c "cleanup=deferred" -- skills/architect/postflight.sh
+exit: 0  ms: 393  bytes: 33
+skills/architect/postflight.sh:1
+
+## (root) line 27
+$ git grep -F -c "cleanup=deferred" -- skills/architect/dispatch.md
+exit: 0  ms: 383  bytes: 31
+skills/architect/dispatch.md:1
+
+## (root) line 28
+$ git grep -F -c "cleanup=deferred" -- docs/solutions/worktree-cleanup-locks.md
+exit: 0  ms: 413  bytes: 43
+docs/solutions/worktree-cleanup-locks.md:1
+
+## (root) line 29
+$ git grep -F -c "no commits beyond freeze" -- skills/architect/postflight.ps1 skills/architect/postflight.sh
+exit: 0  ms: 387  bytes: 67
+skills/architect/postflight.ps1:1
+skills/architect/postflight.sh:1

--- a/docs/jobs/script-hardening/harden-checkrun.md
+++ b/docs/jobs/script-hardening/harden-checkrun.md
@@ -1,5 +1,5 @@
 ﻿# Checkrun: harden-checkrun
-generated: 2026-07-05T19:07:36.8961844Z  runner: ps1  config: C:\Users\danhm\tools\architect-loop\.architect\checkrun-harden.json
+generated: 2026-07-05T19:17:12.4361317Z  runner: ps1  config: C:\Users\danhm\tools\architect-loop\.architect\checkrun-harden.json
 check_file: docs/checks/script-hardening/harden.md  freeze_sha: 10a73c755d0a9ef2dfca3b748bd34dc18c89eb94
 Executor: PowerShell (primary; Windows codex sandbox kills Git Bash with
 executor_config: powershell
@@ -9,51 +9,36 @@ changed_files: 0 listed below; docs_checks_touched=false
 
 ## (root) line 23
 $ uv run python tests/validate_skills.py
-exit: 1  ms: 2312  bytes: 1333
-Traceback (most recent call last):
-  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 920, in <module>
-    sys.exit(main())
-             ^^^^^^
-  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 901, in main
-    check_postflight_lane_fixture()
-  File "C:\Users\danhm\tools\architect-loop\.architect\wt\script-hardening\harden-01\tests\validate_skills.py", line 724, in check_postflight_lane_fixture
-    shutil.rmtree(base)
-  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 781, in rmtree
-    return _rmtree_unsafe(path, onexc)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 635, in _rmtree_unsafe
-    onexc(os.unlink, fullname, err)
-  File "C:\Users\danhm\AppData\Roaming\uv\python\cpython-3.12.4-windows-x86_64-none\Lib\shutil.py", line 633, in _rmtree_unsafe
-    os.unlink(fullname)
-PermissionError: [WinError 5] Access is denied: 'C:\\Users\\danhm\\tools\\architect-loop\\.architect\\wt\\script-hardening\\harden-01\\.architect\\tmp\\postflight-lane-fixture\\lane\\repo\\.git\\objects\\06\\694fcf71ec9569e412d98748f4e9a53e0faf28'
+exit: 0  ms: 3922  bytes: 45
+OK - 2 skills validated, v4 contracts clean
 
 ## (root) line 24
 $ git grep -F -c "check_postflight_lane_fixture" -- tests/validate_skills.py
-exit: 0  ms: 442  bytes: 27
+exit: 0  ms: 548  bytes: 27
 tests/validate_skills.py:2
 
 ## (root) line 25
 $ git grep -F -c "cleanup=deferred" -- skills/architect/postflight.ps1
-exit: 0  ms: 370  bytes: 34
+exit: 0  ms: 448  bytes: 34
 skills/architect/postflight.ps1:1
 
 ## (root) line 26
 $ git grep -F -c "cleanup=deferred" -- skills/architect/postflight.sh
-exit: 0  ms: 393  bytes: 33
+exit: 0  ms: 398  bytes: 33
 skills/architect/postflight.sh:1
 
 ## (root) line 27
 $ git grep -F -c "cleanup=deferred" -- skills/architect/dispatch.md
-exit: 0  ms: 383  bytes: 31
+exit: 0  ms: 407  bytes: 31
 skills/architect/dispatch.md:1
 
 ## (root) line 28
 $ git grep -F -c "cleanup=deferred" -- docs/solutions/worktree-cleanup-locks.md
-exit: 0  ms: 413  bytes: 43
+exit: 0  ms: 627  bytes: 43
 docs/solutions/worktree-cleanup-locks.md:1
 
 ## (root) line 29
 $ git grep -F -c "no commits beyond freeze" -- skills/architect/postflight.ps1 skills/architect/postflight.sh
-exit: 0  ms: 387  bytes: 67
+exit: 0  ms: 397  bytes: 67
 skills/architect/postflight.ps1:1
 skills/architect/postflight.sh:1

--- a/docs/jobs/script-hardening/harden-rulings.md
+++ b/docs/jobs/script-hardening/harden-rulings.md
@@ -1,0 +1,13 @@
+# Rulings: script-hardening/harden (issue #96)
+
+Append-only; orchestrator-owned.
+
+- 2026-07-05 RULING on PHASE-0 item 1 (report path outside MAY TOUCH):
+  docs/jobs/<run>/ artifacts are exempt bookkeeping (standing ruling from run
+  multi-run, docs/jobs/multi-run/s2-skilltext-rulings.md). Not a violation.
+- 2026-07-05 RULING on concern 2 (.sh pair not executed in the Windows codex
+  sandbox): sanctioned - the dispatch block itself set that policy (MSYS2
+  binaries die under the sandbox token, Win32 error 5). The .ps1 path is
+  executed by the fixture; .sh parity is by pattern review here and covered
+  on POSIX by the same fixture (platform-native selection). Judges in the
+  same sandbox grade .sh by reading and record the substitution.

--- a/docs/jobs/script-hardening/harden-rulings.md
+++ b/docs/jobs/script-hardening/harden-rulings.md
@@ -11,3 +11,9 @@ Append-only; orchestrator-owned.
   executed by the fixture; .sh parity is by pattern review here and covered
   on POSIX by the same fixture (platform-native selection). Judges in the
   same sandbox grade .sh by reading and record the substitution.
+- 2026-07-05 RULING after first judge FAIL (validator gate): fixture cleanup
+  must clear the read-only bit before unlink - Python 3.12
+  `shutil.rmtree(path, onexc=<chmod S_IWRITE then retry>)`. Bare
+  shutil.rmtree on any directory containing a .git is forbidden in tests.
+  Fix routed via respawn-with-answer on the same issue, same tier (first
+  FAIL on the failure ladder). Checks unchanged.

--- a/docs/runs/script-hardening/manifest.md
+++ b/docs/runs/script-hardening/manifest.md
@@ -4,7 +4,7 @@ tracking-issue: 95
 factory-branch: factory/script-hardening
 tracker: github
 spec: docs/spec/script-hardening.md
-state: ACTIVE
+state: FINISHED
 created: 2026-07-05
 ---
 

--- a/docs/runs/script-hardening/manifest.md
+++ b/docs/runs/script-hardening/manifest.md
@@ -1,0 +1,13 @@
+---
+run: script-hardening
+tracking-issue: 95
+factory-branch: factory/script-hardening
+tracker: github
+spec: docs/spec/script-hardening.md
+state: ACTIVE
+created: 2026-07-05
+---
+
+Run manifest for architect run `script-hardening`: postflight/preflight
+integration fixes from run multi-run's residual risks. Stacked on
+factory/multi-run (PR #94).

--- a/docs/solutions/worktree-cleanup-locks.md
+++ b/docs/solutions/worktree-cleanup-locks.md
@@ -19,6 +19,10 @@ path is ambiguous when the orchestrator shell's cwd drifts between events. On
 Windows, a directory cannot be removed while a shell or child process still has
 it as cwd or holds an open handle under it.
 
+The session-cwd drift cause remains unattributed after code audit:
+check-runner uses per-process `WorkingDirectory`, preflight/postflight never
+change location, and status.ps1 balances Push/Pop.
+
 ## What Did Not Work
 
 - Assuming relative `worktree` paths were repo-root-relative.
@@ -35,3 +39,6 @@ it as cwd or holds an open handle under it.
   command.
 - Kill the holder, retry worktree removal, and use piecemeal child deletion only
   to isolate which path remains locked.
+- Postflight now retries `git worktree remove`, then retries with `--force`,
+  then reports `cleanup=deferred <path>` on the OK line instead of failing a
+  completed merge for cleanup alone.

--- a/docs/spec/script-hardening.md
+++ b/docs/spec/script-hardening.md
@@ -1,0 +1,88 @@
+# Spec: script-hardening — postflight/preflight integration fixes
+
+Run slug: `script-hardening`. Tracker mode: github. Base: factory/multi-run
+(99ac31c); the fixes depend on the multi-run run's .gitignore and solutions
+notes. Closing PR stacks onto PR #94.
+
+## Problem (all observed live in run multi-run, 2026-07-05)
+
+1. postflight merges the job BRANCH; when the orchestrator has not committed
+   the builder's worktree changes, the merge silently no-ops (job tip ==
+   freeze SHA) and the only symptom is a misleading late
+   `POSTFLIGHT: ERROR worktree remove failed` (observed: S2 first attempt).
+2. `FullPath` in postflight.ps1:37 and preflight.ps1:50 anchors relative
+   config paths to the CALLER'S CWD, not `repo_root`; a relative `worktree`
+   entry then misses `Test-Path` and cleanup silently skips (violates the
+   no-silent-fallback rule). The .sh pair's `abs_path` needs the same audit.
+3. `git worktree remove` fails when anything holds the directory (observed:
+   lingering codex child processes twice; an unattributed session-cwd drift
+   once). No retry, no `--force` fallback; a SUCCESSFUL merge+push then
+   exits 5 as if integration failed.
+4. The #93 close comment blames check-runner for the session-cwd drift;
+   grill code audit exonerates it (per-process WorkingDirectory;
+   preflight/postflight never change location; status.ps1 balances
+   Push/Pop). Cause is unattributed; the orchestrator corrects the comment
+   on the tracker (not builder work). GRILL CORRECTIONS (pre-freeze): a
+   suspected `>\dev\null` defect in postflight.sh was falsified byte-level
+   (Grep display artifact); docs/solutions/worktree-cleanup-locks.md never
+   contained the check-runner attribution.
+
+## Goal
+
+postflight fails loudly and early on an uncommitted lane by committing it
+(matching the recorded manual fallback sequence, which includes
+`add -A; commit`); relative config paths anchor to `repo_root`; cleanup
+survives transient directory holds; the .sh/.ps1 pairs stay in parity; the
+solutions note tells the truth.
+
+## Design
+
+- D1 lane commit: when `worktree` is configured and its tree is dirty,
+  postflight runs `git add -A` + `git commit` in the worktree (message:
+  `<merge_message> (lane)`) BEFORE the touch-set audit, so the audit covers
+  the full lane. AFTER that step, if the job tip still equals `freeze_sha`
+  (no worktree, or worktree clean), exit 5 `POSTFLIGHT: ERROR job branch has
+  no commits beyond freeze` — no silent no-op merge survives on any path.
+  Scripts stay mechanical: no grading, no conflict resolution.
+- D2 path anchoring: `FullPath`/`abs_path` anchor relative paths to the
+  resolved `repo_root` in preflight and postflight, both languages.
+- D3 cleanup resilience: worktree remove retries once after ~2s, then falls
+  back to `git worktree remove --force`, then (still failing) emits
+  `POSTFLIGHT: OK merge=<sha> changed=<n> cleanup=deferred <path>` exit 0 —
+  a completed merge+push is OK with recorded deferred cleanup, not exit 5.
+  dispatch.md's typed-exit table row for postflight exit 0 gains the
+  `cleanup=deferred` form; loop.md/dispatch close-out gains: kill lingering
+  codex children of a consumed exec before postflight.
+- D4 docs/solutions/worktree-cleanup-locks.md: record the cwd-drift cause as
+  unattributed (audit exonerated the scripts) and document the new
+  mechanical safety net (retry / --force / cleanup=deferred).
+
+## Non-goals
+
+No changes to check-runner (exonerated), status scripts, watchdog, judge
+flow, or tracker conventions. No new typed exit codes.
+
+## Validation strategy
+
+- New fixture test in tests/validate_skills.py: temp git repo + worktree with
+  a dirty lane -> postflight commits the lane, merges, exits 0; relative
+  `worktree` path in config resolves against repo_root (worktree actually
+  removed); job-tip==freeze with no worktree -> exit 5 with the new message.
+  Platform-native script; both where available.
+- `uv run python tests/validate_skills.py` green; the new fixture test is
+  named `check_postflight_lane_fixture` so its presence is grep-provable.
+- Grep guards: `cleanup=deferred` present in postflight.ps1, postflight.sh,
+  dispatch.md, and the solutions note.
+
+## Domain language
+
+**lane commit** (postflight committing the builder's dirty worktree onto the
+job branch), **deferred cleanup** (merge OK, directory removal pending).
+
+## Approval record
+
+In-session approval, 2026-07-05: repo owner, verbatim: "can you just go fix
+those \"worth knowing\" issues" — authorizes this run including invocation.
+Design choices D1 (commit-the-lane over hard-error; matches the recorded
+manual fallback) and D3 (exit-0-with-deferred-cleanup over new exit code)
+are orchestrator-ruled; recorded here for after-the-fact veto.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -325,7 +325,7 @@ Typed exits:
 |---|---:|---|---|
 | preflight | 0 | `PREFLIGHT: OK` | worktree exists, HEAD equals `freeze_sha`, and every `require_files` path exists |
 | preflight | 5 | `PREFLIGHT: FAIL` | setup could not complete; record the line and fall back to the recorded manual sequence |
-| postflight | 0 | `POSTFLIGHT: OK` | touch-set audit, merge, optional push, and cleanup completed |
+| postflight | 0 | `POSTFLIGHT: OK` | touch-set audit, merge, optional push, and cleanup completed; may append `cleanup=deferred <path>` |
 | postflight | 2 | `POSTFLIGHT: VIOLATION` | automatic FAIL evidence for the job; do not merge |
 | postflight | 3 | `POSTFLIGHT: CONFLICT` | decomposition failure: kill the conflicting job and re-spec, per the existing rule |
 | postflight | 5 | `POSTFLIGHT: ERROR` | script/config/git error; abort partial merge state, then fall back to the recorded manual sequence |

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -89,7 +89,8 @@ fresh. The orchestrator never authors a missing verdict.
 Close-out: after consuming a subagent result or a background process's typed
 exit, stop or close that subagent or shell task in the same turn, batching
 independent close-outs into parallel calls; no polling and no per-close
-commentary. Kill any lingering job processes when a job is discarded.
+commentary. Before postflight, kill lingering codex children of any consumed
+exec; kill any lingering job processes when a job is discarded.
 
 ## Failure ladder
 

--- a/skills/architect/postflight.ps1
+++ b/skills/architect/postflight.ps1
@@ -34,7 +34,7 @@ function ErrorExit($Reason) {
 }
 function FullPath($Path) {
     if ([System.IO.Path]::IsPathRooted($Path)) { return [System.IO.Path]::GetFullPath($Path) }
-    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    return [System.IO.Path]::GetFullPath((Join-Path $script:RepoRoot $Path))
 }
 function PropString($Obj, $Name) {
     if (@($Obj.PSObject.Properties.Name) -contains $Name -and $Obj.$Name -ne $null) { return [string]$Obj.$Name }
@@ -86,6 +86,27 @@ if ($cat.Code -ne 0) { ErrorExit "freeze_sha not found" }
 $branch = GitRun -GitArgs @("-C", $script:RepoRoot, "show-ref", "--verify", "--quiet", "refs/heads/$job")
 if ($branch.Code -ne 0) { ErrorExit "job_branch not found" }
 
+$wt = ""
+if ($worktree) {
+    $wt = FullPath $worktree
+    if (-not (Test-Path -LiteralPath $wt -PathType Container)) { ErrorExit "worktree missing" }
+    $laneStatus = GitRun -GitArgs @("-C", $wt, "status", "--porcelain")
+    if ($laneStatus.Code -ne 0) { ErrorExit "worktree status failed" }
+    $laneDirty = @($laneStatus.Lines | Where-Object { [string]$_ -ne "" })
+    if ($laneDirty.Count -gt 0) {
+        $laneAdd = GitRun -GitArgs @("-C", $wt, "add", "-A")
+        if ($laneAdd.Code -ne 0) { ErrorExit "lane add failed" }
+        $laneCommit = GitRun -GitArgs @("-C", $wt, "commit", "-m", ($message + " (lane)"))
+        if ($laneCommit.Code -ne 0) { ErrorExit "lane commit failed" }
+    }
+}
+
+$freezeRev = GitRun -GitArgs @("-C", $script:RepoRoot, "rev-parse", $freeze)
+if ($freezeRev.Code -ne 0 -or @($freezeRev.Lines).Count -lt 1) { ErrorExit "freeze rev unavailable" }
+$jobRev = GitRun -GitArgs @("-C", $script:RepoRoot, "rev-parse", $job)
+if ($jobRev.Code -ne 0 -or @($jobRev.Lines).Count -lt 1) { ErrorExit "job rev unavailable" }
+if (([string]$jobRev.Lines[0]).Trim() -eq ([string]$freezeRev.Lines[0]).Trim()) { ErrorExit "job branch has no commits beyond freeze" }
+
 $diff = GitRun -GitArgs @("-C", $script:RepoRoot, "diff", "--name-only", ($freeze + ".." + $job))
 if ($diff.Code -ne 0) { ErrorExit "diff failed" }
 $changed = @($diff.Lines | Where-Object { [string]$_ -ne "" } | ForEach-Object { ([string]$_) -replace "\\", "/" })
@@ -113,16 +134,27 @@ if ($push) {
     $p = GitRun -GitArgs @("-C", $script:RepoRoot, "push", $remote, $factory)
     if ($p.Code -ne 0) { ErrorExit "push failed" }
 }
+$cleanupDeferred = $false
+$cleanupPath = ""
 if ($worktree) {
-    $wt = FullPath $worktree
     if (Test-Path -LiteralPath $wt) {
         $wr = GitRun -GitArgs @("-C", $script:RepoRoot, "worktree", "remove", $wt)
-        if ($wr.Code -ne 0) { ErrorExit "worktree remove failed" }
+        if ($wr.Code -ne 0) {
+            Start-Sleep -Seconds 2
+            $wr = GitRun -GitArgs @("-C", $script:RepoRoot, "worktree", "remove", $wt)
+        }
+        if ($wr.Code -ne 0) { $wr = GitRun -GitArgs @("-C", $script:RepoRoot, "worktree", "remove", "--force", $wt) }
+        if ($wr.Code -ne 0) {
+            $cleanupDeferred = $true
+            $cleanupPath = $wt
+        }
     }
 }
 $del = GitRun -GitArgs @("-C", $script:RepoRoot, "branch", "-d", $job)
 if ($del.Code -ne 0) { Write-Output "POSTFLIGHT: WARNING branch-delete $job" }
 $head = GitRun -GitArgs @("-C", $script:RepoRoot, "rev-parse", "HEAD")
 if ($head.Code -ne 0 -or @($head.Lines).Count -lt 1) { ErrorExit "merge sha unavailable" }
-Write-Output "POSTFLIGHT: OK merge=$(([string]$head.Lines[0]).Trim()) changed=$($changed.Count)"
+$okLine = "POSTFLIGHT: OK merge=$(([string]$head.Lines[0]).Trim()) changed=$($changed.Count)"
+if ($cleanupDeferred) { $okLine = "$okLine cleanup=deferred $cleanupPath" }
+Write-Output $okLine
 exit 0

--- a/skills/architect/postflight.sh
+++ b/skills/architect/postflight.sh
@@ -25,7 +25,7 @@ json_array(){
   ' "$cfg" | while IFS= read -r v; do json_unescape "$v"; printf '\n'; done
 }
 to_bash_path(){ case "$1" in [A-Za-z]:\\*) if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1"; else printf '%s' "$1"; fi;; *) printf '%s' "$1";; esac; }
-abs_path(){ p=$(to_bash_path "$1"); case "$p" in /*) printf '%s' "$p";; *) printf '%s/%s' "$(pwd -P)" "$p";; esac; }
+abs_path(){ p=$(to_bash_path "$1"); case "$p" in /*) printf '%s' "$p";; *) printf '%s/%s' "$repo_root" "$p";; esac; }
 add_tmp(){ tmp_files[${#tmp_files[@]}]=$1; }
 cleanup_tmp(){ for f in "${tmp_files[@]}"; do [ -n "$f" ] && rm -f "$f"; done; }
 trap cleanup_tmp EXIT
@@ -94,6 +94,22 @@ if in_merge; then err "merge in progress"; fi
 git_repo cat-file -e "$freeze_sha^{commit}" >/dev/null 2>&1 || err "freeze_sha not found"
 git_repo show-ref --verify --quiet "refs/heads/$job_branch" || err "job_branch not found"
 
+wt=
+if [ -n "$worktree" ]; then
+  wt=$(abs_path "$worktree")
+  [ -d "$wt" ] || err "worktree missing"
+  lane_status_tmp=$(make_tmp lane-status); add_tmp "$lane_status_tmp"
+  git -C "$wt" status --porcelain > "$lane_status_tmp" || err "worktree status failed"
+  if [ -s "$lane_status_tmp" ]; then
+    git -C "$wt" add -A || err "lane add failed"
+    git -C "$wt" commit -m "$merge_message (lane)" || err "lane commit failed"
+  fi
+fi
+
+freeze_rev=$(git_repo rev-parse "$freeze_sha") || err "freeze rev unavailable"
+job_rev=$(git_repo rev-parse "$job_branch") || err "job rev unavailable"
+if [ "$job_rev" = "$freeze_rev" ]; then err "job branch has no commits beyond freeze"; fi
+
 changed_tmp=$(make_tmp changed); add_tmp "$changed_tmp"
 violations_tmp=$(make_tmp violations); add_tmp "$violations_tmp"
 git_repo diff --name-only "$freeze_sha..$job_branch" > "$changed_tmp" || err "diff failed"
@@ -120,11 +136,26 @@ if ! git_repo merge --no-ff "$job_branch" -m "$merge_message" > "$merge_tmp" 2>&
 fi
 
 if [ "$push" = true ]; then git_repo push "$remote" "$factory_branch" >/dev/null 2>&1 || err "push failed"; fi
+cleanup_deferred=false
+cleanup_path=
 if [ -n "$worktree" ]; then
-  wt=$(abs_path "$worktree")
-  if [ -e "$wt" ]; then git_repo worktree remove "$wt" >/dev/null 2>&1 || err "worktree remove failed"; fi
+  if [ -e "$wt" ]; then
+    if ! git_repo worktree remove "$wt" >/dev/null 2>&1; then
+      sleep 2
+      if ! git_repo worktree remove "$wt" >/dev/null 2>&1; then
+        if ! git_repo worktree remove --force "$wt" >/dev/null 2>&1; then
+          cleanup_deferred=true
+          cleanup_path=$wt
+        fi
+      fi
+    fi
+  fi
 fi
 if ! git_repo branch -d "$job_branch" >/dev/null 2>&1; then printf 'POSTFLIGHT: WARNING branch-delete %s\n' "$job_branch"; fi
 merge_sha=$(git_repo rev-parse HEAD) || err "merge sha unavailable"
-printf 'POSTFLIGHT: OK merge=%s changed=%s\n' "$merge_sha" "$changed_count"
+if [ "$cleanup_deferred" = true ]; then
+  printf 'POSTFLIGHT: OK merge=%s changed=%s cleanup=deferred %s\n' "$merge_sha" "$changed_count" "$cleanup_path"
+else
+  printf 'POSTFLIGHT: OK merge=%s changed=%s\n' "$merge_sha" "$changed_count"
+fi
 exit 0

--- a/skills/architect/preflight.ps1
+++ b/skills/architect/preflight.ps1
@@ -47,7 +47,7 @@ function Fail($Reason) {
 
 function FullPath($Path) {
     if ([System.IO.Path]::IsPathRooted($Path)) { return [System.IO.Path]::GetFullPath($Path) }
-    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    return [System.IO.Path]::GetFullPath((Join-Path $script:RepoRoot $Path))
 }
 
 try {

--- a/skills/architect/preflight.sh
+++ b/skills/architect/preflight.sh
@@ -26,7 +26,7 @@ json_array(){
   ' "$cfg" | while IFS= read -r v; do json_unescape "$v"; printf '\n'; done
 }
 to_bash_path(){ case "$1" in [A-Za-z]:\\*) if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1"; else printf '%s' "$1"; fi;; *) printf '%s' "$1";; esac; }
-abs_path(){ p=$(to_bash_path "$1"); case "$p" in /*) printf '%s' "$p";; *) printf '%s/%s' "$(pwd -P)" "$p";; esac; }
+abs_path(){ p=$(to_bash_path "$1"); case "$p" in /*) printf '%s' "$p";; *) printf '%s/%s' "$repo_root" "$p";; esac; }
 git_repo(){ git -C "$repo_root" "$@"; }
 branch_exists(){ git_repo show-ref --verify --quiet "refs/heads/$1"; }
 cleanup_created(){

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -16,9 +16,12 @@ Run: python tests/validate_skills.py   (exit 0 = pass)
 
 from __future__ import annotations
 
+import json
 import re
 import os
+import shutil
 import subprocess
+import stat
 import sys
 from pathlib import Path
 
@@ -55,6 +58,14 @@ ARCHITECT_HANDOFF_FREE_FILES = [
     SKILLS / "architect" / "dispatch.md",
 ]
 errors: list[str] = []
+
+
+def rmtree_with_writable_retry(path: Path) -> None:
+    def clear_readonly_and_retry(func, failed_path, _excinfo):
+        os.chmod(failed_path, stat.S_IWRITE)
+        func(failed_path)
+
+    shutil.rmtree(path, onexc=clear_readonly_and_retry)
 
 
 def read_text(path: Path) -> str:
@@ -618,6 +629,168 @@ def run_status_fixture(repo_root: Path, run_slug: str | None, env: dict[str, str
     return stdout
 
 
+def git_fixture(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if check and result.returncode != 0:
+        errors.append(
+            "postflight fixture git failed "
+            f"git -C {repo_root} {' '.join(args)} exit {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def write_fixture_file(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def configure_fixture_repo(repo_root: Path) -> str | None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    init = subprocess.run(
+        ["git", "init", str(repo_root)],
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if init.returncode != 0:
+        errors.append(
+            "postflight fixture: git init failed "
+            f"exit {init.returncode}\nstdout:\n{init.stdout}\nstderr:\n{init.stderr}"
+        )
+        return None
+    git_fixture(repo_root, "config", "user.email", "postflight-fixture@example.invalid")
+    git_fixture(repo_root, "config", "user.name", "Postflight Fixture")
+    write_fixture_file(repo_root / "allowed.txt", "base\n")
+    git_fixture(repo_root, "add", "allowed.txt")
+    git_fixture(repo_root, "commit", "-m", "base")
+    git_fixture(repo_root, "branch", "-M", "factory")
+    freeze = git_fixture(repo_root, "rev-parse", "HEAD")
+    if freeze.returncode != 0:
+        return None
+    return freeze.stdout.strip()
+
+
+def platform_postflight_command(config: Path) -> list[str]:
+    if os.name == "nt":
+        return [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(SKILLS / "architect" / "postflight.ps1"),
+            "-Config",
+            str(config),
+        ]
+    return ["sh", str(SKILLS / "architect" / "postflight.sh"), str(config)]
+
+
+def run_postflight_fixture(config: Path, cwd: Path) -> subprocess.CompletedProcess[str] | None:
+    command = platform_postflight_command(config)
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=45,
+        )
+    except Exception as exc:
+        errors.append(f"postflight fixture: {' '.join(command)} raised {exc!r}")
+        return None
+
+
+def write_postflight_config(
+    path: Path,
+    repo_root: Path,
+    freeze: str,
+    job_branch: str,
+    worktree: str | None,
+) -> None:
+    cfg: dict[str, object] = {
+        "repo_root": str(repo_root),
+        "factory_branch": "factory",
+        "job_branch": job_branch,
+        "freeze_sha": freeze,
+        "merge_message": "Merge fixture job",
+        "may_touch": ["allowed.txt"],
+        "push": False,
+    }
+    if worktree is not None:
+        cfg["worktree"] = worktree
+    write_fixture_file(path, json.dumps(cfg, indent=2))
+
+
+def check_postflight_lane_fixture() -> None:
+    base = ROOT / ".architect" / "tmp" / "postflight-lane-fixture"
+    if base.exists():
+        rmtree_with_writable_retry(base)
+    base.mkdir(parents=True)
+
+    lane_repo = base / "lane" / "repo"
+    lane_worktree = base / "lane" / "worktrees" / "job"
+    elsewhere = base / "elsewhere"
+    elsewhere.mkdir(parents=True)
+    freeze = configure_fixture_repo(lane_repo)
+    if freeze is None:
+        return
+    git_fixture(lane_repo, "worktree", "add", "-b", "job", str(lane_worktree), freeze)
+    write_fixture_file(lane_worktree / "allowed.txt", "lane\n")
+    lane_config = base / "configs" / "lane.json"
+    write_postflight_config(lane_config, lane_repo, freeze, "job", "../worktrees/job")
+
+    lane = run_postflight_fixture(lane_config, elsewhere)
+    if lane is not None:
+        stdout = lane.stdout.replace("\r\n", "\n")
+        stderr = lane.stderr.replace("\r\n", "\n")
+        if lane.returncode != 0:
+            errors.append(
+                "postflight fixture dirty lane: command failed "
+                f"exit {lane.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        if "POSTFLIGHT: OK merge=" not in stdout:
+            errors.append(f"postflight fixture dirty lane: missing OK line\nstdout:\n{stdout}")
+        if lane_worktree.exists():
+            errors.append("postflight fixture dirty lane: relative worktree was not removed")
+        head = git_fixture(lane_repo, "rev-parse", "factory")
+        if head.returncode == 0 and head.stdout.strip() == freeze:
+            errors.append("postflight fixture dirty lane: factory head did not advance")
+        log = git_fixture(lane_repo, "log", "--format=%s")
+        if log.returncode == 0 and "Merge fixture job (lane)" not in log.stdout:
+            errors.append("postflight fixture dirty lane: lane commit message missing")
+        content = (lane_repo / "allowed.txt").read_text(encoding="utf-8")
+        if content != "lane\n":
+            errors.append("postflight fixture dirty lane: merged file content missing")
+
+    noop_repo = base / "noop" / "repo"
+    noop_elsewhere = base / "noop-elsewhere"
+    noop_elsewhere.mkdir(parents=True)
+    noop_freeze = configure_fixture_repo(noop_repo)
+    if noop_freeze is None:
+        return
+    git_fixture(noop_repo, "branch", "job", noop_freeze)
+    noop_config = base / "configs" / "noop.json"
+    write_postflight_config(noop_config, noop_repo, noop_freeze, "job", None)
+    noop = run_postflight_fixture(noop_config, noop_elsewhere)
+    if noop is not None:
+        stdout = noop.stdout.replace("\r\n", "\n")
+        stderr = noop.stderr.replace("\r\n", "\n")
+        if noop.returncode != 5:
+            errors.append(
+                "postflight fixture noop: expected exit 5 "
+                f"got {noop.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        needle = "POSTFLIGHT: ERROR job branch has no commits beyond freeze"
+        if needle not in stdout:
+            errors.append(f"postflight fixture noop: missing {needle!r}\nstdout:\n{stdout}")
+
+
 def require_status_contains(label: str, output: str, needle: str) -> None:
     if needle not in output:
         errors.append(f"{label}: missing {needle!r}\noutput:\n{output}")
@@ -734,6 +907,7 @@ def main() -> int:
     check_watchdog_contract()
     check_status_contract()
     check_status_run_pinning_fixture()
+    check_postflight_lane_fixture()
     check_tracker_contract()
     check_architect_handoff_free()
     check_retired_loop_terms()


### PR DESCRIPTION
Fixes the three integration defects observed live during run multi-run. Stacked on #94 (base = factory/multi-run); merge #94 first, then this (or retarget to main after #94 lands).

Closes #95

## Shipped (#96, judge PASS on second judgment)

- **Lane commit + no-op guard**: postflight commits a dirty configured worktree onto the job branch (`<merge_message> (lane)`) before the touch-set audit, and exits 5 with `POSTFLIGHT: ERROR job branch has no commits beyond freeze` whenever the job tip still equals the freeze SHA - no silent no-op merge survives on any path.
- **Path anchoring**: `FullPath`/`abs_path` in all four pre/postflight scripts anchor relative config paths to `repo_root`, never the caller cwd.
- **Cleanup resilience**: worktree removal retries, then `--force`, then reports `cleanup=deferred <path>` on the OK line with exit 0 - a completed merge+push is never reported as ERROR for cleanup alone. dispatch.md typed-exit row and loop.md close-out updated (+1 non-blank line, 1089/1100 cap).
- **Proof**: `check_postflight_lane_fixture` drives the platform-native script end-to-end in throwaway repos (dirty-lane merge, relative-path cleanup with foreign cwd, no-op exit 5). First judgment FAILed on a Windows-only fixture-cleanup defect (bare `shutil.rmtree` vs read-only .git objects); respawn-with-answer fixed it; second judgment PASS. Bare rmtree on .git-bearing dirs is now a forbidden pattern in tests.

## Verification

- Fresh codex judge PASS (integrity, diff-vs-intent, all RUN + judge-only items, both script languages); checkrun evidence committed at docs/jobs/script-hardening/.
- Validator green on the final tree; this run's own postflight cleanup succeeded cleanly.
- Grill note: pre-freeze stress-test falsified two orchestrator-claimed defects (no `>\dev\null` bug exists; the solutions note never blamed check-runner) - both corrected before freeze, and the #93 comment was corrected on the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)