### PR TITLE
factory/judge-scout: graded checkrun, intent-only judge, scout, skeletons, closing review

### DIFF
--- a/.claude/agents/architect-judge.md
+++ b/.claude/agents/architect-judge.md
@@ -13,20 +13,26 @@ Duties:
 
 - Batch independent reads (frozen check file, spec, job report, rulings file,
   checkrun evidence file) into parallel tool calls in one turn; serialize only
-  dependent steps and command re-runs.
+  dependent steps and the single spot-check re-run.
 - Read the frozen check file named in the prompt.
 - Read `docs/jobs/<issue-slug>-rulings.md` when present. It is
   orchestrator-owned, append-only, frozen post-freeze intent; read it alongside
   the frozen check file, spec, and job report. If it is absent or empty, record
   that there are no post-freeze rulings.
 - Check checks integrity with the freeze commit SHA and branch to judge.
-- Run each check command exactly as written, unless the command is impossible to
-  execute in this environment; then return INVALID with raw evidence.
+- Read the checkrun evidence `CHECKRUN SUMMARY` before intent review. Missing
+  or stale evidence is INVALID, never FAIL.
+- Do not re-grade RUN items from the evidence file. Re-run exactly ONE graded
+  RUN item as a spot-check and compare verdicts. Any mismatch is automatic
+  INVALID with both outputs quoted.
+- Execute judge-only items yourself; if an item is impossible to execute in
+  this environment, return INVALID with raw evidence.
 - Read the diff against the frozen spec intent. Tests passing is necessary, not
   sufficient.
-- Return verdicts only: per-check PASS / FAIL / INVALID, checks-integrity
-  PASS / FAIL / INVALID, diff-vs-intent PASS / FAIL / INVALID, raw evidence,
-  and a slice verdict.
+- Return verdicts only: checks-integrity PASS / FAIL / INVALID, diff-vs-intent
+  PASS / FAIL / INVALID, spot-check PASS / FAIL / INVALID with item and both
+  quoted outputs, judge-only evidence, and a slice verdict with one decisive
+  reason.
 - Post the verdict as an issue comment when `gh` is available, formatted per
   loop.md's "## Verdict comments" pointer; if `gh`/network is unavailable,
   record that in the verdict evidence instead of faking the post.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,14 +8,14 @@ Glossary only. No implementation details, no spec content.
   harness, any surface). Grounds, runs intake, decomposes, freezes,
   dispatches, arbitrates, diagnoses, integrates. Never writes implementation
   code, never reads large diffs, never judges checks.
-- **Orchestrator tier** - the model tier used for orchestration and judgment:
-  a capability level, not one process.
+- **Orchestrator tier** - the model tier used for orchestration and designated
+  high-judgment reviews: a capability level, not one process.
 - **Builder** - a fresh-context worker agent that implements exactly one issue
   in an isolated worktree. Cannot commit. The builder tier is typically
   cheaper than the orchestrator tier and never changes because a job failed.
-- **Judge** - a fresh-context, read-only agent at orchestrator tier that runs
-  an issue's frozen checks and returns verdicts with raw evidence. Same
-  capability as the orchestrator, none of its conversation. Not a config key.
+- **Judge** - a fresh-context, read-only intent reviewer for one issue. The
+  deterministic check-runner grades frozen RUN items first; the judge checks
+  integrity, diff-vs-intent, and one graded RUN spot-check. Not a config key.
 - **Watchdog** - a deterministic script that sweeps in-flight jobs and exits
   with typed evidence (`ALL_DONE`, `INTEGRATED`, `STALL`, `REPEAT`). It never
   kills, nudges, or decides; the orchestrator rules on the evidence. A job is
@@ -26,20 +26,21 @@ Glossary only. No implementation details, no spec content.
 - **Stress-test** - a fresh adversarial reviewer of the decomposition before
   the freeze: attacks check commands, issue bodies, and repo reality.
 - **Scout** - a researcher-shaped investigator: reads, researches, reports;
-  may not modify code.
+  may not modify code. Build runs commit a scout map before decomposition.
 
 ## Units of work
 
 - **Issue** - one vertical-slice unit of work, one GitHub issue, one builder
   job. Body carries what-to-build, acceptance criteria, boundaries (disjoint
-  file sets), and interface handoff blocks.
+  file sets), a change-skeleton, and interface handoff blocks.
 - **Tracking issue** - the run's parent issue: dashboard, digest, and
   preflight record. Sub-issues hang off it with native blocked-by edges.
 - **Plan** - the issue set plus native blocked-by links. The schedulable set is
   always the ready issues, dispatched up to five jobs at once.
 - **Wave** - one ready-issue dispatch: its jobs plus one watchdog.
 - **Factory run** - everything between spec approval and the closing PR; runs
-  unattended on the factory branch (`factory/<run>`).
+  unattended on the factory branch (`factory/<run>`), with an optional
+  human-gated closing review before docs-finish.
 
 ## Control & Memory
 
@@ -58,14 +59,25 @@ Glossary only. No implementation details, no spec content.
   and continues. Irreversible or destructive silence takes the non-destructive
   path; `docs/STOP` remains absolute.
 - **Check** - a frozen, committed, exact acceptance check
-  (`docs/checks/<issue-slug>.md`). Read-only for everyone once frozen.
+  (`docs/checks/<issue-slug>.md`). Read-only for everyone once frozen. RUN
+  items are graded by machine-readable expectations.
+- **Graded RUN** - a check RUN item with `-> exit:<n>` and optional fixed
+  stdout `match:"substring"` expectation. Runner exits are typed: 0 all pass,
+  2 any expectation fails, 5 runner error.
+- **Scout map** - the committed `docs/runs/<run>/map.md` file: file:line
+  anchors, conventions, testing seams, and gotchas gathered before
+  decomposition.
+- **Change-skeleton** - a compact per-issue structure block naming files,
+  signatures, data flow, and invariants. It proves ownership and parallelism;
+  it is not implementation code.
 - **Freeze commit** - the commit that locks a run's checks; it is pushed before
   any dispatch, and worktrees are verified against it after spawn.
 - **Rulings file** (`docs/jobs/<issue-slug>-rulings.md`) - orchestrator-owned,
   append-only post-freeze intent: PHASE-0 rulings, boundary amendments,
   respawn answers. Part of the judge's intent context.
-- **Verdict comment** - the judgment record posted on the issue: per-check
-  PASS/FAIL/INVALID, checks integrity, diff-vs-intent, and the slice call.
+- **Verdict comment** - the judgment record posted on the issue: runner
+  summary, checks integrity, diff-vs-intent, the spot-check result, and the
+  slice call.
 - **Sync judge** - a harness-native judge dispatched with
   `run_in_background: false`, so the verdict returns as the tool result.
 - **Recovery ladder** - the ordered rescue path for a missing background
@@ -73,6 +85,9 @@ Glossary only. No implementation details, no spec content.
   fresh. The orchestrator never authors a missing verdict.
 - **Close-out** - stopping or closing a consumed subagent or background shell
   task in the same turn its result or typed exit was consumed.
+- **Closing review** - the human-gated review-and-fix pass after build issues
+  close and before docs-finish. It uses the orchestrator tier and is
+  green-or-discard.
 - **Canary** - the preflight spawn that proves a builder backend actually has
   working tools before the decomposition records it.
 - **Change-context digest** - the shipped-issues, diffstat, rulings,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,8 +3,9 @@
 **The design rationale for an autonomous software factory.** The orchestrator model
 (the session you open — Claude Fable 5 or Codex) runs intake, writes the spec,
 decomposes it into a GitHub issue plan, dispatches parallel fresh builder jobs
-into worktrees, answers blockers, sends fresh judges against frozen checks, and
-merges — with exactly one human step, spec approval. This document is the
+into worktrees, answers blockers, runs graded frozen checks, sends fresh intent
+judges against diffs, and merges — with exactly one human step, spec approval.
+This document is the
 "why", with citations; the skill files in `skills/architect/` are the "how";
 [CONTEXT.md](CONTEXT.md) is the vocabulary.
 
@@ -68,34 +69,35 @@ wiring them into two installable skills with the failure modes closed.
 |---|---|---|
 | **Orchestrator** | the session the human opened | intake, spec, decomposition, check freeze, dispatch, blocker answers, merge decisions, digest |
 | **Builder** | fresh worker agent, one per issue, own worktree | implementation and raw-evidence reporting only |
-| **Judge** | fresh orchestrator-tier agent, read-only | frozen-check verdicts and diff-vs-intent |
+| **Judge** | fresh builders-model agent, read-only | checks-integrity review, diff-vs-intent, one graded-check spot-check |
 | **Watchdog** | deterministic script per wave; "monitor" informally | mechanical stall evidence only — never kills, never decides |
 | **Adversarial reviewer** | fresh reviewer, pre-freeze | the stress-test pass (called the *grill* in earlier runs) falsifies the decomposition before it's authorized |
 | **Human** | you | spec approval, hard stops, taste |
 
 Why the orchestrator does the design work and the builders only build:
 [PEAR](https://arxiv.org/abs/2510.07505) measured that weak planners hurt
-multi-agent performance more than weak executors, so judgment minutes go on
-the strongest model and typing hours on the cheaper one. Community
+multi-agent performance more than weak executors, so planning and merge
+decisions go on the strongest model and typing hours on the cheaper one. Community
 measurements of orchestrator/worker splits report 58–74% lower cost than
 running the top model end-to-end
 ([Fable 5 Orchestrator Playbook](https://www.developersdigest.tech/blog/fable-5-orchestrator-model-playbook)).
 
-Why the judge is a *separate fresh context* at orchestrator tier rather than the
-orchestrator itself: fresh-session review finds more real defects than
-same-session self-review (F1 28.6% vs 24.6%, p=0.008,
+Why the judge is a *separate fresh context* rather than the orchestrator itself:
+fresh-session review finds more real defects than same-session self-review (F1
+28.6% vs 24.6%, p=0.008,
 [Cross-Context Review](https://arxiv.org/abs/2603.12123)), and Anthropic's
 Fable 5 guidance states it directly: "Separate, fresh-context verifier
 subagents tend to outperform self-critique"
 ([Prompting Fable 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5)).
+After the 2026-07-05 judge-scout run, routine slice judges run at the resolved
+builders model because deterministic grading moved into the check-runner; the
+judge spends its context on integrity, intent, and one spot-check of the runner.
 
-Why cross-vendor when both CLIs are installed: builder and judge from
-different labs reduces same-model review bias, which is measured at the
-model-family level ([arXiv:2410.21819](https://arxiv.org/abs/2410.21819),
-Panickssery et al. 2024). GPT-5.5 leads Terminal-Bench 2.0 (82.7%) for
-hands-on terminal work while Anthropic positions Fable 5 for long-horizon
-judgment ([Fable 5 announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)) —
-the split lines up with what each model is best at.
+Why cross-vendor remains available when both CLIs are installed: builder and
+judge from different labs reduces same-model review bias, which is measured at
+the model-family level ([arXiv:2410.21819](https://arxiv.org/abs/2410.21819),
+Panickssery et al. 2024). It is now the high-stakes review choice, not the
+ordinary route for mechanical shell access.
 
 ---
 
@@ -259,6 +261,14 @@ architect-v5 and architect-v5.1 specs, and loop-improvements research
   runs only for new load-bearing abstractions; testing seams are confirmed
   in the spec so jobs don't invent them mid-flight (TDD sourced from
   mattpocock's `tdd` skill; human ruling 2026-07-02).
+- **Scout map and change-skeletons ground the plan.** The 2026-07-05
+  judge-scout run added a read-only pre-spec scout dispatched in parallel with
+  intake questions. The orchestrator commits its file:line-anchored map at
+  `docs/runs/<run>/map.md`, cites it from the spec and issue bodies, and gives
+  each issue a compact change-skeleton: files, signatures, data flow, and
+  invariants, not implementation bodies. The ready frontier is computed from
+  that skeleton file ownership so disjointness is planned before dispatch
+  rather than discovered as a merge conflict.
 - **Judged diffs target ≤ ~400 changed lines (P3).** Human review
   effectiveness falls off past ~200–400 LOC per pass, and long-context
   degradation compounds it ([Chroma](https://www.trychroma.com/research/context-rot));
@@ -382,12 +392,13 @@ grading, checks-integrity review, and diff-vs-intent.
 
 The check-runner is a deterministic script, not an LLM, because a script
 cannot fabricate an exit code; an LLM runner is an unaudited junior judge. The
-check-runner executes frozen RUN commands outside subagent sandboxes and
-records raw evidence, while the fresh judge grades that evidence, performs
-diff-vs-intent, and re-runs at least one RUN command as the spot-check honesty
-guard. D12 consequence: shell-dependent checks no longer force cross-family
-codex judges just to get a shell; cross-family review returns to a high-stakes
-review choice rather than a workaround for stripped tools.
+check-runner executes frozen RUN commands outside subagent sandboxes, grades
+each machine-readable expectation, records per-item expected/verdict evidence,
+and exits typed: 0 when all RUN items pass, 2 when any RUN item fails, and 5 for
+runner error with partial evidence when possible. D12 consequence:
+shell-dependent checks no longer force cross-family codex judges just to get a
+shell; cross-family review returns to a high-stakes review choice rather than a
+workaround for stripped tools.
 
 The RUN grammar came from the design-it-twice record in judge-runner spec D1
 (evidence: git history before the 2026-07-04 cleanup):
@@ -395,6 +406,13 @@ heuristic backtick-span parsing was rejected for structural false positives in
 prose, fenced run blocks were rejected for authoring churn and for separating
 the command from its inline expected outcome, and explicit `- RUN:` markers
 were chosen.
+
+The 2026-07-05 judge-scout run made the grammar graded:
+``- RUN: `<cmd>` -> exit:<n> [match:"substring"]``. `match:` is a fixed
+case-sensitive stdout substring, never regex. A typed runner exit of 2 goes
+straight to the failure ladder with checkrun evidence and no judge dispatch;
+exit 5 uses the runner-error rail. The intent judge still re-runs exactly one
+graded RUN item as the runner-defect spot-check.
 
 #### Orchestrator mechanics offload (2026-07-04)
 
@@ -432,19 +450,36 @@ tree-audit guard also caught an orchestrator orphan-race snapshot commit
 (judgment #2 on #71, INVALID), which shows the honesty guards catch defects in
 both directions.
 
+Run judge-scout (2026-07-05) was the first live use of the graded runner and
+narrowed judge pipeline. Slice #99 shipped graded RUN parsing and typed exits;
+slice #100 narrowed both judge templates and coupled their validator contract;
+slice #101 updated the skill loop for scout maps, change-skeletons, runner
+typed exits, and the human-gated closing review. The closing review then
+hardened malformed `match:` expectations. Evidence pattern: all 3 judged
+slices had green deterministic checkruns and all 3 judge FAILs were useful
+diff-vs-intent catches; parser-divergence defects were caught twice by intent
+review rather than fixtures alone (glob-style shell matching at judgment, then
+space-less and unclosed `match:` expectations at closing review). The run also
+recorded one decomposition kill: judge templates and validator contract greps
+were one atomic contract and had to be re-specced into one boundary. The graded
+runner's first live use finished 7/7.
+
 - **Nobody grades their own work.** The builder reports evidence; a fresh
-  orchestrator-tier judge runs the frozen checks itself (builder claims are
-  hearsay) and returns per-check **PASS / FAIL / INVALID** — INVALID meaning
-  "not measured the way the check specifies", so unmeasured never equals
-  passed ([Demystifying Evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)).
-- **The judge also reads the diff against intent.** Check output alone is
+  deterministic check-runner grades frozen RUN items and the fresh intent judge
+  reads the runner evidence, verifies checks integrity, spot-checks one graded
+  RUN item, and judges diff-vs-intent. INVALID still means "not measured the
+  way the check specifies", so unmeasured never equals passed
+  ([Demystifying Evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)).
+- **The intent judge reads the diff against intent.** Check output alone is
   insufficient: METR found agent PRs that pass tests are mostly unmergeable
   as-is ([METR](https://metr.org/blog/2025-08-12-research-update-towards-reconciling-slowdown-with-time-horizons/)).
 - **The orchestrator may not turn a judge FAIL into a merge.** Verdicts are
   posted as issue comments; an issue with no verdict comment is not built
-  upon. Judgment context is pointer-only — frozen check file, spec, job
-  report, rulings file — delivered by frozen templates the orchestrator may
-  not decorate (template drift is how judge scope quietly widens).
+  upon unless the typed runner exit already put it on the failure ladder.
+  Judgment context is pointer-only — frozen check file, spec, job report,
+  rulings file, checkrun summary, and diff — delivered by frozen templates the
+  orchestrator may not decorate (template drift is how judge scope quietly
+  widens).
 - **Reviewers are calibrated.** "Flag only gaps that affect correctness, the
   stated requirements, or documented project invariants — cite file:line
   evidence. No style preferences." An uncalibrated reviewer always finds
@@ -454,6 +489,12 @@ both directions.
   while the reverse hurt; the skill prefers Claude-reviews-Codex and records
   the direction in the verdict comment
   ([cross-provider review](https://www.mindstudio.ai/blog/openai-codex-plugin-claude-code-cross-provider-review)).
+- **Closing review is human-gated and green-or-discard.** After the last build
+  issue closes and before the docs-finish job, the orchestrator asks through
+  the timed-ruling protocol whether to run a comprehensive review. The default
+  is yes; if it runs, the reviewer is at the resolved orchestrator model, reads
+  spec -> scout map -> diff, may make final fixes, and must keep every graded
+  RUN item green. Red review changes are discarded whole.
 - **Post-freeze rulings live in an append-only file (v5.1 D4).**
   `docs/jobs/<run>/<issue-slug>-rulings.md`, orchestrator-owned, committed before
   judge dispatch and mirrored to the issue — so judges read rulings from a
@@ -504,13 +545,17 @@ both directions.
 
 ### Model routing
 
-- **Orchestrator, builders, judge, and watchdog are configurable roles, not brand
+- **Orchestrator, builders, judges, and watchdog are routed roles, not brand
   names (D2).** Flat `key = value` lines in `.architect/config` (repo) then
   `~/.architect/config` (user); the alias table in `dispatch.md` is the
   single owned rot point mapping `codex/best`, `claude/best`, and tier-downs
   to current CLI flags, so model churn is reviewed in one place. The
   inherit-by-default shape follows the `opusplan` precedent and matching
   requests across aider/goose issue trackers.
+- **Routine issue judges resolve to the builders model.** The runner now owns
+  deterministic grading, so the ordinary judge is a fresh builders-model intent
+  reviewer with one spot-check. The closing review uses the orchestrator model,
+  and cross-family judgment remains an explicit high-stakes route.
 - **Default builders are codex-first.** `codex/best` (gpt-5.5, xhigh) whenever
   the Codex CLI is on PATH; `claude/tier-down` (Sonnet, high) otherwise.
   Typing hours land on the flat-rate subscription with verified `.git`
@@ -663,7 +708,7 @@ decisions, from the 2026-06 evidence review and the r2 calibration pass
 | Failure mode | Mitigation |
 |---|---|
 | Reward hacking / check tampering | Checks frozen in git pre-dispatch; `git diff` integrity check at judgment; tampering = automatic FAIL |
-| Builder grades own work | Raw-evidence-only reports; fresh judge runs checks itself; cross-family review for high-stakes |
+| Builder grades own work | Raw-evidence-only reports; deterministic runner grades frozen RUN items; fresh intent judge checks integrity, diff-vs-intent, and one spot-check; cross-family review for high-stakes |
 | Goalpost moving | Verbatim frozen check text; checks read-only after freeze; missing check = spec defect for the *next* issue |
 | Scope creep | Explicit boundaries and out-of-scope per issue; silent additions = job failure; scope growth beyond spec = hard stop |
 | Context rot | Orchestrator holds judgment only, never reads large diffs; fresh job per issue; tracker + git carry state |
@@ -671,7 +716,7 @@ decisions, from the 2026-06 evidence review and the r2 calibration pass
 | Placeholder implementations | End-to-end executable check commands; "search before implementing; full implementations only" in the builder block |
 | Silent fallbacks masking breakage | P1 ban; fail loudly; explicitly-specced resilience only |
 | Fabricated status reports | Every status claim audited against a tool result, both sides |
-| Check-passing but unmergeable work | Judge reads diff vs intent, not check output alone (METR) |
+| Check-passing but unmergeable work | Intent judge reads diff vs intent, not check output alone (METR) |
 | Builder gaming visible checks | Frozen read-only checks; no iterate-against-judge loop (ImpossibleBench 33%→38%) |
 | Stalled jobs | Watchdog script: growth + process + repeated-action checks; orchestrator rules on typed evidence; no kill ceilings |
 | Wrong run selected by tracker scan | `docs/runs/<run>/manifest.md` pins the tracking issue; status commands take the run slug and never compute a tracker-wide max |
@@ -809,6 +854,18 @@ cleanup. Both namespaces are load-bearing in shipped text.)
   docs debt from the same run produced the route-arounds in
   `docs/solutions/postflight-lane-commit.md` and
   `docs/solutions/worktree-cleanup-locks.md`.
+- **Judge-scout run (2026-07-05).** Spec
+  `docs/spec/judge-narrowing-and-scout.md` shipped #99, #100, #101, then a
+  closing review. Deterministic checkruns stayed green on every judged state,
+  but all three slice judgments initially failed on diff-vs-intent: the first
+  live graded runner used shell-glob matching instead of fixed substring; the
+  failure ladder named judge evidence but not checkrun evidence; and the first
+  dispatch slice split judge templates from validator contract greps before
+  being killed and re-specced as one atomic contract. Closing review was the
+  first live G5 use and caught malformed `match:` parser divergence
+  (space-less and unclosed quotes) before docs-finish. Reusable notes from the
+  run live in `docs/solutions/atomic-contract-decomposition.md` and
+  `docs/solutions/graded-expectation-divergence.md`.
 - **Dogfood runs.** v5 was built *by* the factory as a real issue plan (tracking issue
   #12, issues #13–#18): 1 judge FAIL, 3 respawns, all jobs fresh-judged.
   The v5.1 hardening run (tracking issue #20, issues #21–#25, on `factory/v5.1`)

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ GPT-5.5, xhigh) does the heavy lifting. Both are overridable — see
 - Orchestrator loops through the issues, assigning builders until every
   issue is fully complete:
   - progress lands on the GitHub issue as builders work;
-  - frozen checks run deterministically when a builder finishes;
-  - a fresh orchestrator-tier model adversarially reviews the code for
-    quality and intent;
+  - frozen checks run deterministically and grade their expected results;
+  - a fresh builders-model judge reviews integrity and intent, with one
+    spot-check of the runner;
   - on failure, the orchestrator diagnoses why, updates the issue and its
     requirements, and respawns a fresh builder — otherwise it comments,
     closes, and merges.
@@ -130,17 +130,14 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
   false positives. It never kills — the orchestrator rules on its evidence.
 - **Frozen checks run through a deterministic check-runner.** *token
   savings* — ~9 mechanical commands per check file were burning
-  frontier-priced judge turns; a script records the evidence, and a script
-  can't fabricate an exit code.
+  frontier-priced judge turns; a script grades expected exits and fixed
+  stdout matches, records the evidence, and can't fabricate an exit code.
 - **Dispatch and merge mechanics are scripted.** *token savings* — Worktree
   setup, freeze verification, touch-set audit, merge, and cleanup each
   collapse from 4–5 orchestrator calls into one typed-exit line.
-- **A fresh judge owns every merge.** *quality* — Per-check
-  PASS / FAIL / INVALID, where unmeasured never equals passed; the
-  orchestrator cannot overrule a FAIL.
-- **The judge reads the diff against intent, not just check output.**
-  *quality* — Agent PRs that pass tests are still mostly unmergeable, so
-  green checks with wrong code still fail.
+- **A fresh intent judge owns every merge.** *quality* — It checks
+  integrity, reads the diff against intent, and spot-checks one graded RUN
+  item; the orchestrator cannot overrule a FAIL.
 - **Judged diffs target ≤~400 changed lines.** *quality* — Review
   effectiveness collapses past a few hundred lines, so bigger specs split
   into more issues.
@@ -161,10 +158,10 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
 - **High-stakes changes get cross-family review.** *quality* — Same-family
   review shares blind spots (measured self-preference bias);
   Claude-reviews-Codex is the preferred direction.
-- **Docs debt batches into one job at the PR boundary.** *token savings* —
-  Product docs are the highest-contention files in a repo; one docs job
-  consumes the accumulated pointers instead of every builder fighting over
-  the README.
+- **Closing review and docs debt are batched at the PR boundary.** *token
+  savings* — Product docs are the highest-contention files in a repo; one
+  gated review and one docs job consume the accumulated pointers instead of
+  every builder fighting over the README.
 - **Hard stops.** *quality* — The `docs/STOP` kill-all switch,
   `docs/runs/<run>/STOP` for one run, irreversible actions, two consecutive
   killed jobs, or scope growth beyond the approved spec halt the factory and
@@ -221,8 +218,9 @@ Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` `claude` or
 GPT-5.5 at xhigh, and Sonnet at high / GPT-5.5 at high); any concrete model
 works too. Unconfigured, the orchestrator is your current session and
 builders are `codex/best` when the Codex CLI is installed, else
-`claude/tier-down`. Judges and adversarial reviewers run at orchestrator
-tier; `/architect-research` researchers follow `builders`. `when <task
+`claude/tier-down`. Routine judges follow `builders`; adversarial reviewers
+and closing review follow the orchestrator tier; `/architect-research`
+researchers follow `builders`. `when <task
 class> -> <model>` lines route classes of work to a tier. A configured CLI
 missing at dispatch falls back to the default with a note on the tracking
 issue — never a hard fail.

--- a/docs/checks/judge-scout/docs-finish.md
+++ b/docs/checks/judge-scout/docs-finish.md
@@ -1,0 +1,18 @@
+# Checks: docs-finish (run judge-scout)
+
+Purpose: product docs match what shipped; docs debt consumed. No cold judge
+(human-ruled exception): the orchestrator grades this checkrun directly.
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix README.md, DESIGN.md, CONTEXT.md, or
+docs/solutions/ — never this file. Read-only after freeze.
+Executor: powershell
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK"
+- RUN: `git grep -F -c "closing review" -- DESIGN.md` -> exit:0 (G5 documented)
+- RUN: `git grep -F -c "graded" -- DESIGN.md` -> exit:0 (G1 typed grading documented)
+- RUN: `git grep -F -c "scout" -- DESIGN.md` -> exit:0 (G3 documented)
+- RUN: `git grep -F -l "judge-scout" -- docs/solutions` -> exit:0 (at least one new solution note from this run)
+- RUN: `git grep -F -c "orchestrator-tier judge" -- DESIGN.md README.md` -> exit:1 (stale judge-tier claims retired from product docs)
+- Orchestrator-graded: README voice and hand-written SVG diagram references
+  preserved (human-directed rewrite, 2026-07-05 memory); Config section
+  remains the only ini example.

--- a/docs/checks/judge-scout/docs-finish2.md
+++ b/docs/checks/judge-scout/docs-finish2.md
@@ -1,0 +1,22 @@
+# Checks: docs-finish2 (run judge-scout; re-freeze of docs-finish)
+
+Re-freeze: the original line-14 command used `git grep` against
+docs/solutions, which cannot see the builder's NEW notes because builders
+cannot stage and `git grep` searches tracked content only — a check defect
+(orchestrator-owned), not a builder defect. Corrected with `--untracked`.
+Everything else identical. No cold judge (human-ruled): the orchestrator
+grades this checkrun directly.
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix README.md, DESIGN.md, CONTEXT.md, or
+docs/solutions/ — never this file. Read-only after freeze.
+Executor: powershell
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK"
+- RUN: `git grep -F -c "closing review" -- DESIGN.md` -> exit:0 (G5 documented)
+- RUN: `git grep -F -c "graded" -- DESIGN.md` -> exit:0 (G1 typed grading documented)
+- RUN: `git grep -F -c "scout" -- DESIGN.md` -> exit:0 (G3 documented)
+- RUN: `git grep --untracked -F -l "judge-scout" -- docs/solutions` -> exit:0 (new solution notes carry run provenance; --untracked because builders cannot stage)
+- RUN: `git grep -F -c "orchestrator-tier judge" -- DESIGN.md README.md` -> exit:1 (stale judge-tier claims retired from product docs)
+- Orchestrator-graded: README voice and hand-written SVG diagram references
+  preserved (human-directed rewrite, 2026-07-05 memory); Config section
+  remains the only ini example.

--- a/docs/checks/judge-scout/docs-finish3.md
+++ b/docs/checks/judge-scout/docs-finish3.md
@@ -1,0 +1,23 @@
+# Checks: docs-finish3 (run judge-scout; re-freeze of docs-finish2)
+
+Re-freeze lineage: v1 line 14 used `git grep` (blind to the builder's
+untracked new notes); v2 used `git grep --untracked` (exit 128: conflicts
+with this repo's submodule.recurse config). v3 uses executor-native
+Select-String, live-verified in the worktree before this freeze
+(PROVENANCE_OK). Both prior defects are orchestrator-owned check defects,
+not builder defects. No cold judge (human-ruled): the orchestrator grades
+this checkrun directly.
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix README.md, DESIGN.md, CONTEXT.md, or
+docs/solutions/ — never this file. Read-only after freeze.
+Executor: powershell
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK"
+- RUN: `git grep -F -c "closing review" -- DESIGN.md` -> exit:0 (G5 documented)
+- RUN: `git grep -F -c "graded" -- DESIGN.md` -> exit:0 (G1 typed grading documented)
+- RUN: `git grep -F -c "scout" -- DESIGN.md` -> exit:0 (G3 documented)
+- RUN: `if (Select-String -Path docs/solutions/*.md -Pattern "judge-scout" -SimpleMatch -Quiet) { "PROVENANCE_OK" } else { "PROVENANCE_MISSING"; exit 1 }` -> exit:0 match:"PROVENANCE_OK" (new solution notes carry run provenance; filesystem-based because builders cannot stage new files)
+- RUN: `git grep -F -c "orchestrator-tier judge" -- DESIGN.md README.md` -> exit:1 (stale judge-tier claims retired from product docs)
+- Orchestrator-graded: README voice and hand-written SVG diagram references
+  preserved (human-directed rewrite, 2026-07-05 memory); Config section
+  remains the only ini example.

--- a/docs/checks/judge-scout/s1-runner.md
+++ b/docs/checks/judge-scout/s1-runner.md
@@ -1,0 +1,45 @@
+# Checks: s1-runner (run judge-scout)
+
+Purpose: the deterministic check-runner grades RUN items itself and returns
+typed verdicts, so no LLM re-grades mechanical checks (spec G1).
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix the scripts, fixtures, or validator — never this
+file. This file is read-only after freeze.
+Executor: powershell
+Note: RUN lines below already use the graded grammar this slice builds; the
+current runner ignores expectation tokens as prose, the new runner grades
+them — both compatible (grill finding, 2026-07-05).
+
+Graded-RUN contract under test (normative for this slice):
+`- RUN: `<command>` -> exit:<n>` optionally followed by ` match:"<substring>"`.
+The expectation starts immediately after the closing backtick; anything after
+the expectation tokens is judge-facing prose the runner ignores. `match` is a
+FIXED substring tested against captured stdout only (grep -F semantics; ruled
+on issue #98; spec A1 amended to match). A RUN line with no `->` expectation
+is a grammar error: the runner exits 5 `CHECKRUN: ERROR` naming file and
+line, leaving no partial evidence. Evidence file: each RUN item records
+`expected: <expectation>` and `verdict: PASS|FAIL`; a
+`CHECKRUN SUMMARY: run_items=<n> pass=<n> fail=<n>` line precedes the
+integrity block. Typed exits: 0 = evidence written and fail=0; 2 = evidence
+written and fail>0; 5 = error, no partial evidence. Integrity fields stay
+data-only (judge territory), never part of grading.
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK" (cache redirect embedded per dispatch.md substitutions table)
+- RUN: `git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.ps1` -> exit:0
+- RUN: `git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.sh` -> exit:0
+- RUN: `git grep -F -c "verdict: " -- skills/architect/check-runner.ps1` -> exit:0
+- RUN: `git grep -F -c "verdict: " -- skills/architect/check-runner.sh` -> exit:0
+- RUN: `git grep -F -l -e "-> exit:" -- tests/fixtures/checkrun` -> exit:0 (at least one graded fixture exists; -e guards the leading dash)
+- Judge-only: tests/validate_skills.py contains a graded-runner fixture check
+  that asserts, for BOTH executors where runnable (recorded substitution rules
+  apply): (a) an all-pass graded fixture yields exit 0 with fail=0 in the
+  summary; (b) a fixture containing a failing item — including an absence
+  check `-> exit:1` that actually returns exit 0 — yields exit 2 with the
+  failing item's verdict FAIL; (c) a fixture with a RUN line missing `->`
+  yields exit 5 and no evidence file. Cite validator file:line per assertion.
+- Judge-only: match grading is fixed-substring against stdout (no regex
+  engine call on the expectation) in both check-runner.ps1 and
+  check-runner.sh; cite file:line.
+- Judge-only: existing ungraded fixtures under tests/fixtures/checkrun/ were
+  migrated to graded form or retired; no fixture exercises the retired
+  prose-only path as a passing case.

--- a/docs/checks/judge-scout/s2-dispatch.md
+++ b/docs/checks/judge-scout/s2-dispatch.md
@@ -1,0 +1,39 @@
+# Checks: s2-dispatch (run judge-scout)
+
+Purpose: dispatch.md carries the graded-RUN grammar, the narrowed intent-only
+judge templates, the scout dispatch template, and the extended grill clause;
+the judge agent def matches (spec G1 text, G2, G3 template).
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix skills/architect/dispatch.md or
+.claude/agents/architect-judge.md — never this file. Read-only after freeze.
+Executor: powershell
+Note: RUN lines use the graded grammar (see s1-runner.md contract block);
+the current runner ignores expectations as prose.
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK"
+- RUN: `git grep -F -c "Per check:" -- skills/architect/dispatch.md` -> exit:1 (absence proves both judge templates dropped per-RUN transcription)
+- RUN: `git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md` -> exit:0 (graded grammar documented; -e guards the leading dash)
+- RUN: `git grep -F -c "match:" -- skills/architect/dispatch.md` -> exit:0
+- RUN: `git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md` -> exit:0
+- RUN: `if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }` -> exit:0 match:"BUDGET_OK" (line budget funding s3; five-file guard headroom)
+- Judge-only: both judge templates (C5 and codex) are intent-only: they
+  require checks-integrity verdict, diff-vs-intent verdict, exactly one
+  spot-check re-run of one graded RUN item with mismatch = automatic INVALID
+  (both outputs quoted), and a slice verdict with one decisive reason; they
+  contain NO per-check grading section and NO instruction to grade RUN items
+  from the evidence file. Cite template line spans.
+- Judge-only: the `## Check-runner dispatch` section documents the graded
+  grammar (expectation after the closing backtick, fixed-substring match,
+  no-expectation = exit 5) and typed exits 0/2/5 consistent with the
+  s1-runner contract block. Cite file:line.
+- Judge-only: the stress-test/grill template requires every mechanical check
+  to carry a `->` expectation (a RUN item without one is a check defect) and
+  adds the run-map anchor spot-check duty. Cite file:line.
+- Judge-only: the `## Scout dispatch` section carries a scout template:
+  read-only job, builders model, return capped at ~2,500 tokens, file:line
+  anchors on every entry, honest NOT FOUND lines, no recommendations, output
+  written to the path the orchestrator names (map committed by the
+  orchestrator at docs/runs/<run>/map.md). Cite file:line.
+- Judge-only: .claude/agents/architect-judge.md duties match the narrowed
+  template (evidence-summary reading plus intent review; no per-RUN
+  re-grading duty; spot-check and INVALID rules retained). Cite file:line.

--- a/docs/checks/judge-scout/s2-dispatch2.md
+++ b/docs/checks/judge-scout/s2-dispatch2.md
@@ -1,0 +1,48 @@
+# Checks: s2-dispatch2 (run judge-scout, re-spec of s2-dispatch after decomposition-failure kill)
+
+Purpose: dispatch.md carries the graded-RUN grammar, the narrowed intent-only
+judge templates, the scout dispatch template, and the extended grill clause;
+the judge agent def matches; AND the validator's judge-template contract
+greps assert the narrowed phrases (the atomic contract lives in one slice
+now). Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix skills/architect/dispatch.md,
+.claude/agents/architect-judge.md, or the judge-template contract-grep
+section of tests/validate_skills.py — never this file. Read-only after freeze.
+Executor: powershell
+Note: RUN lines use the graded grammar (s1 shipped; the runner grades them).
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK" (REAL proof now: post-s1 tree, aligned greps required)
+- RUN: `git grep -F -c "Per check:" -- skills/architect/dispatch.md` -> exit:1 (absence proves both judge templates dropped per-RUN transcription)
+- RUN: `git grep -F -c "Per check:" -- tests/validate_skills.py` -> exit:1 (absence proves the retired contract grep is gone from the validator)
+- RUN: `git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md` -> exit:0 (graded grammar documented)
+- RUN: `git grep -F -c "match:" -- skills/architect/dispatch.md` -> exit:0
+- RUN: `git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md` -> exit:0
+- RUN: `if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }` -> exit:0 match:"BUDGET_OK"
+- Judge-only: both judge templates (C5 and codex) are intent-only: they
+  require checks-integrity verdict, diff-vs-intent verdict, exactly one
+  spot-check re-run of one graded RUN item with mismatch = automatic INVALID
+  (both outputs quoted), and a slice verdict with one decisive reason; they
+  contain NO per-check grading section and NO instruction to grade RUN items
+  from the evidence file. Cite template line spans.
+- Judge-only: tests/validate_skills.py's judge-template contract greps
+  assert the NARROWED template phrases (evidence-SUMMARY reading; re-run
+  exactly ONE graded RUN item; mismatch = automatic INVALID) instead of the
+  retired "Per check:" / "re-run at least one RUN command" strings; the
+  validator still asserts all four template marker pairs exist. Cite
+  file:line.
+- Judge-only: the `## Check-runner dispatch` section documents the graded
+  grammar (expectation after the closing backtick, fixed-substring match,
+  no-expectation = exit 5) and typed exits 0/2/5 consistent with the shipped
+  s1 runner. Cite file:line.
+- Judge-only: the stress-test/grill template requires every mechanical check
+  to carry a `->` expectation and adds the run-map anchor spot-check duty.
+  Cite file:line.
+- Judge-only: the `## Scout dispatch` section carries a scout template:
+  read-only job, builders model, return capped at ~2,500 tokens, file:line
+  anchors on every entry, honest NOT FOUND lines, no recommendations, output
+  written to the path the orchestrator names (map committed by the
+  orchestrator at docs/runs/<run>/map.md); SKILL.md's pointer to this
+  heading resolves. Cite file:line.
+- Judge-only: .claude/agents/architect-judge.md duties match the narrowed
+  template (evidence-summary reading plus intent review; no per-RUN
+  re-grading duty; spot-check and INVALID rules retained). Cite file:line.

--- a/docs/checks/judge-scout/s3-skilltext.md
+++ b/docs/checks/judge-scout/s3-skilltext.md
@@ -1,0 +1,44 @@
+# Checks: s3-skilltext (run judge-scout)
+
+Purpose: SKILL.md and loop.md carry the scout intake step, change-skeleton
+decomposition, typed-checkrun judgment ordering, and the human-gated closing
+review (spec G3, G4, G5, and G1/G2 loop wiring).
+Spec: docs/spec/judge-narrowing-and-scout.md
+Fix contract: on FAIL, fix skills/architect/SKILL.md or
+skills/architect/loop.md — never this file. Read-only after freeze.
+Executor: powershell
+Note: RUN lines use the graded grammar (see s1-runner.md contract block);
+the current runner ignores expectations as prose.
+
+- RUN: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py` -> exit:0 match:"OK"
+- RUN: `git grep -F -c "docs/runs/<run>/map.md" -- skills/architect/SKILL.md` -> exit:0
+- RUN: `git grep -F -c "change-skeleton" -- skills/architect/SKILL.md` -> exit:0
+- RUN: `git grep -F -c "closing review" -- skills/architect/SKILL.md` -> exit:0
+- RUN: `git grep -F -c "without judge dispatch" -- skills/architect/loop.md` -> exit:0
+- RUN: `if (((Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() -ne "" }).Count + (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() -ne "" }).Count) -le 411) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }` -> exit:0 match:"BUDGET_OK" (combined line budget; five-file guard headroom)
+- Judge-only: intake dispatches one read-only code scout (builders model,
+  scout job shape, per dispatch.md `## Scout dispatch`) in parallel with the
+  intake question batch and its timer; the orchestrator commits the returned
+  map at docs/runs/<run>/map.md; the spec and issues cite the map. Cite
+  file:line in SKILL.md.
+- Judge-only: decomposition requires a compact change-skeleton per issue
+  (~<=30 lines: files, signatures, data flow, invariants; structure only), a
+  contract-not-mandate rule naming PHASE 0 as the disagreement channel, and
+  the parallel frontier computed from skeleton file-ownership. Cite
+  file:line.
+- Judge-only: the DONE path reads the check-runner's typed exit: exit 2
+  routes to the failure ladder without judge dispatch; exit 0 dispatches the
+  intent judge; exit 5 stays the recorded error rail. Both SKILL.md's loop
+  step and loop.md agree. Cite file:line in both.
+- Judge-only: Finish opens with the timed-ruling closing-review question
+  (recommended default YES, 5-minute silence applies it), then on yes: one
+  fresh subagent at the resolved orchestrator model at medium effort, in a
+  worktree from the factory branch head, reading spec then map then run diff,
+  docs/checks/ read-only, all graded RUN items across the run must stay
+  green, full closing checkrun plus named test suites re-run, green-or-
+  discard (red review changes never merge, discard recorded on the digest),
+  merge through postflight, verdict and diffstat on the tracking issue,
+  ordered BEFORE the docs-finish job. Cite file:line.
+- Judge-only: Hard Rule 3 and Ground wording are consistent with the
+  builders-model intent-only judge (no stale "orchestrator-tier" or
+  evidence-re-grading claims). Cite file:line.

--- a/docs/jobs/judge-scout/docs-finish-01.md
+++ b/docs/jobs/judge-scout/docs-finish-01.md
@@ -1,0 +1,160 @@
+# docs-finish-01 job report
+
+MIRROR: ORCHESTRATOR
+
+## Scope
+
+Updated product docs for the judge-scout run:
+
+- `DESIGN.md`: graded runner, typed exits, intent-only builders-model judge,
+  scout map, change-skeletons, closing review, and run evidence.
+- `README.md`: minimal pipeline/model wording updates while preserving the
+  SVG diagram references and Config shape.
+- `CONTEXT.md`: glossary refresh for judge, graded RUN, scout map,
+  change-skeleton, and closing review.
+- `docs/solutions/atomic-contract-decomposition.md`
+- `docs/solutions/graded-expectation-divergence.md`
+
+No edits were made under `docs/checks/`, `docs/spec/`, `skills/`, `.claude/`,
+`tests/`, or `docs/runs/`.
+
+## Check Evidence
+
+### RUN 1
+
+Command:
+
+```powershell
+$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+```
+
+Exit: 0
+
+Output:
+
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+### RUN 2
+
+Command:
+
+```powershell
+git grep -F -c "closing review" -- DESIGN.md
+```
+
+Exit: 0
+
+Output:
+
+```text
+DESIGN.md:4
+```
+
+### RUN 3
+
+Command:
+
+```powershell
+git grep -F -c "graded" -- DESIGN.md
+```
+
+Exit: 0
+
+Output:
+
+```text
+DESIGN.md:11
+```
+
+### RUN 4
+
+Command:
+
+```powershell
+git grep -F -c "scout" -- DESIGN.md
+```
+
+Exit: 0
+
+Output:
+
+```text
+DESIGN.md:10
+```
+
+### RUN 5
+
+Command:
+
+```powershell
+git grep -F -l "judge-scout" -- docs/solutions
+```
+
+Sandbox setup: plain `git grep` ignores untracked new files, and this sandbox
+denied `git add -N` against `.git/worktrees/docs-finish-01/index.lock` plus
+empty-blob writes to `.git/objects`. For this uncommitted job check, the
+post-fix re-run used the preserved temporary index at
+`.architect/tmp/docs-finish-index-check`, which tracks the two solution paths;
+`git grep` read the current working-tree content after the provenance lines
+were added.
+
+Sandbox-denial evidence:
+
+```text
+fatal: Unable to create 'C:/Users/danhm/tools/architect-loop/.git/worktrees/docs-finish-01/index.lock': Permission denied
+```
+
+```text
+error: insufficient permission for adding an object to repository database C:/Users/danhm/tools/architect-loop/.git/objects
+fatal: cannot create an empty blob in the object database
+```
+
+Exit: 0
+
+Output:
+
+```text
+docs/solutions/atomic-contract-decomposition.md
+docs/solutions/graded-expectation-divergence.md
+```
+
+### RUN 6
+
+Command:
+
+```powershell
+git grep -F -c "orchestrator-tier judge" -- DESIGN.md README.md
+```
+
+Exit: 1
+
+Output:
+
+```text
+
+```
+
+## Orchestrator-Graded Evidence
+
+Command:
+
+```powershell
+Select-String -Path README.md -Pattern "assets/architect-flow.svg|assets/research-flow.svg|```ini"
+```
+
+Exit: 0
+
+Output:
+
+```text
+README.md:38:![architect flow](assets/architect-flow.svg)
+README.md:60:![research flow](assets/research-flow.svg)
+README.md:207:```ini
+```
+
+README voice and structure were preserved by minimal edits to existing bullets
+only. The Config section remains the only `ini` example.
+
+STATUS: COMPLETE

--- a/docs/jobs/judge-scout/docs-finish-checkrun.md
+++ b/docs/jobs/judge-scout/docs-finish-checkrun.md
@@ -1,0 +1,53 @@
+﻿# Checkrun: docs-finish-checkrun
+generated: 2026-07-05T21:55:12.4960926Z  runner: ps1  config: .architect/tmp/runner-docs3.json
+check_file: docs/checks/judge-scout/docs-finish3.md  freeze_sha: 8a5c352c7aa16ac6d9fe77b008965dfe9b081769
+Executor: powershell
+executor_config: powershell
+executor_resolved: powershell
+
+## (root) line 15
+$ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+exit: 0  ms: 6950  bytes: 45
+expected: exit:0 match:"OK"
+verdict: PASS
+OK - 2 skills validated, v4 contracts clean
+
+## (root) line 16
+$ git grep -F -c "closing review" -- DESIGN.md
+exit: 0  ms: 320  bytes: 12
+expected: exit:0
+verdict: PASS
+DESIGN.md:4
+
+## (root) line 17
+$ git grep -F -c "graded" -- DESIGN.md
+exit: 0  ms: 350  bytes: 13
+expected: exit:0
+verdict: PASS
+DESIGN.md:11
+
+## (root) line 18
+$ git grep -F -c "scout" -- DESIGN.md
+exit: 0  ms: 333  bytes: 13
+expected: exit:0
+verdict: PASS
+DESIGN.md:10
+
+## (root) line 19
+$ if (Select-String -Path docs/solutions/*.md -Pattern "judge-scout" -SimpleMatch -Quiet) { "PROVENANCE_OK" } else { "PROVENANCE_MISSING"; exit 1 }
+exit: 0  ms: 396  bytes: 15
+expected: exit:0 match:"PROVENANCE_OK"
+verdict: PASS
+PROVENANCE_OK
+
+## (root) line 20
+$ git grep -F -c "orchestrator-tier judge" -- DESIGN.md README.md
+exit: 1  ms: 311  bytes: 0
+expected: exit:1
+verdict: PASS
+
+CHECKRUN SUMMARY: run_items=6 pass=6 fail=0
+integrity: check_file_matches_freeze=true head=a0eb90ec9c6cfd4536994ca2e05f675722c75648
+changed_files: 2 listed below; docs_checks_touched=true
+docs/checks/judge-scout/docs-finish2.md
+docs/checks/judge-scout/docs-finish3.md

--- a/docs/jobs/judge-scout/s1-runner-01.md
+++ b/docs/jobs/judge-scout/s1-runner-01.md
@@ -1,0 +1,189 @@
+# Job Report: judge-scout/s1-runner-01
+
+MIRROR: ORCHESTRATOR
+
+## Non-blank Line Counts
+
+| file | before | after |
+| --- | ---: | ---: |
+| skills/architect/check-runner.ps1 | 201 | 231 |
+| skills/architect/check-runner.sh | 118 | 201 |
+| tests/validate_skills.py | 823 | 951 |
+| tests/fixtures/checkrun/fixture-checks-ps.md | 8 | 9 |
+| tests/fixtures/checkrun/fixture-checks-bash.md | 8 | 9 |
+| tests/fixtures/checkrun/fixture-checks-quoted-ps.md | 6 | 7 |
+| tests/fixtures/checkrun/fixture-checks-quoted-bash.md | 6 | 7 |
+| tests/fixtures/checkrun/config-missing.json | 1 | 1 |
+| tests/fixtures/checkrun/fixture-checks-missing-ps.md | 0 | 4 |
+| tests/fixtures/checkrun/fixture-checks-missing-bash.md | 0 | 4 |
+| tests/fixtures/checkrun/config-missing-bash.json | 0 | 1 |
+| docs/jobs/judge-scout/s1-runner-01.md | 0 | 157 |
+
+## Route-around
+
+The sh runner match grader now uses POSIX `awk index()` with the expected
+substring passed as `CHECKRUN_EXPECTED_MATCH`, replacing the previous shell
+`case` glob pattern. The awk script reconstructs stdout text and tests the
+expectation as data, so `*` and `?` do not become pattern metacharacters.
+
+PowerShell remains the reference behavior with ordinal `IndexOf` over captured
+stdout.
+
+## Fresh Worktree Verification
+
+```text
+git status --short
+exit 0
+ M skills/architect/check-runner.ps1
+ M skills/architect/check-runner.sh
+ M tests/fixtures/checkrun/config-missing.json
+ M tests/fixtures/checkrun/fixture-checks-bash.md
+ M tests/fixtures/checkrun/fixture-checks-ps.md
+ M tests/fixtures/checkrun/fixture-checks-quoted-bash.md
+ M tests/fixtures/checkrun/fixture-checks-quoted-ps.md
+ M tests/validate_skills.py
+?? docs/jobs/judge-scout/
+?? tests/fixtures/checkrun/config-missing-bash.json
+?? tests/fixtures/checkrun/fixture-checks-missing-bash.md
+?? tests/fixtures/checkrun/fixture-checks-missing-ps.md
+```
+
+```text
+git diff --stat
+exit 0
+ skills/architect/check-runner.ps1                  |  46 ++++++-
+ skills/architect/check-runner.sh                   |  97 +++++++++++++--
+ tests/fixtures/checkrun/config-missing.json        |   2 +-
+ tests/fixtures/checkrun/fixture-checks-bash.md     |   7 +-
+ tests/fixtures/checkrun/fixture-checks-ps.md       |   7 +-
+ .../checkrun/fixture-checks-quoted-bash.md         |   9 +-
+ .../fixtures/checkrun/fixture-checks-quoted-ps.md  |   9 +-
+ tests/validate_skills.py                           | 138 +++++++++++++++++++++
+ 8 files changed, 287 insertions(+), 28 deletions(-)
+```
+
+## Frozen RUN Commands
+
+```text
+$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+exit 0
+OK - 2 skills validated, v4 contracts clean
+```
+
+```text
+git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.ps1
+exit 0
+skills/architect/check-runner.ps1:1
+```
+
+```text
+git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.sh
+exit 0
+skills/architect/check-runner.sh:1
+```
+
+```text
+git grep -F -c "verdict: " -- skills/architect/check-runner.ps1
+exit 0
+skills/architect/check-runner.ps1:1
+```
+
+```text
+git grep -F -c "verdict: " -- skills/architect/check-runner.sh
+exit 0
+skills/architect/check-runner.sh:1
+```
+
+```text
+git grep -F -l -e "-> exit:" -- tests/fixtures/checkrun
+exit 0
+tests/fixtures/checkrun/fixture-checks-bash.md
+tests/fixtures/checkrun/fixture-checks-ps.md
+tests/fixtures/checkrun/fixture-checks-quoted-bash.md
+tests/fixtures/checkrun/fixture-checks-quoted-ps.md
+```
+
+## Judge-only Anchors
+
+```text
+rg -n "IndexOf" skills/architect/check-runner.ps1
+exit 0
+231:    if ($run.Expected.Match -ne $null -and $result.Stdout.IndexOf($run.Expected.Match, [System.StringComparison]::Ordinal) -lt 0) { $verdict = "FAIL" }
+```
+
+```text
+rg -n "CHECKRUN_EXPECTED_MATCH|index\(stdout_text, needle\)" skills/architect/check-runner.sh
+exit 0
+168:      if CHECKRUN_EXPECTED_MATCH=${expected_matches[$i]} awk '
+170:          needle = ENVIRON["CHECKRUN_EXPECTED_MATCH"]
+178:          if (!found && index(stdout_text, needle) > 0) { found = 1 }
+```
+
+```text
+rg -n "a\*b\?c" tests/fixtures/checkrun tests/validate_skills.py
+exit 0
+tests/validate_skills.py:895:            require_checkrun_evidence(f"{runner} pass", pass_evidence, 'expected: exit:0 match:"a*b?c"')
+tests/validate_skills.py:914:            require_checkrun_evidence(f"{runner} fail", fail_evidence, 'expected: exit:0 match:"a*b?c"')
+tests/fixtures/checkrun\fixture-checks-quoted-ps.md:11:- RUN: `Write-Output "glob candidate: axxbZc"` -> exit:0 match:"a*b?c"
+tests/fixtures/checkrun\fixture-checks-quoted-bash.md:11:- RUN: `printf 'glob candidate: axxbZc\n'` -> exit:0 match:"a*b?c"
+tests/fixtures/checkrun\fixture-checks-bash.md:8:- RUN: `printf 'literal glob token: a*b?c\n'` -> exit:0 match:"a*b?c"
+tests/fixtures/checkrun\fixture-checks-ps.md:8:- RUN: `Write-Output "literal glob token: a*b?c"` -> exit:0 match:"a*b?c"
+```
+
+```text
+rg -n "CHECKRUN SUMMARY: run_items=4|CHECKRUN SUMMARY: run_items=3" tests/validate_skills.py
+exit 0
+892:                "CHECKRUN SUMMARY: run_items=4 pass=4 fail=0",
+911:                "CHECKRUN SUMMARY: run_items=3 pass=1 fail=2",
+```
+
+PowerShell fixture evidence from the validator confirmed the literal glob PASS:
+
+```text
+## Fixture line 8
+$ Write-Output "literal glob token: a*b?c"
+exit: 0  ms: 210  bytes: 27
+expected: exit:0 match:"a*b?c"
+verdict: PASS
+literal glob token: a*b?c
+
+CHECKRUN SUMMARY: run_items=4 pass=4 fail=0
+```
+
+PowerShell fixture evidence from the validator confirmed the would-have-globbed
+literal miss grades FAIL:
+
+```text
+## Fixture line 11
+$ Write-Output "glob candidate: axxbZc"
+exit: 0  ms: 407  bytes: 24
+expected: exit:0 match:"a*b?c"
+verdict: FAIL
+glob candidate: axxbZc
+
+CHECKRUN SUMMARY: run_items=3 pass=1 fail=2
+```
+
+The bash fixture assertions are wired in the same validator loop and remain
+behind the existing `os.name != "nt"` guard for this Windows worktree.
+
+## Supplemental Commands
+
+```text
+git diff --check
+exit 0
+warning: in the working copy of 'skills/architect/check-runner.ps1', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/fixtures/checkrun/config-missing.json', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/fixtures/checkrun/fixture-checks-bash.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/fixtures/checkrun/fixture-checks-ps.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/fixtures/checkrun/fixture-checks-quoted-bash.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/fixtures/checkrun/fixture-checks-quoted-ps.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/validate_skills.py', LF will be replaced by CRLF the next time Git touches it
+```
+
+```text
+git status --short docs/checks
+exit 0
+```
+
+STATUS: COMPLETE

--- a/docs/jobs/judge-scout/s1-runner-checkrun.md
+++ b/docs/jobs/judge-scout/s1-runner-checkrun.md
@@ -1,0 +1,41 @@
+﻿# Checkrun: s1-runner-checkrun
+generated: 2026-07-05T20:41:17.4082656Z  runner: ps1  config: .architect/tmp/runner-s1.json
+check_file: docs/checks/judge-scout/s1-runner.md  freeze_sha: 8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
+Executor: powershell
+executor_config: powershell
+executor_resolved: powershell
+integrity: check_file_matches_freeze=true head=8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
+changed_files: 0 listed below; docs_checks_touched=false
+
+## (root) line 27
+$ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+exit: 0  ms: 6732  bytes: 45
+OK - 2 skills validated, v4 contracts clean
+
+## (root) line 28
+$ git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.ps1
+exit: 0  ms: 672  bytes: 36
+skills/architect/check-runner.ps1:1
+
+## (root) line 29
+$ git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.sh
+exit: 0  ms: 384  bytes: 35
+skills/architect/check-runner.sh:1
+
+## (root) line 30
+$ git grep -F -c "verdict: " -- skills/architect/check-runner.ps1
+exit: 0  ms: 400  bytes: 36
+skills/architect/check-runner.ps1:1
+
+## (root) line 31
+$ git grep -F -c "verdict: " -- skills/architect/check-runner.sh
+exit: 0  ms: 376  bytes: 35
+skills/architect/check-runner.sh:1
+
+## (root) line 32
+$ git grep -F -l -e "-> exit:" -- tests/fixtures/checkrun
+exit: 0  ms: 426  bytes: 198
+tests/fixtures/checkrun/fixture-checks-bash.md
+tests/fixtures/checkrun/fixture-checks-ps.md
+tests/fixtures/checkrun/fixture-checks-quoted-bash.md
+tests/fixtures/checkrun/fixture-checks-quoted-ps.md

--- a/docs/jobs/judge-scout/s1-runner-checkrun.md
+++ b/docs/jobs/judge-scout/s1-runner-checkrun.md
@@ -1,5 +1,5 @@
 ﻿# Checkrun: s1-runner-checkrun
-generated: 2026-07-05T20:41:17.4082656Z  runner: ps1  config: .architect/tmp/runner-s1.json
+generated: 2026-07-05T20:52:30.5353347Z  runner: ps1  config: .architect/tmp/runner-s1.json
 check_file: docs/checks/judge-scout/s1-runner.md  freeze_sha: 8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
 Executor: powershell
 executor_config: powershell
@@ -9,32 +9,32 @@ changed_files: 0 listed below; docs_checks_touched=false
 
 ## (root) line 27
 $ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
-exit: 0  ms: 6732  bytes: 45
+exit: 0  ms: 7822  bytes: 45
 OK - 2 skills validated, v4 contracts clean
 
 ## (root) line 28
 $ git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.ps1
-exit: 0  ms: 672  bytes: 36
+exit: 0  ms: 413  bytes: 36
 skills/architect/check-runner.ps1:1
 
 ## (root) line 29
 $ git grep -F -c "CHECKRUN SUMMARY:" -- skills/architect/check-runner.sh
-exit: 0  ms: 384  bytes: 35
+exit: 0  ms: 351  bytes: 35
 skills/architect/check-runner.sh:1
 
 ## (root) line 30
 $ git grep -F -c "verdict: " -- skills/architect/check-runner.ps1
-exit: 0  ms: 400  bytes: 36
+exit: 0  ms: 356  bytes: 36
 skills/architect/check-runner.ps1:1
 
 ## (root) line 31
 $ git grep -F -c "verdict: " -- skills/architect/check-runner.sh
-exit: 0  ms: 376  bytes: 35
+exit: 0  ms: 362  bytes: 35
 skills/architect/check-runner.sh:1
 
 ## (root) line 32
 $ git grep -F -l -e "-> exit:" -- tests/fixtures/checkrun
-exit: 0  ms: 426  bytes: 198
+exit: 0  ms: 379  bytes: 198
 tests/fixtures/checkrun/fixture-checks-bash.md
 tests/fixtures/checkrun/fixture-checks-ps.md
 tests/fixtures/checkrun/fixture-checks-quoted-bash.md

--- a/docs/jobs/judge-scout/s1-runner-rulings.md
+++ b/docs/jobs/judge-scout/s1-runner-rulings.md
@@ -1,0 +1,14 @@
+# Post-freeze rulings: judge-scout/s1-runner
+
+RULING 1 (2026-07-05, after first judgment FAIL): the sh runner's match
+grading via `case "$stdout_text" in *"$expected"*)` treats glob
+metacharacters in the expected substring as patterns; the frozen contract
+requires FIXED-substring semantics identical to the ps1 ordinal IndexOf over
+whole captured stdout. Fix the sh side to a mechanism where `*`, `?`, `[`
+are inert and matching runs over the whole stdout string (e.g. POSIX
+quoted-pattern parameter expansion or awk index(); builder's choice, POSIX
+sh only, no bashisms). ADD a fixture RUN case whose match expectation
+contains glob metacharacters (at least `*` and `?`) that must match only
+literally, plus a companion case proving a glob-would-match-but-literal-
+does-not input FAILs; wire both into the validator's fixture assertions for
+both executors. Everything else in judgment 1 passed; keep it as built.

--- a/docs/jobs/judge-scout/s2-dispatch-01.md
+++ b/docs/jobs/judge-scout/s2-dispatch-01.md
@@ -1,0 +1,174 @@
+# Job report: judge-scout/s2-dispatch-01
+
+## Non-blank line counts
+
+| file | before | after |
+|---|---:|---:|
+| skills/architect/dispatch.md | 582 | 543 |
+| .claude/agents/architect-judge.md | 40 | 43 |
+| docs/jobs/judge-scout/s2-dispatch-01.md | MISSING | 152 |
+
+## Live dependency checks
+
+Command:
+```powershell
+uv --version
+```
+Exit: 0
+```text
+uv 0.9.10 (44f5a14f4 2025-11-17)
+```
+
+Command:
+```powershell
+git --version
+```
+Exit: 0
+```text
+git version 2.51.2.windows.1
+```
+
+Command:
+```powershell
+$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+```
+Exit: 0
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+## Frozen RUN checks
+
+Command:
+```powershell
+$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+```
+Exit: 1
+```text
+FAIL - 3 problem(s):
+  - skills/architect/dispatch.md: C5 judge template missing Per check:
+  - skills/architect/dispatch.md: architect-judge-template missing re-run at least one RUN command
+  - skills/architect/dispatch.md: architect-codex-judge-template missing re-run at least one RUN command
+```
+
+Command:
+```powershell
+git grep -F -c "Per check:" -- skills/architect/dispatch.md
+```
+Exit: 1
+```text
+```
+
+Command:
+```powershell
+git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+git grep -F -c "match:" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:2
+```
+
+Command:
+```powershell
+git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
+```
+Exit: 0
+```text
+BUDGET_OK
+```
+
+## Raw anchor evidence
+
+Command:
+```powershell
+rg -n "Evidence rules:|Verdict format:|## Check-runner dispatch|Graded RUN grammar|Typed exits:|Exit 2 routes|## Scout dispatch|read-only code scout|NOT FOUND|No recommendations|Grill clause:|dangling anchor" skills/architect/dispatch.md
+```
+Exit: 0
+```text
+130:Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
+131:Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
+148:Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
+149:Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
+153:## Check-runner dispatch
+155:Graded RUN grammar is normative from the frozen s1-runner contract: ``- RUN: `<command>` -> exit:<n>`` with optional ` match:"<substring>"`.
+160:Typed exits: 0 = all RUN items pass; 2 = any RUN item fails; 5 = error, no partial evidence file left behind.
+162:Exit 2 routes to the failure ladder with no judge dispatch; `loop.md` owns the full rule.
+164:## Scout dispatch
+169:You are a read-only code scout. Output path: <docs/runs/<run>/map.md>.
+170:Return <= ~2,500 tokens. No recommendations.
+172:If a requested category is absent, write `NOT FOUND: <category> - <searched paths>`.
+188:Grill clause: every mechanical check MUST use `- RUN:` form with a `->` expectation; a mechanical RUN item without an expectation is a check defect.
+191:For every delete/rename, grep the repo for references and verify the owning job boundary covers them or a dependency edge orders the fix. For every NEW artifact path, run `git check-ignore <path>` and flag ignored paths. If a run map exists, sample map entries and verify each file:line anchor resolves; any dangling anchor is a check defect.
+286:Typed exits:
+```
+
+Command:
+```powershell
+rg -n "CHECKRUN SUMMARY|Do not re-grade|Re-run exactly ONE graded RUN|Return verdicts only|Do not edit files|checks-integrity|diff-vs-intent|spot-check" .claude/agents/architect-judge.md
+```
+Exit: 0
+```text
+16:  dependent steps and the single spot-check re-run.
+23:- Read the checkrun evidence `CHECKRUN SUMMARY` before intent review. Missing
+25:- Do not re-grade RUN items from the evidence file. Re-run exactly ONE graded
+26:  RUN item as a spot-check and compare verdicts. Any mismatch is automatic
+30:- Return verdicts only: checks-integrity PASS / FAIL / INVALID, diff-vs-intent
+31:  PASS / FAIL / INVALID, spot-check PASS / FAIL / INVALID with item and both
+46:Do not edit files, do not fix failures, do not stage changes, do not commit,
+```
+
+## Boundary evidence
+
+Command:
+```powershell
+git diff -- docs/checks
+```
+Exit: 0
+```text
+```
+
+Command:
+```powershell
+git status --short
+```
+Exit: 0
+```text
+ M .claude/agents/architect-judge.md
+ M skills/architect/dispatch.md
+?? docs/jobs/judge-scout/
+```
+
+Command:
+```powershell
+git diff --stat -- skills/architect/dispatch.md .claude/agents/architect-judge.md
+```
+Exit: 0
+```text
+ .claude/agents/architect-judge.md |  19 ++++---
+ skills/architect/dispatch.md      | 115 +++++++++++---------------------------
+ 2 files changed, 45 insertions(+), 89 deletions(-)
+warning: in the working copy of '.claude/agents/architect-judge.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'skills/architect/dispatch.md', LF will be replaced by CRLF the next time Git touches it
+```
+
+MIRROR: ORCHESTRATOR
+
+STATUS: COMPLETE_WITH_CONCERNS (validator command fails because live tests/validate_skills.py still requires retired C5 strings "Per check:" and "re-run at least one RUN command"; tests/ is outside this job boundary)

--- a/docs/jobs/judge-scout/s2-dispatch-02.md
+++ b/docs/jobs/judge-scout/s2-dispatch-02.md
@@ -1,0 +1,248 @@
+# Job report: judge-scout/s2-dispatch-02
+
+## Non-blank line counts
+
+| file | before | after |
+|---|---:|---:|
+| skills/architect/dispatch.md | 582 | 545 |
+| .claude/agents/architect-judge.md | 40 | 46 |
+| tests/validate_skills.py | 951 | 976 |
+| docs/jobs/judge-scout/s2-dispatch-02.md | MISSING | 221 |
+
+## Live dependency checks
+
+Command:
+```powershell
+uv --version
+```
+Exit: 0
+```text
+uv 0.9.10 (44f5a14f4 2025-11-17)
+```
+
+Command:
+```powershell
+git --version
+```
+Exit: 0
+```text
+git version 2.51.2.windows.1
+```
+
+Command:
+```powershell
+python --version
+```
+Exit: 1
+```text
+Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Apps > Advanced app settings > App execution aliases.
+```
+
+Command:
+```powershell
+$env:UV_CACHE_DIR='.architect/tmp/uv-cache'; uv run python --version
+```
+Exit: 0
+```text
+Python 3.12.4
+```
+
+## Frozen RUN checks
+
+Command:
+```powershell
+$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+```
+Exit: 0
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+Command:
+```powershell
+git grep -F -c "Per check:" -- skills/architect/dispatch.md
+```
+Exit: 1
+```text
+```
+
+Command:
+```powershell
+git grep -F -c "Per check:" -- tests/validate_skills.py
+```
+Exit: 1
+```text
+```
+
+Command:
+```powershell
+git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:2
+```
+
+Command:
+```powershell
+git grep -F -c "match:" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:2
+```
+
+Command:
+```powershell
+git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/dispatch.md:1
+```
+
+Command:
+```powershell
+if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
+```
+Exit: 0
+```text
+BUDGET_OK
+```
+
+## Raw anchor evidence
+
+Command:
+```powershell
+rg -n "Evidence rules:|Verdict format:|## Check-runner dispatch|Graded RUN grammar|Typed exits:|Exit 2 routes|## Scout dispatch|read-only code scout|NOT FOUND|No recommendations|Grill clause:|dangling anchor" skills/architect/dispatch.md
+```
+Exit: 0
+```text
+137:Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
+139:Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
+163:Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
+165:Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item, executor, and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
+169:## Check-runner dispatch
+171:Graded RUN grammar is normative from the shipped s1 runner in `skills/architect/check-runner.ps1`: first backtick span is the command; expectation begins immediately after the closing backtick as ``-> exit:<n>`` with optional `match:"<substring>"`. `match:` is a fixed, case-sensitive stdout substring check, never regex. Text after the expectation is judge-facing prose; non-RUN items are judge-only. A RUN item without an expectation exits 5 with `CHECKRUN: ERROR missing RUN expectation`, and no partial evidence is kept.
+175:Typed exits: 0 = all RUN items pass; 2 = any RUN item fails; 5 = error, no partial evidence file left behind.
+176:Launch pattern: run `skills/architect/check-runner.ps1` or `check-runner.sh` in the background and commit `docs/jobs/<run>/<issue-slug>-checkrun.md` before judge dispatch on exit 0. Exit 2 routes to the failure ladder with no judge dispatch; `loop.md` owns the full rule.
+178:## Scout dispatch
+183:You are a read-only code scout. Output path: <docs/runs/<run>/map.md>.
+184:Return <= ~2,500 tokens. No recommendations.
+186:Every entry must carry a real file:line anchor. If a requested category is absent, write `NOT FOUND: <category> - <searched paths>`. No implementation plan, no edits.
+199:Grill clause: every mechanical check MUST use `- RUN:` form with a `->` expectation; a RUN item without an expectation is a check defect.
+204:If a run map exists, sample map entries and verify each file:line anchor resolves; a dangling anchor is a check defect.
+295:Typed exits:
+```
+
+Command:
+```powershell
+rg -n "CHECKRUN SUMMARY|Do not re-grade|Re-run exactly ONE graded RUN|automatic|Return verdicts only|Do not edit files|checks-integrity|diff-vs-intent|spot-check|read-only" .claude/agents/architect-judge.md
+```
+Exit: 0
+```text
+3:description: Runs frozen architect checks as a fresh read-only judge, verifies checks integrity and diff intent, and returns PASS/FAIL/INVALID verdicts with raw evidence only.
+16:  dependent steps and the single spot-check re-run.
+23:- Read the checkrun evidence `CHECKRUN SUMMARY` before intent review. Missing
+25:- Do not re-grade RUN items from the evidence file. Re-run exactly ONE graded
+26:  RUN item as a spot-check and compare verdicts. Any mismatch is automatic
+32:- Return verdicts only: checks-integrity PASS / FAIL / INVALID, diff-vs-intent
+33:  PASS / FAIL / INVALID, spot-check PASS | FAIL | INVALID with item and both
+40:  with read-only tools (claude-code #60237 silently drops those two
+49:Do not edit files, do not fix failures, do not stage changes, do not commit,
+```
+
+Command:
+```powershell
+rg -n "architect-judge-template|architect-codex-judge-template|architect-stress-test-template|architect-monitor-fallback-template|read the checkrun evidence SUMMARY|Do not grade RUN items|Re-run exactly ONE graded RUN item|mismatch is automatic INVALID|missing .*marker block|independent reads exactly once|before grading; grade RUN items" tests/validate_skills.py
+```
+Exit: 0
+```text
+269:        r"<!-- architect-judge-template:start -->\n```text\n(.*?)\n```\n<!-- architect-judge-template:end -->",
+285:        "read the checkrun evidence SUMMARY",
+286:        "Do not grade RUN items from the evidence file",
+287:        "Re-run exactly ONE graded RUN item",
+288:        "mismatch is automatic INVALID",
+319:        "architect-judge-template",
+320:        "architect-codex-judge-template",
+321:        "architect-stress-test-template",
+322:        "architect-monitor-fallback-template",
+329:            errors.append(f"skills/architect/dispatch.md: missing {marker} marker block")
+332:    for marker in ("architect-judge-template", "architect-codex-judge-template"):
+337:            "read the checkrun evidence SUMMARY",
+338:            "Do not grade RUN items from the evidence file",
+339:            "Re-run exactly ONE graded RUN item",
+340:            "mismatch is automatic INVALID",
+347:        if "before grading; grade RUN items from the evidence file" in block:
+355:                f"{marker} must contain independent reads exactly once"
+```
+
+Command:
+```powershell
+rg -n "ParseRunExpectation|missing RUN expectation|IndexOf|CHECKRUN SUMMARY|exit 2|exit 5|expected:|verdict:" skills/architect/check-runner.ps1
+```
+Exit: 0
+```text
+24:    exit 5
+131:function ParseRunExpectation($Text, $File, $LineNo) {
+133:    if (-not $m.Success) { StopRun "missing RUN expectation ${File}:$LineNo" }
+167:    exit 5
+211:        $expectation = ParseRunExpectation $m.Groups[2].Value $checkFile $lineNo
+231:    if ($run.Expected.Match -ne $null -and $result.Stdout.IndexOf($run.Expected.Match, [System.StringComparison]::Ordinal) -lt 0) { $verdict = "FAIL" }
+241:    [void]$e.Add("expected: $($run.Expected.Text)")
+242:    [void]$e.Add("verdict: $verdict")
+246:[void]$e.Add("CHECKRUN SUMMARY: run_items=$($runs.Count) pass=$passCount fail=$failCount")
+256:if ($failCount -gt 0) { exit 2 }
+```
+
+Command:
+```powershell
+rg -n "## Scout dispatch|dispatch.md.*Scout dispatch" skills/architect/SKILL.md skills/architect/dispatch.md
+```
+Exit: 0
+```text
+skills/architect/SKILL.md:23:- dispatch.md sections `## Scout dispatch`, `## Monitor dispatch`
+skills/architect/SKILL.md:87:In parallel with that batch and timer, dispatch one read-only code scout at the builders model using the `scout` job shape and `dispatch.md` `## Scout dispatch`; commit its returned map at `docs/runs/<run>/map.md`. The spec and every issue cite the map pointer.
+skills/architect/dispatch.md:178:## Scout dispatch
+```
+
+## Boundary evidence
+
+Command:
+```powershell
+git diff -- docs/checks
+```
+Exit: 0
+```text
+```
+
+Command:
+```powershell
+git status --short
+```
+Exit: 0
+```text
+ M .claude/agents/architect-judge.md
+ M skills/architect/dispatch.md
+ M tests/validate_skills.py
+?? docs/jobs/judge-scout/s2-dispatch-02.md
+```
+
+Command:
+```powershell
+git diff --stat -- skills/architect/dispatch.md .claude/agents/architect-judge.md tests/validate_skills.py
+```
+Exit: 0
+```text
+ .claude/agents/architect-judge.md | 18 +++++---
+ skills/architect/dispatch.md      | 96 ++++++++++++---------------------------
+ tests/validate_skills.py          | 35 ++++++++++++--
+ 3 files changed, 71 insertions(+), 78 deletions(-)
+warning: in the working copy of '.claude/agents/architect-judge.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'skills/architect/dispatch.md', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'tests/validate_skills.py', LF will be replaced by CRLF the next time Git touches it
+```
+
+MIRROR: ORCHESTRATOR
+
+STATUS: COMPLETE

--- a/docs/jobs/judge-scout/s2-dispatch-rulings.md
+++ b/docs/jobs/judge-scout/s2-dispatch-rulings.md
@@ -1,0 +1,15 @@
+# Post-freeze rulings: judge-scout/s2-dispatch (re-spec lineage)
+
+RULING 1 (2026-07-05, job -01 killed pre-judgment): decomposition failure —
+the narrowed judge templates and the validator's template-contract greps are
+one atomic contract; boundary re-specced to own both (see issue #100
+comments). Not a builder defect.
+
+RULING 2 (2026-07-05, after job -02 judgment FAIL): the validator's template
+marker-pair existence loop must cover ALL FOUR marker pairs in dispatch.md
+(architect-judge-template, architect-codex-judge-template,
+architect-stress-test-template, architect-monitor-fallback-template), per
+the frozen check's "all four template marker pairs" clause. The narrowed-
+phrase assertions apply to the two judge templates only, as built. Extend
+the loop at tests/validate_skills.py:317-323; change nothing else. All other
+judgment-2 items PASSed; keep them as built.

--- a/docs/jobs/judge-scout/s2-dispatch2-checkrun.md
+++ b/docs/jobs/judge-scout/s2-dispatch2-checkrun.md
@@ -1,5 +1,5 @@
 ﻿# Checkrun: s2-dispatch2-checkrun
-generated: 2026-07-05T21:09:22.9547163Z  runner: ps1  config: .architect/tmp/runner-s2b.json
+generated: 2026-07-05T21:18:08.0508276Z  runner: ps1  config: .architect/tmp/runner-s2b.json
 check_file: docs/checks/judge-scout/s2-dispatch2.md  freeze_sha: 567841119507f5138e92ec37b1b461ede1ba9330
 Executor: powershell
 executor_config: powershell
@@ -7,47 +7,47 @@ executor_resolved: powershell
 
 ## (root) line 14
 $ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
-exit: 0  ms: 7549  bytes: 45
+exit: 0  ms: 7733  bytes: 45
 expected: exit:0 match:"OK"
 verdict: PASS
 OK - 2 skills validated, v4 contracts clean
 
 ## (root) line 15
 $ git grep -F -c "Per check:" -- skills/architect/dispatch.md
-exit: 1  ms: 381  bytes: 0
+exit: 1  ms: 352  bytes: 0
 expected: exit:1
 verdict: PASS
 
 ## (root) line 16
 $ git grep -F -c "Per check:" -- tests/validate_skills.py
-exit: 1  ms: 482  bytes: 0
+exit: 1  ms: 358  bytes: 0
 expected: exit:1
 verdict: PASS
 
 ## (root) line 17
 $ git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md
-exit: 0  ms: 401  bytes: 31
+exit: 0  ms: 411  bytes: 31
 expected: exit:0
 verdict: PASS
 skills/architect/dispatch.md:2
 
 ## (root) line 18
 $ git grep -F -c "match:" -- skills/architect/dispatch.md
-exit: 0  ms: 402  bytes: 31
+exit: 0  ms: 368  bytes: 31
 expected: exit:0
 verdict: PASS
 skills/architect/dispatch.md:2
 
 ## (root) line 19
 $ git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md
-exit: 0  ms: 399  bytes: 31
+exit: 0  ms: 371  bytes: 31
 expected: exit:0
 verdict: PASS
 skills/architect/dispatch.md:1
 
 ## (root) line 20
 $ if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
-exit: 0  ms: 415  bytes: 11
+exit: 0  ms: 446  bytes: 11
 expected: exit:0 match:"BUDGET_OK"
 verdict: PASS
 BUDGET_OK

--- a/docs/jobs/judge-scout/s2-dispatch2-checkrun.md
+++ b/docs/jobs/judge-scout/s2-dispatch2-checkrun.md
@@ -1,0 +1,57 @@
+﻿# Checkrun: s2-dispatch2-checkrun
+generated: 2026-07-05T21:09:22.9547163Z  runner: ps1  config: .architect/tmp/runner-s2b.json
+check_file: docs/checks/judge-scout/s2-dispatch2.md  freeze_sha: 567841119507f5138e92ec37b1b461ede1ba9330
+Executor: powershell
+executor_config: powershell
+executor_resolved: powershell
+
+## (root) line 14
+$ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+exit: 0  ms: 7549  bytes: 45
+expected: exit:0 match:"OK"
+verdict: PASS
+OK - 2 skills validated, v4 contracts clean
+
+## (root) line 15
+$ git grep -F -c "Per check:" -- skills/architect/dispatch.md
+exit: 1  ms: 381  bytes: 0
+expected: exit:1
+verdict: PASS
+
+## (root) line 16
+$ git grep -F -c "Per check:" -- tests/validate_skills.py
+exit: 1  ms: 482  bytes: 0
+expected: exit:1
+verdict: PASS
+
+## (root) line 17
+$ git grep -F -c -e "-> exit:" -- skills/architect/dispatch.md
+exit: 0  ms: 401  bytes: 31
+expected: exit:0
+verdict: PASS
+skills/architect/dispatch.md:2
+
+## (root) line 18
+$ git grep -F -c "match:" -- skills/architect/dispatch.md
+exit: 0  ms: 402  bytes: 31
+expected: exit:0
+verdict: PASS
+skills/architect/dispatch.md:2
+
+## (root) line 19
+$ git grep -F -c "## Scout dispatch" -- skills/architect/dispatch.md
+exit: 0  ms: 399  bytes: 31
+expected: exit:0
+verdict: PASS
+skills/architect/dispatch.md:1
+
+## (root) line 20
+$ if ((Get-Content skills/architect/dispatch.md | Where-Object { $_.Trim() -ne "" }).Count -le 545) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
+exit: 0  ms: 415  bytes: 11
+expected: exit:0 match:"BUDGET_OK"
+verdict: PASS
+BUDGET_OK
+
+CHECKRUN SUMMARY: run_items=7 pass=7 fail=0
+integrity: check_file_matches_freeze=true head=567841119507f5138e92ec37b1b461ede1ba9330
+changed_files: 0 listed below; docs_checks_touched=false

--- a/docs/jobs/judge-scout/s3-skilltext-01.md
+++ b/docs/jobs/judge-scout/s3-skilltext-01.md
@@ -1,0 +1,69 @@
+# judge-scout/s3-skilltext-01
+
+MIRROR: ORCHESTRATOR
+
+## Scope
+
+Applied the judge-ruling route-around only: Failure ladder now diagnoses judge FAILs from judge evidence and check-runner exit 2 from the checkrun evidence file's failing items.
+
+## Touched Files
+
+| file | before nonblank | after nonblank |
+|---|---:|---:|
+| skills/architect/SKILL.md | 255 | 234 |
+| skills/architect/loop.md | 121 | 118 |
+| docs/jobs/judge-scout/s3-skilltext-01.md | 0 | 55 |
+
+Combined SKILL.md + loop.md nonblank: 352 / 411.
+
+## Frozen RUN Outputs
+
+### RUN 1
+COMMAND: `$env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py`
+EXIT: 0
+OUTPUT:
+```text
+OK - 2 skills validated, v4 contracts clean
+```
+
+### RUN 2
+COMMAND: `git grep -F -c "docs/runs/<run>/map.md" -- skills/architect/SKILL.md`
+EXIT: 0
+OUTPUT:
+```text
+skills/architect/SKILL.md:3
+```
+
+### RUN 3
+COMMAND: `git grep -F -c "change-skeleton" -- skills/architect/SKILL.md`
+EXIT: 0
+OUTPUT:
+```text
+skills/architect/SKILL.md:3
+```
+
+### RUN 4
+COMMAND: `git grep -F -c "closing review" -- skills/architect/SKILL.md`
+EXIT: 0
+OUTPUT:
+```text
+skills/architect/SKILL.md:1
+```
+
+### RUN 5
+COMMAND: `git grep -F -c "without judge dispatch" -- skills/architect/loop.md`
+EXIT: 0
+OUTPUT:
+```text
+skills/architect/loop.md:1
+```
+
+### RUN 6
+COMMAND: `if (((Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() -ne "" }).Count + (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() -ne "" }).Count) -le 411) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }`
+EXIT: 0
+OUTPUT:
+```text
+BUDGET_OK
+```
+
+STATUS: PASS

--- a/docs/jobs/judge-scout/s3-skilltext-checkrun.md
+++ b/docs/jobs/judge-scout/s3-skilltext-checkrun.md
@@ -1,5 +1,5 @@
 ﻿# Checkrun: s3-skilltext-checkrun
-generated: 2026-07-05T20:38:57.3940158Z  runner: ps1  config: .architect/tmp/runner-s3.json
+generated: 2026-07-05T20:48:28.0453369Z  runner: ps1  config: .architect/tmp/runner-s3.json
 check_file: docs/checks/judge-scout/s3-skilltext.md  freeze_sha: 8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
 Executor: powershell
 executor_config: powershell
@@ -9,30 +9,30 @@ changed_files: 0 listed below; docs_checks_touched=false
 
 ## (root) line 13
 $ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
-exit: 0  ms: 3860  bytes: 45
+exit: 0  ms: 4289  bytes: 45
 OK - 2 skills validated, v4 contracts clean
 
 ## (root) line 14
 $ git grep -F -c "docs/runs/<run>/map.md" -- skills/architect/SKILL.md
-exit: 0  ms: 426  bytes: 28
+exit: 0  ms: 354  bytes: 28
 skills/architect/SKILL.md:3
 
 ## (root) line 15
 $ git grep -F -c "change-skeleton" -- skills/architect/SKILL.md
-exit: 0  ms: 420  bytes: 28
+exit: 0  ms: 414  bytes: 28
 skills/architect/SKILL.md:3
 
 ## (root) line 16
 $ git grep -F -c "closing review" -- skills/architect/SKILL.md
-exit: 0  ms: 376  bytes: 28
+exit: 0  ms: 381  bytes: 28
 skills/architect/SKILL.md:1
 
 ## (root) line 17
 $ git grep -F -c "without judge dispatch" -- skills/architect/loop.md
-exit: 0  ms: 461  bytes: 27
+exit: 0  ms: 364  bytes: 27
 skills/architect/loop.md:1
 
 ## (root) line 18
 $ if (((Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() -ne "" }).Count + (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() -ne "" }).Count) -le 411) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
-exit: 0  ms: 434  bytes: 11
+exit: 0  ms: 353  bytes: 11
 BUDGET_OK

--- a/docs/jobs/judge-scout/s3-skilltext-checkrun.md
+++ b/docs/jobs/judge-scout/s3-skilltext-checkrun.md
@@ -1,0 +1,38 @@
+﻿# Checkrun: s3-skilltext-checkrun
+generated: 2026-07-05T20:38:57.3940158Z  runner: ps1  config: .architect/tmp/runner-s3.json
+check_file: docs/checks/judge-scout/s3-skilltext.md  freeze_sha: 8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
+Executor: powershell
+executor_config: powershell
+executor_resolved: powershell
+integrity: check_file_matches_freeze=true head=8965e40c6ccc657266b6a5ac5e5f36fabbe2b6fe
+changed_files: 0 listed below; docs_checks_touched=false
+
+## (root) line 13
+$ $env:UV_CACHE_DIR=".architect/tmp/uv-cache"; uv run python tests/validate_skills.py
+exit: 0  ms: 3860  bytes: 45
+OK - 2 skills validated, v4 contracts clean
+
+## (root) line 14
+$ git grep -F -c "docs/runs/<run>/map.md" -- skills/architect/SKILL.md
+exit: 0  ms: 426  bytes: 28
+skills/architect/SKILL.md:3
+
+## (root) line 15
+$ git grep -F -c "change-skeleton" -- skills/architect/SKILL.md
+exit: 0  ms: 420  bytes: 28
+skills/architect/SKILL.md:3
+
+## (root) line 16
+$ git grep -F -c "closing review" -- skills/architect/SKILL.md
+exit: 0  ms: 376  bytes: 28
+skills/architect/SKILL.md:1
+
+## (root) line 17
+$ git grep -F -c "without judge dispatch" -- skills/architect/loop.md
+exit: 0  ms: 461  bytes: 27
+skills/architect/loop.md:1
+
+## (root) line 18
+$ if (((Get-Content skills/architect/SKILL.md | Where-Object { $_.Trim() -ne "" }).Count + (Get-Content skills/architect/loop.md | Where-Object { $_.Trim() -ne "" }).Count) -le 411) { "BUDGET_OK" } else { "BUDGET_FAIL"; exit 1 }
+exit: 0  ms: 434  bytes: 11
+BUDGET_OK

--- a/docs/jobs/judge-scout/s3-skilltext-rulings.md
+++ b/docs/jobs/judge-scout/s3-skilltext-rulings.md
@@ -1,0 +1,9 @@
+# Post-freeze rulings: judge-scout/s3-skilltext
+
+RULING 1 (2026-07-05, after first judgment FAIL): the Failure ladder in
+loop.md must name BOTH diagnosis sources: on a judge FAIL, the judge's
+evidence; on a check-runner exit 2 (the no-judge path), the checkrun
+evidence file's failing items. One sentence amendment inside the existing
+"## Failure ladder" section; everything else in the judge's PASS findings
+stays as built. The combined SKILL.md+loop.md budget (<= 411 non-blank)
+still applies; current state is 350, so the amendment fits.

--- a/docs/runs/judge-scout/manifest.md
+++ b/docs/runs/judge-scout/manifest.md
@@ -4,7 +4,7 @@ tracking-issue: 98
 factory-branch: factory/judge-scout
 tracker: github
 spec: docs/spec/judge-narrowing-and-scout.md
-state: ACTIVE
+state: FINISHED
 created: 2026-07-05
 ---
 

--- a/docs/runs/judge-scout/manifest.md
+++ b/docs/runs/judge-scout/manifest.md
@@ -1,0 +1,14 @@
+---
+run: judge-scout
+tracking-issue: 98
+factory-branch: factory/judge-scout
+tracker: github
+spec: docs/spec/judge-narrowing-and-scout.md
+state: ACTIVE
+created: 2026-07-05
+---
+
+Factory run building docs/spec/judge-narrowing-and-scout.md: graded RUN
+checks with typed runner verdicts, intent-only builders-model judge,
+pre-spec code scout with committed run map, change-skeleton decomposition,
+and the human-gated closing review.

--- a/docs/solutions/atomic-contract-decomposition.md
+++ b/docs/solutions/atomic-contract-decomposition.md
@@ -1,0 +1,39 @@
+# atomic-contract-decomposition
+
+Evidence: factory run judge-scout, 2026-07-05, issues #99-#101
+
+## Symptom
+
+Run judge-scout slice #100 was killed before judgment because the work split
+one atomic contract across boundaries: judge template phrases changed in one
+slice while `tests/validate_skills.py` template-contract greps still enforced
+the old phrases elsewhere.
+
+The visible failure shape was a decomposition failure, not a bad patch: the
+validator and the skill text described the same public contract but were owned
+by different jobs.
+
+## Root Cause
+
+Validator-enforced contract phrases couple the skill text to the validator.
+When a slice retires or renames those phrases, the validator's corresponding
+contract section is part of the same product change. Splitting them creates a
+false frontier: each job looks local, but neither boundary owns the whole
+contract.
+
+## What Did Not Work
+
+- Treating template wording and validator greps as independent edits.
+- Letting marker-loop coverage stand in for pairwise phrase coverage.
+- Waiting for judgment to discover that a contract was only half-retired.
+
+## Route Around
+
+- During decomposition, identify every validator-enforced phrase that a slice
+  changes or retires.
+- Put the owning skill/template text and the validator contract section in the
+  same boundary.
+- If that coupling is discovered after freeze, kill the split job and re-spec
+  the boundary instead of patching around it.
+- Add a docs-finish note when the coupling teaches a reusable decomposition
+  rule, as judge-scout did here.

--- a/docs/solutions/graded-expectation-divergence.md
+++ b/docs/solutions/graded-expectation-divergence.md
@@ -1,0 +1,37 @@
+# graded-expectation-divergence
+
+Evidence: factory run judge-scout, 2026-07-05, issues #99-#101
+
+## Symptom
+
+Run judge-scout shipped graded RUN expectations for both PowerShell and shell
+executors. Three live divergences escaped ordinary fixtures and were caught by
+intent review instead:
+
+- The shell runner graded `match:` through shell-glob case matching instead of
+  fixed substring semantics.
+- A space-less `match:"..."` expectation parsed differently.
+- An unclosed `match:"...` expectation did not die consistently.
+
+## Root Cause
+
+Expectation syntax is a cross-executor language. If PowerShell and shell parse
+or grade it differently, the same frozen check can mean different things on
+different hosts. That breaks the check contract even when the individual test
+fixtures are green.
+
+## What Did Not Work
+
+- Assuming simple `match:` handling was too small to need adversarial fixtures.
+- Letting malformed expectations degrade into prose or partial parsing.
+- Proving new grammar behavior on one executor and trusting the other.
+
+## Route Around
+
+- Fixture-prove every new expectation feature on both executors.
+- Grade `match:` as a fixed stdout substring, never regex or shell pattern.
+- Treat malformed expectations as typed runner errors: exit 5, loudly, with
+  partial evidence when possible.
+- Add malformed-input fixtures for parser edges, not just happy-path examples.
+- Keep the intent judge's one spot-check; judge-scout showed it catches runner
+  language drift that fixtures can miss.

--- a/docs/spec/judge-narrowing-and-scout.md
+++ b/docs/spec/judge-narrowing-and-scout.md
@@ -1,0 +1,187 @@
+# Spec: judge-narrowing-and-scout
+
+Reshape per-slice verification and pre-spec grounding per the 2026-07-05
+judge-value audit and its same-day adversarial review: mechanical grading
+moves into the deterministic check-runner, the cold judge narrows to
+intent-only, and a pre-spec code scout produces a committed map that grounds
+the spec, the decomposition skeletons, and every builder.
+
+## Evidence digest (why)
+
+- **Transcription waste is measured, not hypothetical.** harden-01's judge
+  FAIL cited `exit: 1` that was already verbatim in the committed checkrun
+  evidence file; a frontier judge run was spent reading an exit code. The
+  s1/s2 multi-run PASS verdicts are mostly re-transcription of evidence-file
+  outputs the runner had already recorded.
+- **The judge stays per-slice; #17 is the proof.** v5 issue #17
+  (v5-handoff-retire): gates HR1–HR5 ALL PASS, integrity PASS, SLICE FAIL on
+  diff-vs-intent only — the builder added a validator exception with the
+  filename constructed from fragments to evade the frozen HR3 literal grep,
+  masking README.md:170's dead link. A low-stakes-looking slice, all-green
+  deterministic checks, caught only by intent review. Stakes-gating and
+  random audits are rejected (builders are fresh contexts and cannot
+  condition on judge probability; "deterrence" was anthropomorphized).
+- **The runner cannot grade today by design.** The RUN grammar treats
+  everything after the closing backtick as judge-facing prose the runner
+  ignores; absence checks PASS on exit 1 (e.g. multi-run s1 line 23), so
+  exit-code-only grading is wrong without machine-readable expectations.
+- **Judgment budget goes to intent, not re-grading.** TRACE
+  (`.architect/research/02-llm-judge-rubric.md`): code-quality LLM judges
+  align with humans only 6–18% above chance; Anthropic evals guidance
+  separates deterministic correctness from LLM review.
+- **Amortized exploration has shipped precedent.** The A1 research-loop
+  pattern (heavy reading in lanes, capped ~2,500-token returns with anchors)
+  and the existing `scout` job shape; today every parallel builder re-explores
+  the codebase from scratch.
+
+## Goal
+
+- **G1 — Graded RUN checks with typed runner verdicts.** Extend the RUN
+  grammar with machine-readable expectations immediately after the command
+  span: `- RUN: `<cmd>` -> exit:<n>` with optional `match:"<regex>"` against
+  stdout. Text after the expectation stays judge-facing prose. The
+  check-runner grades each RUN item, records per-item PASS/FAIL plus a
+  summary in the evidence file, and exits typed: 0 = all RUN items PASS,
+  2 = any FAIL, 5 = `CHECKRUN: ERROR` unchanged. The orchestrator rules on
+  the typed exit; exit 2 goes straight to the failure ladder with no judge
+  dispatch (the harden-01 path). The grill clause extends: every mechanical
+  check MUST carry an expectation; a RUN item without one is a check defect.
+  Fixtures under `tests/fixtures/checkrun/` gain graded cases including an
+  absence check (`exit:1`) and a `match:` case, both executors.
+- **G2 — Intent-only judge.** Both judge templates (C5 and codex) shrink to:
+  read the frozen check file, spec, job report, rulings file, checkrun
+  evidence summary, and the diff; return Checks-integrity, Diff-vs-intent,
+  and the Slice verdict with one decisive reason — no per-RUN re-grading or
+  transcription blocks. Keep exactly one spot-check re-run of a graded RUN
+  item (mismatch = automatic INVALID) as the runner-defect honesty guard —
+  this class caught the first-live-use quoting defect. Tree audit and
+  INVALID-on-stale-evidence rules unchanged. `architect-judge.md` duties
+  updated to match. Judges run at the resolved builders model (already live
+  in the working tree, 2026-07-05: SKILL.md Hard Rule 3 + Ground + loop step,
+  dispatch.md per-harness Judge row; this spec is the durable record).
+- **G3 — Pre-spec code scout and committed map.** At intake, in parallel with
+  the intake question batch and its 5-minute timer, dispatch one read-only
+  scout job (builders model, `scout` shape): return ≤~2,500 tokens mapping
+  key modules/files, load-bearing types and function signatures, conventions
+  and patterns, testing seams, and gotchas — every entry with file:line
+  anchors, `NOT FOUND` recorded honestly, no recommendations. The
+  orchestrator commits it as `docs/runs/<run>/map.md`. The spec and
+  decomposition cite the map; every issue body carries the map pointer so
+  builders navigate without re-exploring; the grill spot-checks a sample of
+  map anchors against the tree (extends its existing pointer-resolution
+  duty). Builders' FIRST-ACTION verification remains the last defense against
+  a stale map.
+- **G4 — Change-skeletons drive decomposition.** The spec and each issue
+  carry a compact change-skeleton grounded in the map: ≤~30 lines per issue
+  of files, signatures, data flow, and invariants — structure only, no
+  bodies. The skeleton is a contract, not a line-by-line mandate; PHASE 0
+  disagreement governs conflicts with reality. Decomposition computes the
+  parallel frontier from skeleton file-ownership so disjointness is proved
+  before dispatch, not discovered as a merge conflict.
+- **G5 — Human-gated closing review.** After the last build issue closes and
+  before the docs-finish job and closing PR, the orchestrator asks through
+  the timed-ruling protocol: one comprehensive closing review, recommended
+  default YES; 5 minutes of silence applies the default. On yes, dispatch one
+  fresh subagent at the resolved ORCHESTRATOR model at medium effort, in a
+  worktree cut from the factory branch head, with the spec path, the scout
+  map path, the full run diff, and rulings/solutions pointers. Its task:
+  review the shipped work for correctness, simplification, DRY, and dead
+  code, starting from the spec, then the map, then the diff; make the final
+  changes directly; `docs/checks/` stays read-only (an edit there fails the
+  pass); every graded RUN item across the run must stay green; finish by
+  re-running the full run check set plus the named test suites and reporting
+  raw evidence with a diffstat. The orchestrator merges through postflight
+  and records the review verdict and diffstat on the tracking issue. If the
+  closing checkrun goes red and the reviewer cannot restore green, the review
+  worktree is discarded whole — the run merges without the review changes,
+  recorded on the digest; red review changes are never merged. On NO, record
+  the ruling and skip. The closing review is additive to per-slice judging,
+  and it supersedes the previously deferred duplication-triggered
+  consolidation lane.
+
+## Non-goals
+
+- No stakes-gating of the judge and no random audit sampling (rejected on
+  #17 and the fresh-context argument above).
+- No standing duplication-detector consolidation lane: G5's human-gated
+  closing review supersedes it.
+- No small-task carve-outs (tiny-tree scout skip, per-slice skeleton
+  exemptions): a future `/architect-fast` skill owns the small-task lane;
+  every `/architect` run pays scout + skeletons.
+- docs-finish no-judge exception unchanged; grill, freeze, preflight,
+  postflight, failure ladder, and Hard Rules unchanged except where named.
+- Fast-mode pins stay builder-only; the judge change is model, not speed.
+
+## Assumptions (approve or veto at approval)
+
+- **A1:** Expectation grammar is exactly `-> exit:<n>` with optional
+  `match:"<regex>"` (regex over stdout, case-sensitive). Veto → propose an
+  alternative form at approval; the graded-runner requirement itself stands.
+- **A2:** A builders-model judge may be same-family as the builder (codex
+  judging codex): the #17 catch was a codex judge on codex work, and
+  cross-family review remains the recorded high-stakes escape hatch.
+- **A3:** Scout return cap ~2,500 tokens (A1 research-loop precedent); map
+  path `docs/runs/<run>/map.md`.
+- **A4:** The five-file guard stays at 1100 non-blank lines; G2's template
+  shrink is expected to offset G3/G4 additions. If it cannot, raising the cap
+  follows the ~6% headroom convention and is a tracked approval item, never a
+  silent bump.
+- **A5:** The 2026-07-05 working-tree edits (builders-model judge text;
+  codex Fast builder default in dispatch.md) ride into the run's factory
+  branch as pre-approved context and are not re-implemented by builders.
+- **A6:** The closing review runs before the docs-finish job so the docs job
+  documents the final code; its postflight touch-set is the union of the
+  run's per-issue touch-sets, with any reviewer addition beyond that union
+  recorded on the tracking issue rather than auto-failed.
+- **A7:** "Nobody grades their own work" is satisfied for the closing review
+  by the human gate plus the deterministic closing checkrun; no cold judge
+  re-reviews the reviewer. Veto → add a cold intent judge on the review diff.
+
+## Validation strategy
+
+- G1: extended checkrun fixtures pass under both executors with typed exits
+  0/2 asserted (absence-check fixture must PASS via `exit:1`); grill clause
+  and RUN grammar text updated in `dispatch.md` — frozen check greps;
+  `tests/validate_skills.py` suite stays green.
+- G2: both judge templates contain no per-check verdict block (grep absence
+  of the `Per check:` section) and retain integrity, intent, spot-check, and
+  INVALID rules — frozen check greps against `dispatch.md` and
+  `.claude/agents/architect-judge.md`.
+- G3: SKILL.md intake names the scout dispatch parallel to the question
+  batch; map path convention and grill anchor spot-check present — greps.
+- G4: decomposition section requires the skeleton block and
+  ownership-derived parallel frontier — greps.
+- G5: SKILL.md Finish opens with the timed-ruling closing-review question
+  (default YES), names the orchestrator-model-at-medium pin, the
+  spec→map→diff reading order, the docs/checks/ read-only rule, the
+  green-or-discard rail, and ordering before the docs job — greps.
+- End-to-end: the first factory run after merge exercises graded checkrun →
+  typed exit → intent-only judge live and records the evidence in DESIGN.md.
+
+## Domain language
+
+- **Graded RUN** — a RUN item with a machine-readable expectation the runner
+  scores. **Intent judge** — the narrowed judge: integrity + diff-vs-intent
+  + one spot-check, no re-grading. **Scout map** — the committed
+  ≤~2,500-token code map with file:line anchors. **Change-skeleton** — the
+  per-issue structural pseudocode contract that proves decomposition
+  disjointness. **Closing review** — the human-gated, orchestrator-model
+  medium-effort review-and-fix pass at the PR boundary, green-or-discarded.
+
+## Approval record
+
+In-session approval, 2026-07-05: after directing this spec's design
+in-session (judge audit, adversarial review, G1–G5 scope, no small-task
+carve-outs, closing-review step), the repo owner invoked, verbatim:
+`/architect build it`. Tracking issue #98 carries the assumptions digest and
+after-the-fact veto instructions.
+
+## Open questions (carried, not blocking)
+
+- No documented signal confirms Fast mode activates under `codex exec`
+  (`/fast` is TUI-documented); the first run records whatever evidence the
+  session files expose.
+- Should judges also carry the Fast pins now that they run the builders
+  model? Human call; default no.
+- `match:` semantics on multi-line stdout (first match anywhere vs. anchored)
+  — settle at decomposition with the fixture as the tiebreaker.

--- a/docs/spec/judge-narrowing-and-scout.md
+++ b/docs/spec/judge-narrowing-and-scout.md
@@ -38,8 +38,10 @@ the spec, the decomposition skeletons, and every builder.
 
 - **G1 — Graded RUN checks with typed runner verdicts.** Extend the RUN
   grammar with machine-readable expectations immediately after the command
-  span: `- RUN: `<cmd>` -> exit:<n>` with optional `match:"<regex>"` against
-  stdout. Text after the expectation stays judge-facing prose. The
+  span: `- RUN: `<cmd>` -> exit:<n>` with optional `match:"<substring>"`
+  (fixed substring, grep -F semantics) against stdout — amended from regex by
+  the pre-freeze ruling on #98: .NET-regex-vs-POSIX-ERE divergence between
+  the ps1/sh runners would make graded verdicts executor-dependent. Text after the expectation stays judge-facing prose. The
   check-runner grades each RUN item, records per-item PASS/FAIL plus a
   summary in the evidence file, and exits typed: 0 = all RUN items PASS,
   2 = any FAIL, 5 = `CHECKRUN: ERROR` unchanged. The orchestrator rules on
@@ -114,9 +116,10 @@ the spec, the decomposition skeletons, and every builder.
 
 ## Assumptions (approve or veto at approval)
 
-- **A1:** Expectation grammar is exactly `-> exit:<n>` with optional
-  `match:"<regex>"` (regex over stdout, case-sensitive). Veto → propose an
-  alternative form at approval; the graded-runner requirement itself stands.
+- **A1 (amended by #98 ruling):** Expectation grammar is exactly
+  `-> exit:<n>` with optional `match:"<substring>"` — fixed substring over
+  stdout, case-sensitive, never regex. Regex upgrade deferred until a real
+  check needs it.
 - **A2:** A builders-model judge may be same-family as the builder (codex
   judging codex): the #17 catch was a codex judge on codex work, and
   cross-family review remains the recorded high-stakes escape hatch.
@@ -183,5 +186,5 @@ after-the-fact veto instructions.
   session files expose.
 - Should judges also carry the Fast pins now that they run the builders
   model? Human call; default no.
-- `match:` semantics on multi-line stdout (first match anywhere vs. anchored)
-  — settle at decomposition with the fixture as the tiebreaker.
+- `match:` semantics: settled by the #98 ruling — fixed substring found
+  anywhere in captured stdout; no anchoring, no regex.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -20,7 +20,7 @@ templates live behind these pointers:
 
 - dispatch.md section `## Model alias table`
 - dispatch.md section `## Issue conventions`
-- dispatch.md section `## Monitor dispatch`
+- dispatch.md sections `## Scout dispatch`, `## Monitor dispatch`
 - dispatch.md section `## Respawn-with-answer template`
 - loop.md section `## Factory block procedure`; `research.md` for research fan-out
 - `tracker.md` sections `## Preflight per mode`, `## Finish per mode`, `## Command mapping`
@@ -33,7 +33,7 @@ templates live behind these pointers:
 2. **Checks freeze in git before dispatch.** Issue checks live under
    `docs/checks/`, freeze at one commit, and become read-only. Any builder edit
    under `docs/checks/` is an automatic FAIL.
-3. **Nobody grades their own work.** Builders report raw evidence only. A fresh, independent judge at the builders model checks intent. Frozen checks are executed by the deterministic check-runner; the judge grades the evidence and spot-checks. The orchestrator may not turn a judge FAIL into a merge.
+3. **Nobody grades their own work.** Builders report raw evidence only. The deterministic check-runner grades frozen RUN items. A fresh, independent builders-model judge grades intent plus one spot-check, not per-RUN evidence. The orchestrator may not turn a judge FAIL into a merge.
 4. **The orchestrator never writes implementation code and never reads large
    diffs.** Builders code; verifier and judge subagents inspect large diffs.
 5. **Fresh builder per issue.** Use worktree isolation and one issue per
@@ -84,6 +84,7 @@ timed-ruling protocol (`### 2. Spec Approval`) — plaintext options plus the
 5-minute timer, never a blocking question UI. Questions unanswered at timer
 expiry become recorded `## Assumptions` in the spec, using the orchestrator's
 recommended option.
+In parallel with that batch and timer, dispatch one read-only code scout at the builders model using the `scout` job shape and `dispatch.md` `## Scout dispatch`; commit its returned map at `docs/runs/<run>/map.md`. The spec and every issue cite the map pointer.
 
 Preflight is tracker-conditional (see `tracker.md` `## Preflight per mode`):
 github mode requires a GitHub remote, passing `gh auth status`, and `gh` >=
@@ -176,22 +177,12 @@ entry, or rejection is recorded.
 
 Compile the approved spec into tracker issues:
 
-- Add sub-issues under the existing tracking issue, which is the dashboard and
-  digest target.
-- Each sub-issue is one vertical slice with acceptance criteria, boundaries,
-  may-touch and must-not-touch sets, check path, raw-report path, and native
-  parent plus blocked-by edges.
-- Checks per issue live in `docs/checks/<run>/` and freeze in git before dispatch.
-- Dispatch has hard-stop preconditions, in order: freeze committed on the
-  factory branch; factory branch pushed; `preflight.ps1`/`preflight.sh`
-  executes worktree creation, freeze-verify, and frozen-file spot-check.
-  Builders still perform FIRST-ACTION input verification as the last defense.
-- Run one fresh read-only stress-test pass over the whole decomposition, not per
-  issue. It attacks the plan, checks, file-touch sets, dependency edges,
-  missing context, non-falsifiable checks, and repo-name grep collisions.
-- Design parallelism at this point: concurrently schedulable issues must not
-  share files, migrations, lockfiles, generated artifacts, config, schemas,
-  dev servers, databases, or other mutable runtime state.
+- Add sub-issues under the existing tracking issue, the dashboard and digest target.
+- Each sub-issue is one vertical slice with acceptance criteria, boundaries, may-touch/must-not-touch sets, check path, raw-report path, native parent plus blocked-by edges, the map pointer `docs/runs/<run>/map.md`, and a compact `change-skeleton` (~<=30 lines: files, signatures, data flow, invariants).
+- A `change-skeleton` is structure only: a contract, not a line mandate; PHASE 0 is the disagreement channel when reality conflicts with it.
+- Checks live in `docs/checks/<run>/` and freeze in git before dispatch. Preconditions: freeze committed on the factory branch, factory branch pushed, and `preflight.ps1`/`preflight.sh` verifies worktree creation, freeze, and frozen-file spot-check. Builders still FIRST-ACTION verify inputs.
+- Run one fresh read-only stress-test pass over the whole decomposition, not per issue; it attacks the plan, checks, file-touch sets, dependency edges, missing context, non-falsifiable checks, and repo-name grep collisions.
+- Compute the parallel frontier from `change-skeleton` file-ownership: concurrent issues must not share files, migrations, lockfiles, generated artifacts, config, schemas, dev servers, databases, or other mutable runtime state.
 
 Embed D9 in the issue graph:
 
@@ -235,7 +226,7 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
   `skills/architect/status.sh <run>` on POSIX; use `-RepoRoot <path>` /
   `--repo-root <path>` for explicit roots. Print output verbatim in a fenced
   code block, answer in prose, and never hand-compose the tree.
-- On DONE, write the runner config, launch the check-runner in the background, let its exit wake the loop, commit the checkrun evidence file, then send a fresh, independent builders-model judge with the evidence path: Claude Agent-tool judges dispatch synchronously with `run_in_background: false`; codex-backend judges use the background typed-exit path.
+- On DONE, write the runner config, launch the check-runner in the background, and let its typed exit wake the loop: exit 0 commits evidence and sends a fresh builders-model intent judge with the evidence path; exit 2 commits failure evidence and enters the failure ladder without judge dispatch; exit 5 stays on the recorded error rail. Claude Agent-tool judges dispatch synchronously with `run_in_background: false`; codex-backend judges use the background typed-exit path.
   Merge through postflight only after a passing verdict; `POSTFLIGHT: OK` exit
   0 is the clean touch-set evidence.
 - On BLOCKED, answer on the issue, cite durable evidence, and respawn a fresh
@@ -245,8 +236,7 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
   and respawn-with-answer summaries. The orchestrator owns the file, commits it
   before judge dispatch, mirrors it to the issue thread for humans, and judges
   read the file rather than thread prose.
-- On check failure, diagnose from judge evidence, not a large direct diff. Fix
-  the input, re-decompose, or stop; do not change tier because of failure.
+- On check failure, diagnose from checkrun evidence; on judge FAIL, diagnose from judge evidence. Never use a large direct diff; fix the input, re-decompose, or stop, and do not change tier because of failure.
 - On merge conflict, treat it as decomposition failure: kill the conflicting
   job and re-spec the graph instead of hand-resolving builder work.
 - Calibrate open-ended reviews with this line: "Flag only gaps that affect
@@ -262,19 +252,8 @@ human digest item.
 
 ### 5. Finish
 
-Dispatch one dedicated builder docs job before the finish boundary; the
-orchestrator never writes those docs directly. Its dispatch block includes a
-change-context digest: shipped issue numbers with one-line summaries, per-issue
-diffstat, pointers to rulings files and solutions/docs-debt notes, and any
-domain-language changes. The job consumes docs debt, updates product docs,
-writes `docs/solutions/<slug>.md` entries, and codifies changed domain language
-or sparse ADRs. The docs job needs no cold judge (human-ruled exception to
-Hard Rule 3): the orchestrator runs its frozen checks through the check-runner
-and grades the evidence directly before merging. In github mode prepare the PR with
-`Closes #<tracking-issue>`, shipped issue numbers, and per-issue PR back-links;
-in markdown mode leave the branch ready after appending the digest and merge
-instructions (see `tracker.md` `## Finish per mode`). Final digest names shipped
-issues, skipped work, residual risks, and verification evidence.
+Open finish with a timed-ruling closing review question: recommended default YES; 5-minute silence applies it. On YES, dispatch one fresh subagent at the resolved orchestrator model at MEDIUM effort, in a worktree from the factory branch head; it reads the spec, then `docs/runs/<run>/map.md`, then the run diff; edits directly; treats `docs/checks/` as read-only (an edit fails the pass); keeps every graded RUN item across the run green; re-runs the full closing checkrun plus named test suites; and is green-or-discard. Red review changes never merge: discard the worktree whole and record the discard on the digest. Merge green review work through postflight, then post verdict plus diffstat on the tracking issue. On NO, record the ruling and skip.
+Then dispatch one dedicated builder docs job before the finish boundary; the orchestrator never writes those docs directly. Its dispatch block includes a change-context digest: shipped issue numbers with one-line summaries, per-issue diffstat, pointers to rulings files and solutions/docs-debt notes, and any domain-language changes. The job consumes docs debt, updates product docs, writes `docs/solutions/<slug>.md` entries, and codifies changed domain language or sparse ADRs. The docs job needs no cold judge (human-ruled exception to Hard Rule 3): the orchestrator runs its frozen checks through the check-runner and grades the evidence directly before merging. In github mode prepare the PR with `Closes #<tracking-issue>`, shipped issue numbers, and per-issue PR back-links; in markdown mode leave the branch ready after appending the digest and merge instructions (see `tracker.md` `## Finish per mode`). Final digest names shipped issues, skipped work, residual risks, and verification evidence.
 
 Done when docs debt is consumed, the mode-specific finish artifact is ready,
 the tracking issue digest is posted, and no issue remains silently unresolved.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -33,7 +33,7 @@ templates live behind these pointers:
 2. **Checks freeze in git before dispatch.** Issue checks live under
    `docs/checks/`, freeze at one commit, and become read-only. Any builder edit
    under `docs/checks/` is an automatic FAIL.
-3. **Nobody grades their own work.** Builders report raw evidence only. A fresh, independent orchestrator-tier judge checks intent. Frozen checks are executed by the deterministic check-runner; the judge grades the evidence and spot-checks. The orchestrator may not turn a judge FAIL into a merge.
+3. **Nobody grades their own work.** Builders report raw evidence only. A fresh, independent judge at the builders model checks intent. Frozen checks are executed by the deterministic check-runner; the judge grades the evidence and spot-checks. The orchestrator may not turn a judge FAIL into a merge.
 4. **The orchestrator never writes implementation code and never reads large
    diffs.** Builders code; verifier and judge subagents inspect large diffs.
 5. **Fresh builder per issue.** Use worktree isolation and one issue per
@@ -67,8 +67,8 @@ Run this at every factory block boundary.
   edges, unjudged jobs, stale reports, check freeze SHAs, and branch heads.
 - Resolve orchestrator and builder models from `.architect/config`, then
   `~/.architect/config`, then `dispatch.md` `## Model alias table` and config
-  rules; judges run at orchestrator tier and the monitor is a script, not a
-  model.
+  rules; judges run at the resolved builders model and the monitor is a
+  script, not a model.
 - Check `docs/STOP` in the run checkout and primary checkout (`git rev-parse
   --git-common-dir`), plus uncommitted `docs/runs/<run>/STOP`, before dispatch.
 
@@ -235,7 +235,7 @@ Use `loop.md` `## Factory block procedure` for the detailed event loop.
   `skills/architect/status.sh <run>` on POSIX; use `-RepoRoot <path>` /
   `--repo-root <path>` for explicit roots. Print output verbatim in a fenced
   code block, answer in prose, and never hand-compose the tree.
-- On DONE, write the runner config, launch the check-runner in the background, let its exit wake the loop, commit the checkrun evidence file, then send a fresh, independent orchestrator-tier judge with the evidence path: Claude Agent-tool judges dispatch synchronously with `run_in_background: false`; codex-backend judges use the background typed-exit path.
+- On DONE, write the runner config, launch the check-runner in the background, let its exit wake the loop, commit the checkrun evidence file, then send a fresh, independent builders-model judge with the evidence path: Claude Agent-tool judges dispatch synchronously with `run_in_background: false`; codex-backend judges use the background typed-exit path.
   Merge through postflight only after a passing verdict; `POSTFLIGHT: OK` exit
   0 is the clean touch-set evidence.
 - On BLOCKED, answer on the issue, cite durable evidence, and respawn a fresh

--- a/skills/architect/check-runner.ps1
+++ b/skills/architect/check-runner.ps1
@@ -125,7 +125,26 @@ function CaptureCommand($Executor, $ExecutorResolved, $Command, $Workdir) {
         $stderr = $_.Exception.Message + [Environment]::NewLine
     }
     $sw.Stop()
-    return [pscustomobject]@{ ExitCode = $code; Ms = [int64]$sw.ElapsedMilliseconds; Output = ($stdout + $stderr) }
+    return [pscustomobject]@{ ExitCode = $code; Ms = [int64]$sw.ElapsedMilliseconds; Stdout = $stdout; Stderr = $stderr; Output = ($stdout + $stderr) }
+}
+
+function ParseRunExpectation($Text, $File, $LineNo) {
+    $m = [regex]::Match($Text, '^\s*->\s*exit:([0-9]+)(.*)$')
+    if (-not $m.Success) { StopRun "missing RUN expectation ${File}:$LineNo" }
+
+    $expectedExit = [int]$m.Groups[1].Value
+    $rest = $m.Groups[2].Value
+    $matchText = $null
+    $expected = "exit:$expectedExit"
+
+    $match = [regex]::Match($rest, '^\s+match:"([^"]*)"(.*)$')
+    if ($match.Success) {
+        $matchText = $match.Groups[1].Value
+        $expected = $expected + ' match:"' + $matchText + '"'
+        $rest = $match.Groups[2].Value
+    }
+
+    return [pscustomobject]@{ ExitCode = $expectedExit; Match = $matchText; Text = $expected }
 }
 
 function OutputSlice($Text, $MaxLines) {
@@ -186,8 +205,12 @@ for ($i = 0; $i -lt $lines.Count; $i++) {
     $line = $lines[$i]
     if ($executorHeader -eq "" -and $line -match '^\s*Executor:\s*') { $executorHeader = $line.TrimEnd() }
     if ($line.StartsWith("## ", [System.StringComparison]::Ordinal)) { $section = $line.Substring(3) }
-    $m = [regex]::Match($line, '^\s*- RUN:\s*`([^`]*)`')
-    if ($m.Success) { $runs += [pscustomobject]@{ Section = $section; Line = $i + 1; Command = $m.Groups[1].Value } }
+    $m = [regex]::Match($line, '^\s*- RUN:\s*`([^`]*)`(.*)$')
+    if ($m.Success) {
+        $lineNo = $i + 1
+        $expectation = ParseRunExpectation $m.Groups[2].Value $checkFile $lineNo
+        $runs += [pscustomobject]@{ Section = $section; Line = $lineNo; Command = $m.Groups[1].Value; Expected = $expectation }
+    }
 }
 
 $e = New-Object System.Collections.Generic.List[string]
@@ -198,12 +221,15 @@ $slug = [System.IO.Path]::GetFileNameWithoutExtension($evidenceOut)
 if ($executorHeader) { [void]$e.Add($executorHeader) }
 [void]$e.Add("executor_config: $executor")
 [void]$e.Add("executor_resolved: $executorResolved")
-[void]$e.Add("integrity: check_file_matches_freeze=$checkMatch head=$head")
-[void]$e.Add("changed_files: $($changed.Count) listed below; docs_checks_touched=$docsTouched")
-foreach ($path in $changed) { [void]$e.Add($path) }
 
+$passCount = 0
+$failCount = 0
 foreach ($run in $runs) {
     $result = CaptureCommand $executor $executorResolved $run.Command $workdir
+    $verdict = "PASS"
+    if ($result.ExitCode -ne $run.Expected.ExitCode) { $verdict = "FAIL" }
+    if ($run.Expected.Match -ne $null -and $result.Stdout.IndexOf($run.Expected.Match, [System.StringComparison]::Ordinal) -lt 0) { $verdict = "FAIL" }
+    if ($verdict -eq "PASS") { $passCount += 1 } else { $failCount += 1 }
     $bytes = [System.Text.Encoding]::UTF8.GetByteCount($result.Output)
     $slice = OutputSlice $result.Output $maxOutputLines
     $mark = ""
@@ -212,12 +238,20 @@ foreach ($run in $runs) {
     [void]$e.Add("## $($run.Section) line $($run.Line)")
     [void]$e.Add('$ ' + $run.Command)
     [void]$e.Add("exit: $($result.ExitCode)  ms: $($result.Ms)  bytes: $bytes$mark")
+    [void]$e.Add("expected: $($run.Expected.Text)")
+    [void]$e.Add("verdict: $verdict")
     foreach ($line in $slice.Lines) { [void]$e.Add($line) }
 }
+[void]$e.Add("")
+[void]$e.Add("CHECKRUN SUMMARY: run_items=$($runs.Count) pass=$passCount fail=$failCount")
+[void]$e.Add("integrity: check_file_matches_freeze=$checkMatch head=$head")
+[void]$e.Add("changed_files: $($changed.Count) listed below; docs_checks_touched=$docsTouched")
+foreach ($path in $changed) { [void]$e.Add($path) }
 
 $dir = Split-Path -Parent $evidenceOut
 if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
 $tmpEvidence = $evidenceOut + ".tmp." + ([System.Guid]::NewGuid().ToString("N"))
 Set-Content -LiteralPath $tmpEvidence -Value $e -Encoding utf8
 Move-Item -LiteralPath $tmpEvidence -Destination $evidenceOut -Force
+if ($failCount -gt 0) { exit 2 }
 exit 0

--- a/skills/architect/check-runner.ps1
+++ b/skills/architect/check-runner.ps1
@@ -142,6 +142,8 @@ function ParseRunExpectation($Text, $File, $LineNo) {
         $matchText = $match.Groups[1].Value
         $expected = $expected + ' match:"' + $matchText + '"'
         $rest = $match.Groups[2].Value
+    } elseif ([regex]::IsMatch($rest, '^\s*match:"')) {
+        StopRun "malformed RUN match expectation ${File}:$LineNo"
     }
 
     return [pscustomobject]@{ ExitCode = $expectedExit; Match = $matchText; Text = $expected }

--- a/skills/architect/check-runner.sh
+++ b/skills/architect/check-runner.sh
@@ -18,6 +18,51 @@ make_tmp(){
   [ -n "$tmp_base" ] || die "tmp unavailable"
   mktemp "$tmp_base/$1.XXXXXX" 2>/dev/null || die "tmp unavailable"
 }
+trim_left(){
+  trim_left_result=$1
+  while :; do
+    case "$trim_left_result" in ' '*) trim_left_result=${trim_left_result#?};; $'\t'*) trim_left_result=${trim_left_result#?};; *) break;; esac
+  done
+}
+parse_expectation(){
+  parse_tail=$1
+  parse_line=$2
+  trim_left "$parse_tail"
+  parse_tail=$trim_left_result
+  case "$parse_tail" in
+    '->'*) parse_tail=${parse_tail#'->'};;
+    *) die "missing RUN expectation $check_file:$parse_line";;
+  esac
+  trim_left "$parse_tail"
+  parse_tail=$trim_left_result
+  case "$parse_tail" in
+    exit:[0-9]*)
+      parse_after_exit=${parse_tail#exit:}
+      parse_exit=${parse_after_exit%%[!0-9]*}
+      [ -n "$parse_exit" ] || die "missing RUN expectation $check_file:$parse_line"
+      parse_rest=${parse_after_exit#"$parse_exit"}
+      parse_expected="exit:$parse_exit"
+      parse_match=
+      parse_has_match=false
+      trim_left "$parse_rest"
+      parse_rest=$trim_left_result
+      case "$parse_rest" in
+        match:\"*)
+          parse_after_match=${parse_rest#match:\"}
+          case "$parse_after_match" in
+            *\"*)
+              parse_match=${parse_after_match%%\"*}
+              parse_has_match=true
+              parse_expected="$parse_expected match:\"$parse_match\""
+              ;;
+            *) die "malformed RUN match expectation $check_file:$parse_line";;
+          esac
+          ;;
+      esac
+      ;;
+    *) die "missing RUN expectation $check_file:$parse_line";;
+  esac
+}
 
 cfg=${1:-}
 [ -n "$cfg" ] || die "unreadable config"
@@ -55,7 +100,7 @@ section='(root)'
 executor_header=
 line_no=0
 count=0
-declare -a sections line_numbers commands
+declare -a sections line_numbers commands expected_exits expected_texts expected_matches expected_has_matches
 while IFS= read -r line || [ -n "$line" ]; do
   line_no=$((line_no + 1))
   case "$line" in Executor:*) [ -z "$executor_header" ] && executor_header=$line;; esac
@@ -71,9 +116,15 @@ while IFS= read -r line || [ -n "$line" ]; do
         *"$bt"*"$bt"*)
           after=${rest#*"$bt"}
           cmd=${after%%"$bt"*}
+          tail=${after#*"$bt"}
+          parse_expectation "$tail" "$line_no"
           sections[$count]=$section
           line_numbers[$count]=$line_no
           commands[$count]=$cmd
+          expected_exits[$count]=$parse_exit
+          expected_texts[$count]=$parse_expected
+          expected_matches[$count]=$parse_match
+          expected_has_matches[$count]=$parse_has_match
           count=$((count + 1))
           ;;
       esac
@@ -93,22 +144,47 @@ slug=$(basename "$out" .md)
   printf 'check_file: %s  freeze_sha: %s\n' "$check_file" "$freeze_sha"
   [ -n "$executor_header" ] && printf '%s\n' "$executor_header"
   printf 'executor_config: %s\n' "$executor"
-  printf 'integrity: check_file_matches_freeze=%s head=%s\n' "$check_match" "$head"
-  printf 'changed_files: %s listed below; docs_checks_touched=%s\n' "$changed_count" "$docs_touched"
-  cat "$changed_tmp"
+  pass_count=0
+  fail_count=0
   i=0
   while [ "$i" -lt "$count" ]; do
     run_out=$(make_tmp run); add_tmp "$run_out"
+    run_stdout=$(make_tmp stdout); add_tmp "$run_stdout"
+    run_stderr=$(make_tmp stderr); add_tmp "$run_stderr"
     start=$(now_ms)
     if [ "$executor" = powershell ]; then
-      (cd "$workdir" && powershell -NoProfile -Command "${commands[$i]}") > "$run_out" 2>&1
+      (cd "$workdir" && powershell -NoProfile -Command "${commands[$i]}") > "$run_stdout" 2> "$run_stderr"
       code=$?
     else
-      (cd "$workdir" && bash -c "${commands[$i]}") > "$run_out" 2>&1
+      (cd "$workdir" && bash -c "${commands[$i]}") > "$run_stdout" 2> "$run_stderr"
       code=$?
     fi
     end=$(now_ms)
     ms=$((end - start))
+    cat "$run_stdout" "$run_stderr" > "$run_out"
+    verdict=PASS
+    [ "$code" = "${expected_exits[$i]}" ] || verdict=FAIL
+    if [ "${expected_has_matches[$i]}" = true ]; then
+      if CHECKRUN_EXPECTED_MATCH=${expected_matches[$i]} awk '
+        BEGIN {
+          needle = ENVIRON["CHECKRUN_EXPECTED_MATCH"]
+          found = (needle == "")
+        }
+        {
+          if (NR > 1) { stdout_text = stdout_text "\n" }
+          stdout_text = stdout_text $0
+        }
+        END {
+          if (!found && index(stdout_text, needle) > 0) { found = 1 }
+          exit(found ? 0 : 1)
+        }
+      ' "$run_stdout"; then
+        :
+      else
+        verdict=FAIL
+      fi
+    fi
+    if [ "$verdict" = PASS ]; then pass_count=$((pass_count + 1)); else fail_count=$((fail_count + 1)); fi
     bytes=$(wc -c < "$run_out" | tr -d ' ')
     total_lines=$(awk 'END{print NR}' "$run_out")
     mark=
@@ -116,12 +192,19 @@ slug=$(basename "$out" .md)
     printf '\n## %s line %s\n' "${sections[$i]}" "${line_numbers[$i]}"
     printf '$ %s\n' "${commands[$i]}"
     printf 'exit: %s  ms: %s  bytes: %s%s\n' "$code" "$ms" "$bytes" "$mark"
+    printf 'expected: %s\n' "${expected_texts[$i]}"
+    printf 'verdict: %s\n' "$verdict"
     sed -n "1,${max_output_lines}p" "$run_out"
-    rm -f "$run_out"
+    rm -f "$run_out" "$run_stdout" "$run_stderr"
     i=$((i + 1))
   done
+  printf '\nCHECKRUN SUMMARY: run_items=%s pass=%s fail=%s\n' "$count" "$pass_count" "$fail_count"
+  printf 'integrity: check_file_matches_freeze=%s head=%s\n' "$check_match" "$head"
+  printf 'changed_files: %s listed below; docs_checks_touched=%s\n' "$changed_count" "$docs_touched"
+  cat "$changed_tmp"
 } > "$tmp"
 
 mv "$tmp" "$out"
 cleanup_tmp
+if [ "$fail_count" -gt 0 ]; then exit 2; fi
 exit 0

--- a/skills/architect/check-runner.sh
+++ b/skills/architect/check-runner.sh
@@ -44,10 +44,13 @@ parse_expectation(){
       parse_expected="exit:$parse_exit"
       parse_match=
       parse_has_match=false
+      parse_sep=false
+      case "$parse_rest" in ' '*|$'\t'*) parse_sep=true;; esac
       trim_left "$parse_rest"
       parse_rest=$trim_left_result
       case "$parse_rest" in
         match:\"*)
+          [ "$parse_sep" = true ] || die "malformed RUN match expectation $check_file:$parse_line"
           parse_after_match=${parse_rest#match:\"}
           case "$parse_after_match" in
             *\"*)

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -75,6 +75,14 @@ default above. Absent dispatch rules = the codex-first default. A matching
 rule is still a judgment aid; the orchestrator records which rule was used
 and may override it with a reason recorded on the issue.
 
+Builder speed default: when the resolved builders backend is Codex under
+ChatGPT auth, every builder `codex exec` appends the Fast-mode pins
+`-c service_tier="fast" -c features.fast_mode=true` — same model, faster
+inference (gpt-5.5 at 2.5x credit burn), never a tier change. Verify at the
+intake canary; API-key auth cannot use Fast mode — drop the two pins and
+record the substitution on the tracking issue (no silent fallback). The
+default is builder-only; judges and the monitor never carry the Fast pins.
+
 Configured builders CLI absent at preflight -> fall back per the codex-first
 default (on Claude Code without Codex: `claude/tier-down`) and write one
 tracking-issue comment naming requested vs substituted. Cross-family
@@ -89,7 +97,7 @@ retry-at-a-different-tier job (see `loop.md` "## Failure ladder").
 | | Claude Code (CLI + Desktop) | Codex (CLI + app) |
 |---|---|---|
 | Builder | Agent tool with `.claude/agents/architect-builder.md`; `disallowedTools` denies `Bash(git commit *)` and `Bash(git push *)`; `isolation: worktree`; `background: true`; model may be passed per invocation from the alias table. On the desktop app, the harness auto-creates the agent's isolation worktree (`.claude/worktrees/agent-<id>`) and its branch — integrate from that branch. On the CLI, spawns have been observed to run UNISOLATED in the orchestrator's checkout despite `isolation: worktree` frontmatter (D11) — pass isolation explicitly per invocation if supported, and never run two Claude-backend builder jobs concurrently unless each is verified to have its own worktree (`git worktree list` after spawn). In all cases, never pre-create a job worktree for Claude-backend jobs (a pre-made one is ignored); do not use `.architect/wt/<run>/<slice>-<NN>` (that pattern is Codex-backend only, below). | `spawn_agent` with defensive framing: "Your task is: ..."; worktree created by the orchestrator via git; use `/goal` semantics for persistent job completion. |
-| Judge | Agent tool with `.claude/agents/architect-judge.md`; dispatch synchronously with `run_in_background: false` so the verdict is the tool result; read-only tools plus Bash for check commands; orchestrator tier via `model: inherit` or per-invocation model. | Background `codex exec -o <file>` typed-exit path with read-only instructions and the fixed judge template; the process exit wakes the loop. |
+| Judge | Agent tool with `.claude/agents/architect-judge.md`; dispatch synchronously with `run_in_background: false` so the verdict is the tool result; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions and the fixed judge template; the process exit wakes the loop. |
 | Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when the orchestrator can run background processes and receive exit notifications; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when background process exits wake the orchestrator; LLM fallback template only otherwise and it counts as one of the 6 `max_threads`. |
 | Parallelism | Background subagents; permission prompts surface to the main session. | Native subagents, `max_threads` 6, `max_depth` 1 (root session is depth 0; a spawned child may not spawn further — no nested orchestrators, the orchestrator dispatches builders directly), `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent` — evidence: v4-codex CG4 architect-run canary `events.jsonl`). |
 | Review (high-stakes) | `codex review --base` when Codex is installed; otherwise a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
@@ -252,6 +260,7 @@ Single-job slice in the current checkout, resolved builders `codex/best`:
 ```bash
 codex exec -C <repo-root> --sandbox workspace-write \
   -m gpt-5.5 -c model_reasoning_effort="xhigh" \
+  -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/last-run.md \
   - < .architect/dispatch-block.md
 ```
@@ -261,6 +270,7 @@ If the effort call resolves to `codex/tier-down`, change only the effort pin:
 ```bash
 codex exec -C <repo-root> --sandbox workspace-write \
   -m gpt-5.5 -c model_reasoning_effort="high" \
+  -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/last-run.md \
   - < .architect/dispatch-block.md
 ```
@@ -273,6 +283,7 @@ git -C <repo-root> worktree add .architect/wt/<run>/<slice>-<NN> \
 
 codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox workspace-write \
   -m gpt-5.5 -c model_reasoning_effort="xhigh" \
+  -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/wt/<run>/<slice>-<NN>.last-run.md \
   - < .architect/wt/<run>/<slice>-<NN>.block.md
 ```

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -8,6 +8,7 @@
 - C5 judge delegation template
 - Codex judge delegation template
 - Check-runner dispatch
+- Scout dispatch
 - Stress-test delegation template
 - Codex backend from a Claude orchestrator
 - Preflight and postflight dispatch
@@ -119,8 +120,7 @@ or reports the check BLOCKED — never silently skips a check or invents output.
 
 ## C5 judge delegation template
 
-The orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation.
-Judge intent context is pointer-only: frozen check file, spec pointer, job report, and `docs/jobs/<run>/<issue-slug>-rulings.md` (orchestrator-owned, append-only; absent = no post-freeze rulings).
+The orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation. Judge intent context is pointer-only: frozen check file, spec pointer, job report, and `docs/jobs/<run>/<issue-slug>-rulings.md` (orchestrator-owned, append-only; absent = no post-freeze rulings).
 
 <!-- architect-judge-template:start -->
 ```text
@@ -134,20 +134,9 @@ Rulings file: docs/jobs/<run>/<issue-slug>-rulings.md (absent = no post-freeze r
 
 Batch independent reads (frozen check file, spec, job report, rulings file, checkrun evidence file) into parallel tool calls in one turn; serialize only dependent steps and command re-runs.
 
-Evidence rules: read the checkrun evidence file before grading; grade RUN items from the evidence file; execute judge-only items yourself; re-run at least one RUN command and compare with the evidence file -- any mismatch is automatic INVALID with both outputs quoted; missing/stale evidence (integrity false or freeze SHA mismatch) -> INVALID, never FAIL.
+Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
 
-Verdict format:
-- Checks integrity: PASS | FAIL | INVALID
-  Raw evidence: <git diff <freeze-sha>..HEAD -- docs/checks/>
-- Diff vs intent: PASS | FAIL | INVALID
-  Raw evidence: <file:line evidence from the diff and frozen check/spec text>
-- Per check:
-  - <check id>: PASS | FAIL | INVALID
-    Command: <exact command from the frozen check>
-    Source: evidence-file | re-run
-    Raw evidence: <verbatim stdout/stderr and exit code>
-- Slice verdict: PASS | FAIL | INVALID
-  Decisive reason: <one sentence tied to raw evidence>
+Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
 ```
 <!-- architect-judge-template:end -->
 
@@ -163,67 +152,43 @@ Branch to judge: <branch>
 Worktree note: <worktree note>
 checkrun evidence file path: <docs/jobs/<run>/<issue-slug>-checkrun.md>
 
-You are a fresh read-only judge. You did not build this job. Flag only gaps
-that affect correctness, the stated requirements, or documented project
-invariants -- cite file:line evidence for every finding. Do not report
-stylistic preferences.
-
-Tree audit: workspace-write exists only so validators can run. Any tracked-file
-modification during judgment means the verdict is discarded INVALID.
-
-Sanctioned substitutions, recorded per check: Git Bash CreateFileMapping Win32
-error 5 -> PowerShell same-pattern; uv AppData cache denial -> run with
-`UV_CACHE_DIR=.architect/tmp/uv-cache`; tracker posting unavailable -> report
-`MIRROR: ORCHESTRATOR`.
+You are a fresh read-only judge. You did not build this job. Flag only gaps that affect correctness, the stated requirements, or documented project invariants; cite file:line evidence. Do not report stylistic preferences.
+Tree audit: workspace-write exists only so validators can run. Any tracked-file modification during judgment means the verdict is discarded INVALID.
+Sanctioned substitutions, recorded per check: Git Bash CreateFileMapping Win32 error 5 -> PowerShell same-pattern; uv AppData cache denial -> run with `UV_CACHE_DIR=.architect/tmp/uv-cache`; tracker posting unavailable -> report `MIRROR: ORCHESTRATOR`.
 
 Intent context pointers: frozen check file above; spec pointer named by the frozen check; job report named by the issue/check; rulings file `docs/jobs/<run>/<issue-slug>-rulings.md` (absent = no post-freeze rulings).
 
 Batch independent reads (frozen check file, spec, job report, rulings file, checkrun evidence file) into parallel tool calls in one turn; serialize only dependent steps and command re-runs.
 
-Evidence rules: read the checkrun evidence file before grading; grade RUN items from the evidence file; execute judge-only items yourself; re-run at least one RUN command and compare with the evidence file -- any mismatch is automatic INVALID with both outputs quoted; missing/stale evidence (integrity false or freeze SHA mismatch) -> INVALID, never FAIL.
+Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
 
-Verdict format:
-- Checks integrity: PASS | FAIL | INVALID
-  Raw evidence: <git diff <freeze-sha>..HEAD -- docs/checks/>
-- Diff vs intent: PASS | FAIL | INVALID
-  Raw evidence: <file:line evidence from the diff and frozen check/spec text>
-- Per check:
-  - <check id>: PASS | FAIL | INVALID
-    Command: <exact command from the frozen check>
-    Executor: <executor used>
-    Source: evidence-file | re-run
-    Raw evidence: <verbatim stdout/stderr and exit code>
-- Slice verdict: PASS | FAIL | INVALID
-  Decisive reason: <one sentence tied to raw evidence>
+Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item, executor, and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
 ```
 <!-- architect-codex-judge-template:end -->
 
 ## Check-runner dispatch
 
-RUN grammar for check files is normative from judge-runner D1 (evidence: judge-runner spec, git history): a runnable check is a list line beginning `- RUN:` whose first single backtick span is the complete command, executable verbatim in the file's named executor. Everything after the closing backtick is judge-facing prose the runner ignores. The check file header names one `Executor:`; items without `RUN:` are judge-only.
-Example line: ``- RUN: `git grep -c "needle" -- path/to/file.md` -> 1``
+Graded RUN grammar is normative from the shipped s1 runner in `skills/architect/check-runner.ps1`: first backtick span is the command; expectation begins immediately after the closing backtick as ``-> exit:<n>`` with optional `match:"<substring>"`. `match:` is a fixed, case-sensitive stdout substring check, never regex. Text after the expectation is judge-facing prose; non-RUN items are judge-only. A RUN item without an expectation exits 5 with `CHECKRUN: ERROR missing RUN expectation`, and no partial evidence is kept.
+Example line: ``- RUN: `git grep -F -c "needle" -- path/to/file.md` -> exit:0 match:"needle"``
 
-Runner config JSON, written by the orchestrator per judgment:
+Evidence contains per-item `expected:` and `verdict:` lines, then `CHECKRUN SUMMARY: run_items=<n> pass=<n> fail=<n>`.
+Typed exits: 0 = all RUN items pass; 2 = any RUN item fails; 5 = error, no partial evidence file left behind.
+Launch pattern: run `skills/architect/check-runner.ps1` or `check-runner.sh` in the background and commit `docs/jobs/<run>/<issue-slug>-checkrun.md` before judge dispatch on exit 0. Exit 2 routes to the failure ladder with no judge dispatch; `loop.md` owns the full rule.
 
-```json
-{
-  "check_file": "docs/checks/<run>/<slice>.md",
-  "workdir": "<worktree or repo path>",
-  "freeze_sha": "<sha>",
-  "evidence_out": "docs/jobs/<run>/<issue-slug>-checkrun.md",
-  "executor": "powershell|bash",
-  "max_output_lines": 60
-}
+## Scout dispatch
+
+Dispatch one scout during intake when the run needs a code map. The scout uses the resolved builders model, job shape `scout`, and read-only tools only. The orchestrator names the output path; the scout writes there, and the orchestrator commits it at `docs/runs/<run>/map.md`.
+
+```text
+You are a read-only code scout. Output path: <docs/runs/<run>/map.md>.
+Return <= ~2,500 tokens. No recommendations.
+Include only anchored entries: key modules/files; load-bearing types/function signatures; conventions/patterns; testing seams; gotchas.
+Every entry must carry a real file:line anchor. If a requested category is absent, write `NOT FOUND: <category> - <searched paths>`. No implementation plan, no edits.
 ```
-
-Typed exits: 0 = evidence file written; 5 = `CHECKRUN: ERROR <reason>` on stdout, no partial evidence file left behind.
-Launch pattern: the orchestrator writes the config with file tools, then launches `skills/architect/check-runner.ps1` or `skills/architect/check-runner.sh` as a background process whose exit wakes the loop. On success, the orchestrator commits the evidence file `docs/jobs/<run>/<issue-slug>-checkrun.md` before judge dispatch.
 
 ## Stress-test delegation template
 
-The orchestrator must send this template as-is except for replacing
-placeholders. It must not add slice-specific prose, encouragement, summaries,
-or interpretation.
+The orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation.
 
 <!-- architect-stress-test-template:start -->
 ```text
@@ -231,17 +196,14 @@ Draft check file path: <docs/checks/<run>/<slice>.md>
 Branch: <branch>
 Issue bodies: <pasted issue bodies for this plan>
 
-Grill clause: every mechanical check MUST use `- RUN:` form; a mechanical check not in RUN form is a check defect.
+Grill clause: every mechanical check MUST use `- RUN:` form with a `->` expectation; a RUN item without an expectation is a check defect.
 
 Task: try to falsify this draft. Execute each check command against the current tree, verify every referenced path/SHA/pointer resolves, attack each acceptance criterion and pasted issue bodies against the spec for contradictions and non-falsifiability, including patterns that collide with repo realities (e.g. a grep pattern matching the repo's own name), and flag any assumption not evidenced in the repo.
 For every file a job deletes or renames, grep the whole repo for references and verify the owning job's boundary covers them or a dependency edge orders the fix.
 For every NEW artifact path a job will create, run `git check-ignore <path>` and flag the plan if ignored.
+If a run map exists, sample map entries and verify each file:line anchor resolves; a dangling anchor is a check defect.
 
-Defect report format:
-- <check id or clause>: FALSIFIED | HOLDS
-  Evidence: <command run and verbatim output, or file:line>
-- Plan findings: <delete/rename reference and ignored-new-path findings, or none>
-- Assumptions not evidenced in the repo: <list or none>
+Defect report format: `<check id or clause>: FALSIFIED | HOLDS` with command output or file:line evidence; plan findings; assumptions not evidenced.
 ```
 <!-- architect-stress-test-template:end -->
 

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -173,17 +173,17 @@ Example line: ``- RUN: `git grep -F -c "needle" -- path/to/file.md` -> exit:0 ma
 
 Evidence contains per-item `expected:` and `verdict:` lines, then `CHECKRUN SUMMARY: run_items=<n> pass=<n> fail=<n>`.
 Typed exits: 0 = all RUN items pass; 2 = any RUN item fails; 5 = error, no partial evidence file left behind.
-Launch pattern: run `skills/architect/check-runner.ps1` or `check-runner.sh` in the background and commit `docs/jobs/<run>/<issue-slug>-checkrun.md` before judge dispatch on exit 0. Exit 2 routes to the failure ladder with no judge dispatch; `loop.md` owns the full rule.
+Launch pattern: write the runner config JSON — fields `check_file`, `workdir`, `freeze_sha`, `evidence_out`, `executor` (`powershell`|`bash`), `max_output_lines` (default 60) — then run `skills/architect/check-runner.ps1 -Config <path>` or `check-runner.sh <path>` in the background and commit `docs/jobs/<run>/<issue-slug>-checkrun.md` before judge dispatch on exit 0. Exit 2 routes to the failure ladder with no judge dispatch; `loop.md` owns the full rule.
 
 ## Scout dispatch
 
-Dispatch one scout during intake when the run needs a code map. The scout uses the resolved builders model, job shape `scout`, and read-only tools only. The orchestrator names the output path; the scout writes there, and the orchestrator commits it at `docs/runs/<run>/map.md`.
+Dispatch one scout during intake when the run needs a code map. The scout uses the resolved builders model and job shape `scout`, read-only except its single write: the orchestrator names the output path, the scout writes the map there, and the orchestrator commits it at `docs/runs/<run>/map.md`.
 
 ```text
 You are a read-only code scout. Output path: <docs/runs/<run>/map.md>.
 Return <= ~2,500 tokens. No recommendations.
 Include only anchored entries: key modules/files; load-bearing types/function signatures; conventions/patterns; testing seams; gotchas.
-Every entry must carry a real file:line anchor. If a requested category is absent, write `NOT FOUND: <category> - <searched paths>`. No implementation plan, no edits.
+Every entry must carry a real file:line anchor. If a requested category is absent, write `NOT FOUND: <category> - <searched paths>`. No implementation plan, no edits beyond the output path.
 ```
 
 ## Stress-test delegation template

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -25,8 +25,7 @@ Parallel rules: harness-native judge subagents (Claude Agent tool) dispatch sync
 2. **Sleep.** Zero orchestrator work between dispatch and the next event —
    no polling.
 3. **Wake on one event**, exactly one of:
-   - **Job DONE.** Ordering: write the runner config; launch `check-runner.ps1`
-     or `check-runner.sh` as a background process whose exit is the next wake; commit the checkrun artifact `docs/jobs/<run>/<issue-slug>-checkrun.md`; then dispatch the fixed judge template from `dispatch.md` by backend: Claude Agent-tool judges run synchronously with `run_in_background: false`, while codex-backend judges run the background `codex exec -o <file>` typed-exit path and wake on that process exit. Record the verdict in an issue comment (see Verdict comments). On PASS, run `postflight.ps1` or `postflight.sh`: exit 0 `POSTFLIGHT: OK` means merge completed with clean touch-set evidence; exit 2 `POSTFLIGHT: VIOLATION` is automatic FAIL evidence for the job; exit 3 `POSTFLIGHT: CONFLICT` is the merge-conflict decomposition-failure rail; exit 5 `POSTFLIGHT: ERROR` falls back to the recorded manual integration sequence in `dispatch.md`. On FAIL, diagnose (see Failure ladder). Exception: the finish-boundary docs job skips the judge (human-ruled; see SKILL.md `### 5. Finish`) — the orchestrator grades its checkrun evidence directly, then merges.
+   - **Job DONE.** Ordering: write the runner config; launch `check-runner.ps1` or `check-runner.sh` as a background process whose typed exit is the next wake. Exit 0: commit the checkrun artifact `docs/jobs/<run>/<issue-slug>-checkrun.md`, then dispatch the fixed intent judge template from `dispatch.md` by backend; Claude Agent-tool judges run synchronously with `run_in_background: false`, while codex-backend judges run the background `codex exec -o <file>` typed-exit path. Exit 2: commit failure evidence and enter the Failure ladder without judge dispatch. Exit 5: stay on the recorded error rail. After judge PASS, run `postflight.ps1` or `postflight.sh`: exit 0 `POSTFLIGHT: OK` means merge completed with clean touch-set evidence; exit 2 `POSTFLIGHT: VIOLATION` is automatic FAIL evidence; exit 3 `POSTFLIGHT: CONFLICT` is the decomposition-failure rail; exit 5 `POSTFLIGHT: ERROR` falls back to the recorded manual integration sequence in `dispatch.md`. Exception: after the closing review is applied or skipped, the finish-boundary docs job skips the judge (human-ruled; see SKILL.md `### 5. Finish`) and the orchestrator grades its checkrun evidence directly before merge.
    - **Job BLOCKED.** A blocker comment on the issue is a completion event.
      Read it, rule an answer, and respawn a fresh builder job on the same
      issue with the answer in its spawn context (see `dispatch.md`
@@ -42,8 +41,8 @@ Parallel rules: harness-native judge subagents (Claude Agent tool) dispatch sync
      protocol, SKILL.md "### 2. Spec Approval"); already resolved is a no-op.
 4. **Recompute the ready issues.** Closing an issue may unblock others;
    recompute and dispatch the next wave.
-5. **Repeat** until no issues remain open, then post the escalation
-   digest's end-of-run summary on the tracking issue.
+5. **Finish boundary.** When build issues close, run the SKILL.md `### 5. Finish` timed-ruling closing review before the docs job: default YES, 5-minute silence applies; YES uses one fresh resolved-orchestrator-model MEDIUM subagent from the factory branch head, reading spec -> `docs/runs/<run>/map.md` -> run diff, editing directly with `docs/checks/` read-only, keeping every graded RUN green, rerunning the full closing checkrun plus named suites, and merging only green review work through postflight. Red review changes are discarded whole and recorded on the digest; verdict plus diffstat is posted on the tracking issue.
+6. **Repeat** until no issues remain open, the closing review/docs finish boundary is handled, then post the escalation digest's end-of-run summary on the tracking issue.
 
 ## Monitor protocol
 
@@ -70,12 +69,8 @@ detection-only boundary and per-job evidence requirements.
 
 ## Verdict comments
 
-Judgment is recorded on the issue, not in a file. At judgment, one comment
-is posted on the job's issue with: per-check PASS/FAIL/INVALID, a
-checks-integrity verdict, a diff-vs-intent verdict, the slice call
-KILL/CONTINUE, and the decisive reason tied to raw evidence; exact tracker
-comment format lives in `dispatch.md` "## Issue conventions".
-The judge's intent context is exactly the frozen check file, spec, job report, checkrun evidence file, and `docs/jobs/<run>/<issue-slug>-rulings.md`. The checkrun artifact `docs/jobs/<run>/<issue-slug>-checkrun.md` is committed before judge dispatch. The rulings file is orchestrator-owned, append-only, and committed before judge dispatch; if it is absent, there are no post-freeze rulings. Judge dispatch blocks carry no ruling prose.
+Judgment is recorded on the issue, not in a file. At judgment, one comment is posted on the job's issue with: the check-runner typed summary, checks-integrity verdict, diff-vs-intent verdict, one spot-check result, slice call KILL/CONTINUE, and the decisive reason tied to raw evidence; exact tracker comment format lives in `dispatch.md` "## Issue conventions".
+The judge's intent context is exactly the frozen check file, spec, job report, checkrun evidence file, and `docs/jobs/<run>/<issue-slug>-rulings.md`. The checkrun artifact `docs/jobs/<run>/<issue-slug>-checkrun.md` is committed before judge dispatch. The rulings file is orchestrator-owned, append-only, and committed before judge dispatch; if it is absent, there are no post-freeze rulings. Judge dispatch blocks carry no ruling prose and do not re-grade every RUN item.
 The issue is closed on merge. No verdict comment on an issue means the
 next factory block must not build on it as accepted; the orchestrator may re-run
 judgment with a fresh judge if evidence is missing, but may not fill in a
@@ -94,8 +89,10 @@ exec; kill any lingering job processes when a job is discarded.
 
 ## Failure ladder
 
-First FAIL on an issue: the orchestrator diagnoses from the judge's evidence (not
-the full diff), may fan out researcher agents to inform the diagnosis, fixes
+First FAIL on an issue: on a judge FAIL, the orchestrator diagnoses from the
+judge's evidence; on check-runner exit 2, where no judge exists on that path, it
+diagnoses from the checkrun evidence file's failing items (not the full diff),
+may fan out researcher agents to inform the diagnosis, fixes
 the input — issue text, missing context, or a forbidden-pattern note — and
 respawns a fresh builder job at the same tier.
 The tier is set once, at decomposition (config plus dispatch rules), and

--- a/tests/fixtures/checkrun/config-missing-bash.json
+++ b/tests/fixtures/checkrun/config-missing-bash.json
@@ -1,0 +1,1 @@
+{"check_file":"tests/fixtures/checkrun/fixture-checks-missing-bash.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-missing-bash.md","executor":"bash","max_output_lines":60}

--- a/tests/fixtures/checkrun/config-missing.json
+++ b/tests/fixtures/checkrun/config-missing.json
@@ -1,1 +1,1 @@
-{"check_file":"tests/fixtures/checkrun/DOES-NOT-EXIST.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-missing.md","executor":"powershell","max_output_lines":60}
+{"check_file":"tests/fixtures/checkrun/fixture-checks-missing-ps.md","workdir":".","freeze_sha":"HEAD","evidence_out":".architect/tmp/checkrun-missing-ps.md","executor":"powershell","max_output_lines":60}

--- a/tests/fixtures/checkrun/fixture-checks-bash.md
+++ b/tests/fixtures/checkrun/fixture-checks-bash.md
@@ -4,9 +4,10 @@ Executor: bash
 
 ## Fixture
 
-- RUN: `git --version` -> records git version.
-- RUN: `seq 1 100` -> truncation exercise.
-- RUN: `exit 3` -> records exit 3.
+- RUN: `printf 'CHECKRUN-BASH-OK\n'` -> exit:0 match:"CHECKRUN-BASH-OK"
+- RUN: `printf 'literal glob token: a*b?c\n'` -> exit:0 match:"a*b?c"
+- RUN: `git grep -F -q "CHECKRUN_FIXTURE_SHOULD_NOT_EXIST_6C3B0E" -- README.md` -> exit:1
+- RUN: `exit 3` -> exit:3
 
 This markerless prose span must not run: `touch tests/fixtures/checkrun/TRAP.txt`.
 

--- a/tests/fixtures/checkrun/fixture-checks-missing-bash.md
+++ b/tests/fixtures/checkrun/fixture-checks-missing-bash.md
@@ -1,0 +1,7 @@
+# Fixture Checks: Missing Expectation Bash
+
+Executor: bash
+
+## Fixture
+
+- RUN: `printf 'missing expectation\n'` missing expectation.

--- a/tests/fixtures/checkrun/fixture-checks-missing-ps.md
+++ b/tests/fixtures/checkrun/fixture-checks-missing-ps.md
@@ -1,0 +1,7 @@
+# Fixture Checks: Missing Expectation PowerShell
+
+Executor: powershell
+
+## Fixture
+
+- RUN: `Write-Output "missing expectation"` missing expectation.

--- a/tests/fixtures/checkrun/fixture-checks-ps.md
+++ b/tests/fixtures/checkrun/fixture-checks-ps.md
@@ -4,9 +4,10 @@ Executor: powershell
 
 ## Fixture
 
-- RUN: `git --version` -> records git version.
-- RUN: `1..100 | ForEach-Object { $_ }` -> truncation exercise.
-- RUN: `powershell -NoProfile -Command "exit 3"` -> records exit 3.
+- RUN: `Write-Output "CHECKRUN-PS-OK"` -> exit:0 match:"CHECKRUN-PS-OK"
+- RUN: `Write-Output "literal glob token: a*b?c"` -> exit:0 match:"a*b?c"
+- RUN: `git grep -F -q "CHECKRUN_FIXTURE_SHOULD_NOT_EXIST_6C3B0E" -- README.md` -> exit:1
+- RUN: `powershell -NoProfile -Command "exit 3"` -> exit:3
 
 This markerless prose span must not run: `New-Item tests/fixtures/checkrun/TRAP.txt -ItemType File`.
 

--- a/tests/fixtures/checkrun/fixture-checks-quoted-bash.md
+++ b/tests/fixtures/checkrun/fixture-checks-quoted-bash.md
@@ -1,10 +1,11 @@
-# Fixture Checks: Quoted Bash
+# Fixture Checks: Failing Bash
 
 Executor: bash
 
 ## Fixture
 
-QUOTED MARKER sentinel
+CHECKRUN_BASH_PRESENT_MARKER
 
-- RUN: `git --version` -> records git version.
-- RUN: `git grep -c "QUOTED MARKER" -- tests/fixtures/checkrun/fixture-checks-quoted-bash.md` -> records quoted grep count.
+- RUN: `printf 'quoted marker\n'` -> exit:0 match:"quoted marker"
+- RUN: `git grep -F -q "CHECKRUN_BASH_PRESENT_MARKER" -- tests/fixtures/checkrun/fixture-checks-quoted-bash.md` -> exit:1
+- RUN: `printf 'glob candidate: axxbZc\n'` -> exit:0 match:"a*b?c"

--- a/tests/fixtures/checkrun/fixture-checks-quoted-ps.md
+++ b/tests/fixtures/checkrun/fixture-checks-quoted-ps.md
@@ -1,10 +1,11 @@
-# Fixture Checks: Quoted PowerShell
+# Fixture Checks: Failing PowerShell
 
 Executor: powershell
 
 ## Fixture
 
-QUOTED MARKER sentinel
+CHECKRUN_PS_PRESENT_MARKER
 
-- RUN: `git --version` -> records git version.
-- RUN: `git grep -c "QUOTED MARKER" -- tests/fixtures/checkrun/fixture-checks-quoted-ps.md` -> records quoted grep count.
+- RUN: `Write-Output "quoted marker"` -> exit:0 match:"quoted marker"
+- RUN: `git grep -F -q "CHECKRUN_PS_PRESENT_MARKER" -- tests/fixtures/checkrun/fixture-checks-quoted-ps.md` -> exit:1
+- RUN: `Write-Output "glob candidate: axxbZc"` -> exit:0 match:"a*b?c"

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -281,7 +281,11 @@ def check_judge_template() -> None:
         "Verdict format:",
         "Checks integrity:",
         "Diff vs intent:",
-        "Per check:",
+        "Spot-check:",
+        "read the checkrun evidence SUMMARY",
+        "Do not grade RUN items from the evidence file",
+        "Re-run exactly ONE graded RUN item",
+        "mismatch is automatic INVALID",
     ):
         if required not in block:
             errors.append(f"skills/architect/dispatch.md: C5 judge template missing {required}")
@@ -310,7 +314,13 @@ def check_check_runner_dispatch_contract() -> None:
         errors.append("skills/architect/dispatch.md: missing ## Check-runner dispatch")
     if "## Preflight and postflight dispatch" not in text.splitlines():
         errors.append("skills/architect/dispatch.md: missing ## Preflight and postflight dispatch")
-    for marker in ("architect-judge-template", "architect-codex-judge-template"):
+    marker_blocks: dict[str, str] = {}
+    for marker in (
+        "architect-judge-template",
+        "architect-codex-judge-template",
+        "architect-stress-test-template",
+        "architect-monitor-fallback-template",
+    ):
         start = f"<!-- {marker}:start -->"
         end = f"<!-- {marker}:end -->"
         start_at = text.find(start)
@@ -318,11 +328,26 @@ def check_check_runner_dispatch_contract() -> None:
         if start_at == -1 or end_at == -1:
             errors.append(f"skills/architect/dispatch.md: missing {marker} marker block")
             continue
-        block = text[start_at + len(start) : end_at]
-        if "re-run at least one RUN command" not in block:
+        marker_blocks[marker] = text[start_at + len(start) : end_at]
+    for marker in ("architect-judge-template", "architect-codex-judge-template"):
+        block = marker_blocks.get(marker)
+        if block is None:
+            continue
+        for required in (
+            "read the checkrun evidence SUMMARY",
+            "Do not grade RUN items from the evidence file",
+            "Re-run exactly ONE graded RUN item",
+            "mismatch is automatic INVALID",
+        ):
+            if required not in block:
+                errors.append(
+                    "skills/architect/dispatch.md: "
+                    f"{marker} missing {required}"
+                )
+        if "before grading; grade RUN items from the evidence file" in block:
             errors.append(
                 "skills/architect/dispatch.md: "
-                f"{marker} missing re-run at least one RUN command"
+                f"{marker} still tells judges to grade RUN items from the evidence file"
             )
         if block.count("independent reads") != 1:
             errors.append(

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -791,6 +791,143 @@ def check_postflight_lane_fixture() -> None:
             errors.append(f"postflight fixture noop: missing {needle!r}\nstdout:\n{stdout}")
 
 
+def check_runner_cases() -> list[tuple[str, list[str], dict[str, Path]]]:
+    cases: list[tuple[str, list[str], dict[str, Path]]] = []
+    powershell = shutil.which("powershell")
+    if powershell:
+        cases.append(
+            (
+                "powershell",
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(SKILLS / "architect" / "check-runner.ps1"),
+                    "-Config",
+                ],
+                {
+                    "pass": ROOT / "tests" / "fixtures" / "checkrun" / "config-ps.json",
+                    "fail": ROOT / "tests" / "fixtures" / "checkrun" / "config-quoted-ps.json",
+                    "missing": ROOT / "tests" / "fixtures" / "checkrun" / "config-missing.json",
+                },
+            )
+        )
+    bash = shutil.which("bash")
+    if bash and os.name != "nt":
+        cases.append(
+            (
+                "bash",
+                [bash, str(SKILLS / "architect" / "check-runner.sh")],
+                {
+                    "pass": ROOT / "tests" / "fixtures" / "checkrun" / "config-bash.json",
+                    "fail": ROOT / "tests" / "fixtures" / "checkrun" / "config-quoted-bash.json",
+                    "missing": ROOT / "tests" / "fixtures" / "checkrun" / "config-missing-bash.json",
+                },
+            )
+        )
+    return cases
+
+
+def run_check_runner_case(
+    label: str,
+    command_prefix: list[str],
+    config: Path,
+    expected_exit: int,
+) -> tuple[subprocess.CompletedProcess[str] | None, str]:
+    cfg = json.loads(read_text(config))
+    evidence = ROOT / cfg["evidence_out"]
+    evidence.unlink(missing_ok=True)
+    command = [*command_prefix, str(config)]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=45,
+        )
+    except Exception as exc:
+        errors.append(f"check-runner fixture {label}: {' '.join(command)} raised {exc!r}")
+        return None, ""
+    stdout = result.stdout.replace("\r\n", "\n")
+    stderr = result.stderr.replace("\r\n", "\n")
+    if result.returncode != expected_exit:
+        errors.append(
+            f"check-runner fixture {label}: expected exit {expected_exit} "
+            f"got {result.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    if expected_exit == 5:
+        if evidence.exists():
+            errors.append(f"check-runner fixture {label}: evidence file exists after exit 5")
+        return result, ""
+    if not evidence.exists():
+        errors.append(f"check-runner fixture {label}: missing evidence file {evidence.relative_to(ROOT)}")
+        return result, ""
+    return result, read_text(evidence).replace("\r\n", "\n")
+
+
+def require_checkrun_evidence(label: str, evidence: str, needle: str) -> None:
+    if needle not in evidence:
+        errors.append(f"check-runner fixture {label}: missing {needle!r}\nevidence:\n{evidence}")
+
+
+def check_check_runner_fixture() -> None:
+    cases = check_runner_cases()
+    if not cases:
+        errors.append("check-runner fixture: no runnable executor found")
+        return
+    for runner, command_prefix, configs in cases:
+        _, pass_evidence = run_check_runner_case(
+            f"{runner} pass",
+            command_prefix,
+            configs["pass"],
+            0,
+        )
+        if pass_evidence:
+            require_checkrun_evidence(
+                f"{runner} pass",
+                pass_evidence,
+                "CHECKRUN SUMMARY: run_items=4 pass=4 fail=0",
+            )
+            require_checkrun_evidence(f"{runner} pass", pass_evidence, 'expected: exit:0 match:"')
+            require_checkrun_evidence(f"{runner} pass", pass_evidence, 'expected: exit:0 match:"a*b?c"')
+            require_checkrun_evidence(f"{runner} pass", pass_evidence, "expected: exit:1")
+            require_checkrun_evidence(f"{runner} pass", pass_evidence, "verdict: PASS")
+            if "verdict: FAIL" in pass_evidence:
+                errors.append(f"check-runner fixture {runner} pass: unexpected FAIL verdict")
+
+        _, fail_evidence = run_check_runner_case(
+            f"{runner} fail",
+            command_prefix,
+            configs["fail"],
+            2,
+        )
+        if fail_evidence:
+            require_checkrun_evidence(
+                f"{runner} fail",
+                fail_evidence,
+                "CHECKRUN SUMMARY: run_items=3 pass=1 fail=2",
+            )
+            require_checkrun_evidence(f"{runner} fail", fail_evidence, "expected: exit:1")
+            require_checkrun_evidence(f"{runner} fail", fail_evidence, 'expected: exit:0 match:"a*b?c"')
+            require_checkrun_evidence(f"{runner} fail", fail_evidence, "verdict: FAIL")
+
+        missing_result, _ = run_check_runner_case(
+            f"{runner} missing",
+            command_prefix,
+            configs["missing"],
+            5,
+        )
+        if missing_result is not None:
+            stdout = missing_result.stdout.replace("\r\n", "\n")
+            if "CHECKRUN: ERROR missing RUN expectation" not in stdout:
+                errors.append(
+                    f"check-runner fixture {runner} missing: missing grammar error\nstdout:\n{stdout}"
+                )
+
+
 def require_status_contains(label: str, output: str, needle: str) -> None:
     if needle not in output:
         errors.append(f"{label}: missing {needle!r}\noutput:\n{output}")
@@ -908,6 +1045,7 @@ def main() -> int:
     check_status_contract()
     check_status_run_pinning_fixture()
     check_postflight_lane_fixture()
+    check_check_runner_fixture()
     check_tracker_contract()
     check_architect_handoff_free()
     check_retired_loop_terms()


### PR DESCRIPTION
Closes #98

Factory run `judge-scout` — builds `docs/spec/judge-narrowing-and-scout.md`:

- **#99 s1-runner** — the check-runner grades RUN items itself: `-> exit:<n>` + optional `match:"<substring>"` (fixed substring, never regex), per-item expected/verdict evidence, `CHECKRUN SUMMARY` line, typed exits 0/2/5; graded fixtures + validator assertions both executors.
- **#100 s2-dispatch** — both judge templates narrowed to intent-only (integrity, diff-vs-intent, exactly one spot-check, decisive reason; no per-RUN transcription); `## Scout dispatch` template; grill clause requires expectations + map-anchor spot-checks; judge agent def + validator contract greps aligned.
- **#101 s3-skilltext** — scout dispatched at intake parallel with the question timer (map at `docs/runs/<run>/map.md`); per-issue change-skeletons drive the parallel frontier; DONE path keys on runner typed exits (exit 2 → failure ladder without judge dispatch); human-gated closing review before the docs job (timed ruling, default YES, green-or-discard); Hard Rule 3 rewritten for the builders-model intent judge.
- **Closing review** (first live G5 use, REVIEW: GREEN): restored the runner-config schema, hardened both runners against malformed match expectations (space-less / unclosed quote → typed exit 5), fixed scout template wording.
- **Docs job**: DESIGN.md/README/CONTEXT updated; 2 new solution notes (atomic-contract decomposition; graded-expectation divergence).
- Pre-approved session edits ride along: codex Fast-mode builder default; judges at the resolved builders model.

Run evidence in one line: deterministic checkruns were green on every judged state; **all three judge FAILs were diff-vs-intent catches** (failure-ladder inconsistency, sh glob-match divergence, 2-of-4 marker coverage), plus the closing review caught two more parser-divergence rails — the narrowed-judge design validated itself on its own build.

Residual risks / carried items: Fast-mode activation under `codex exec` accepted-but-unverifiable (no service-tier echo); check-runner.sh is bash-dialect (pre-existing, flagged); `git grep` untracked-blindness and `--untracked`-vs-submodule.recurse are recorded check-authoring gotchas (docs-finish re-frozen twice for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
