### PR TITLE
fix: repair PR #125 five-file guard regression

### DIFF
--- a/docs/solutions/served-model-verification.md
+++ b/docs/solutions/served-model-verification.md
@@ -1,0 +1,35 @@
+# served-model-verification
+
+## Symptom
+
+A model pin on a subagent spawn (`model: fable`) is a request, not proof:
+the harness UI never surfaces which model actually served the session, the
+built-in Explore agent is documented to silently cap at Opus, and nothing
+in the Agent tool's result distinguishes a served pin from a substituted
+one.
+
+## Verification method (evidence 2026-07-06)
+
+Grep the spawn's saved transcript (the harness task output JSONL) for
+`"model":` fields — every assistant event names the serving model. Live
+proof: a closing-review spawn pinned `model: fable` showed
+`claude-fable-5` on 108/108 assistant events. Headless
+`claude -p --model fable --output-format stream-json` carries the same
+per-event proof and is the verified same-model fallback (~$0.5 fixed
+bootstrap cost per invocation).
+
+## Caveats (both verified live)
+
+- **Resume drifts the model.** Post-resume turns run at the parent
+  session's model, not the spawn pin: a `model: sonnet` builder resumed
+  twice from a Fable orchestrator showed 164 sonnet + 15 fable assistant
+  events, the fable turns matching the resume rounds exactly. Repin on
+  resume or accept the drift.
+- **`CLAUDE_CODE_SUBAGENT_MODEL` outranks every per-invocation pin**
+  (official resolution order). Preflight should confirm it is unset.
+
+## What did not work
+
+- Asking a subagent to self-report its model (unreliable).
+- Looking for a documented verification surface — official docs confirm
+  none exists (researched 2026-07-06; sub-agents + model-config docs).

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -60,17 +60,7 @@ codex backend (`builders = codex/best`) is the config-selected alternative;
 its dispatch path in the sections below is unchanged. Flat `key = value`
 lines are the supported format for role keys. Unknown keys warn and never fail.
 
-Served-model verification (evidence 2026-07-06): a model pin is a request,
-not proof. Verify what actually served a Claude Agent-tool spawn by grepping
-its saved transcript for `"model":` fields — each assistant event names the
-serving model (e.g. `claude-fable-5`); the harness UI surfaces nothing.
-Caveats, both verified live: (a) post-RESUME turns run at the parent
-session's model, not the spawn pin — repin on resume or accept the drift;
-(b) the `CLAUDE_CODE_SUBAGENT_MODEL` env var outranks every per-invocation
-pin (official resolution order) — preflight confirms it is unset. Headless
-`claude -p --model fable` is the verified same-model fallback (~$0.5 fixed
-bootstrap cost per invocation; stream-json events carry the same `"model":`
-proof).
+A pin is a request, not proof — served-model verification and its resume/env-var caveats: `docs/solutions/served-model-verification.md`.
 
 Optional dispatch-rules lines route task classes to a builder tier:
 


### PR DESCRIPTION
Moves the served-model verification note to docs/solutions/ (its rightful home) with a one-line dispatch.md pointer; guard back under the 989 cap; validator verified green with unpiped exit code this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)