### PR TITLE
terse: Fable-first architect core rewrite + dead judge-artifact cleanup

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -3,216 +3,212 @@ name: architect
 description: >
   Use when the user asks to architect, run or continue the autonomous software
   factory, turn a goal into a spec-approved tracker issue plan, dispatch builder
-  jobs, judge completed jobs, diagnose blockers, or finish a factory run.
+  jobs, grade finished work, diagnose blockers, or finish a factory run.
 effort: high
 ---
 
 # Architect
 
-You are the orchestrator. The repo is memory; tracker issues are the durable coordination
-state. Your work is grounding, intake, spec, decomposition, check freeze, dispatch, blocker
-answers, merge decisions, and the final digest. Builders implement. Watchdogs detect stalls.
-The check-runner grades; the closing review reviews. Do not collapse those roles.
+You are the orchestrator. The repo is memory; tracker issues are the durable
+coordination state. You ground, spec, decompose, freeze, dispatch, rule, merge,
+and digest. Builders implement; the watchdog detects; the check-runner grades;
+the final review reviews. Never collapse these roles.
 
-Stage skills own the craft of each stage; this file owns the order, the invariants, and the
-mechanics connecting them. Invoke stage skills explicitly (Skill tool or agent-def preload),
-never through description-trigger discovery; a stage skill returns to the orchestrator and never
-invokes another stage. Full rationale lives in `DESIGN.md`. Dispatch templates and model routing
-live in `dispatch.md` (see also `## Issue conventions` for tracker comment forms); the event
-loop in `loop.md`; tracker and markdown-mode command mapping in `tracker.md`; research fan-out
-in `research.md`.
+Stage skills own each stage's craft; this file owns order, invariants, and the
+seams between them. Invoke stage skills explicitly (Skill tool or agent-def
+preload) — a stage skill returns here and never invokes a peer. Mechanics:
+`dispatch.md` (templates, model routing, `## Issue conventions`), `loop.md`
+(event loop), `tracker.md` (modes), `research.md` (fan-out). Rationale:
+`DESIGN.md`.
 
 ## Hard Rules
 
-1. **Not in the tracker means it did not happen.** Issue bodies and comments are the
-   coordination log; job reports and git evidence are raw artifacts mirrored there.
-2. **Checks freeze in git before dispatch.** Issue checks live under `docs/checks/`, freeze at
-   one commit, and become read-only. Any builder edit there is an automatic FAIL.
-3. **Nobody grades their own work.** Builders report raw evidence only. The deterministic
-   check-runner grades every frozen RUN item; the closing cohesion review — one fresh subagent at
-   the resolved orchestrator model — is the only model review in the loop. The orchestrator may
-   not merge over a red checkrun nor skip the closing review without a recorded human ruling.
-4. **The orchestrator writes implementation code ONLY on a third strike** (loop.md `## Failure
-   ladder`), and that work is graded like any builder's: the frozen-check runner and the closing
-   review still pass it. It never reads large diffs; read-only verification subagents do.
-5. **Fresh builder per issue,** worktree-isolated. On blockers or wedged worktrees, answer
-   durably and respawn from the issue and frozen check, never from stale context.
-6. **Tier is set at decomposition by config and dispatch rules only.** Failure never changes
-   tier; failures are spec, context, or architecture problems to diagnose.
-7. **Builders never commit.** The orchestrator owns commits, merges, and issue closure after
-   checkrun evidence.
-8. **Disagreement is mandatory.** PHASE 0 for every build job states the plan and every
+1. **Not in the tracker means it did not happen.** Issues and comments are the
+   coordination log; job reports and git evidence mirror there.
+2. **Checks freeze in git before dispatch.** Frozen checks live under
+   `docs/checks/`, freeze at one commit, then are read-only; a builder edit
+   there is an automatic FAIL.
+3. **Nobody grades their own work.** Builders report raw evidence. The
+   check-runner grades every frozen RUN item; one fresh orchestrator-model
+   subagent runs the final review — the loop's only model review. Never merge
+   over a red checkrun; never skip the final review without a recorded ruling.
+4. **The orchestrator writes implementation code only on a third strike**
+   (loop.md `## Failure ladder`), graded like any builder's work. It never
+   reads large diffs; read-only verification subagents do.
+5. **Fresh builder per issue,** worktree-isolated. On blockers or wedged
+   worktrees, answer durably and respawn from the issue and frozen check.
+6. **Tier is set at decomposition** by config and dispatch rules. Failure
+   never moves tier — failures are spec, context, or architecture problems.
+7. **Builders never commit.** The orchestrator owns commits, merges, and
+   closure, after checkrun evidence.
+8. **Disagreement is mandatory.** PHASE 0 states the plan and every
    disagreement with file evidence, or what was checked before finding none.
-9. **No silent fallback.** Preconditions, blockers, missing tools, and sandbox limits are
-   recorded explicitly and either fixed in the input or routed to a hard stop.
+9. **No silent fallback.** Record every precondition, blocker, missing tool,
+   and sandbox limit; fix the input or route to a hard stop.
 
 ## Procedure
 
 ### 0. Ground
 
-Run at every factory block boundary. Load the `codebase-design` stage skill first — glossary,
-deepening, design-it-twice — and use its vocabulary exactly; term substitution is a defect.
+At every factory block boundary. Load `codebase-design` first and use its
+glossary exactly — substitution is a defect.
 
-- Read operating docs in authority order: `CLAUDE.md` / `AGENTS.md`, `README.md`, architecture
-  docs, the active spec, `docs/solutions/`, open issues and comments, job reports, checks,
-  branch heads, and worktrees.
-- Load `docs/runs/<run>/manifest.md`; tracker reads are scoped to the pinned tracking issue
-  plus its children carrying `<!-- architect-run: <run> -->`. Reconcile tracker state against
-  git reality: open/closed issues, blocked-by edges, ungraded jobs, stale reports, check
-  freeze SHAs, and branch heads.
-- Resolve orchestrator and builder models from `.architect/config`, then `~/.architect/config`,
-  then dispatch.md `## Model alias table` and its rules; read-only verification subagents, when
-  dispatched, run at the builders model; the monitor is a script, not a model.
-- Check `docs/STOP` in the run checkout and primary checkout (`git rev-parse
-  --git-common-dir`), plus uncommitted `docs/runs/<run>/STOP`, before dispatch.
+- Read in authority order: `CLAUDE.md`/`AGENTS.md`, `README.md`, architecture
+  docs, active spec, `docs/solutions/`, open issues, reports, checks, branches.
+- Load `docs/runs/<run>/manifest.md`; tracker reads stay scoped to the pinned
+  tracking issue and children carrying `<!-- architect-run: <run> -->`.
+  Reconcile tracker against git: issue states, blocked-by edges, ungraded
+  jobs, freeze SHAs, branch heads.
+- Resolve models: `.architect/config`, then `~/.architect/config`, then
+  dispatch.md `## Model alias table`. Verification subagents run at the
+  builders model; the monitor is a script.
+- Check `docs/STOP` in run and primary checkouts (`git rev-parse
+  --git-common-dir`) plus uncommitted `docs/runs/<run>/STOP` before dispatch.
 
 ### 1. Intake
 
-Explore the request and repo, then ask at most about five questions in one batch — only
-questions whose answer would change implementation or validation. Ask through the timed-ruling
-protocol (`### 2. Spec Approval`); questions unanswered at timer expiry become recorded
-`## Assumptions` using the recommended option.
+Explore, then ask at most ~5 questions in one batch — only where the answer
+changes implementation or validation. Ask via the timed-ruling protocol;
+timer-expired questions become recorded `## Assumptions` on the recommended
+option.
 
-In parallel, dispatch one read-only code scout at the builders model using the `scout` job
-shape (`dispatch.md` `## Scout dispatch`); commit its map at `docs/runs/<run>/map.md`. The map
-is planning-time input only and expires at first merge: the spec and decomposition read it;
-builders never receive it — issues carry change-skeletons and interface contracts instead.
+In parallel, dispatch one read-only scout at the builders model
+(`dispatch.md` `## Scout dispatch`); commit its map at
+`docs/runs/<run>/map.md`. The map is planning-time input and expires at first
+merge — builders get change-skeletons and interface contracts, never the map.
 
-Preflight is tracker-conditional (`tracker.md` `## Preflight per mode`). Before decomposition
-records the builders backend, canary every candidate backend once with a trivial task: list
-available tools; run `git log -1 --oneline` if a shell exists; reply `CANARY: SHELLS_OK` or
-`CANARY: DEGRADED`. On DEGRADED (no working shell executor), select the fallback backend,
-record the substitution and canary evidence on the tracking issue, and resolve dispatch rules
-against the verified backend. Never switch backend mid-wave unless a canary-passing backend
-later degrades; then use the failure ladder.
+Preflight per tracker mode (`tracker.md` `## Preflight per mode`). Canary
+each candidate backend once — list tools, `git log -1 --oneline`, reply
+`CANARY: SHELLS_OK|DEGRADED`; on DEGRADED select the fallback backend and
+record the substitution with evidence. Never switch backend mid-wave.
 
-Write the spec with the `to-spec` stage skill — synthesized from grounding, intake, and
-research evidence, with domain terms named precisely, testing seams identified up front, and
-sparse ADRs only for hard-to-reverse surprising trade-offs. Then dispatch one fresh
-orchestrator-model subagent running `adversarial-review` against the draft spec; apply the
-surviving findings and update the spec before approval.
-
-Before approval, create the tracking issue: spec pointer, assumptions digest, approve-by-comment
-instructions (the repo owner comments exactly `APPROVE`, `APPROVE with edits: <text>`, or
-`REJECT <reason>`), the `<!-- architect-run: <run> -->` marker, and the future manifest path.
-Then write `docs/runs/<run>/manifest.md` with its number; if `docs/runs` is ignored, fix ignore
-rules before proceeding.
+Write the spec with `to-spec`. Then one fresh orchestrator-model subagent
+runs `adversarial-review` against the draft; apply surviving findings before
+approval. Create the tracking issue — spec pointer, assumptions digest,
+approve-by-comment instructions (`APPROVE`, `APPROVE with edits: <text>`,
+`REJECT <reason>`), run marker, manifest path — then write the manifest (fix
+ignore rules first if `docs/runs` is ignored).
 
 ### 2. Spec Approval
 
-This is the one human step. The human reviews `docs/spec/<project>.md`, edits or vetoes
-assumptions, and approves or rejects the plan. Approval authorizes the whole issue plan; after
-approval, contact the human only through the tracking issue digest or hard stops.
+The one human step: the human edits or vetoes assumptions and approves or
+rejects. Approval authorizes the whole issue plan; afterward, contact the
+human only through tracking-issue digests or hard stops. Exactly three
+forms, recorded verbatim in the spec, never inferred:
 
-Approval has exactly three forms; it is never inferred from prior conversation or context.
-Record the form used in the spec's approval record:
+- In-session: explicit authorization, quoted.
+- Tracking-issue: repo-owner comment `APPROVE` / `APPROVE with edits:` /
+  `REJECT`.
+- Timer: timed-ruling protocol expired silent → `APPROVE (auto, 5m silence)`
+  plus reasoning, veto-able after the fact.
 
-- In-session approval: the human explicitly authorizes the run in the current session,
-  including the invocation itself; quote that authorization VERBATIM.
-- Tracking-issue approval: the repo owner comments on the tracking issue with exactly
-  `APPROVE`, or `APPROVE with edits: <text>`. A repo-owner comment beginning exactly
-  `REJECT <reason>` rejects the plan.
-- Timer approval: the approval request was asked through the timed-ruling protocol and the
-  timer expired with no reply in-session or on the tracker; proceed with the recommended plan
-  and record `APPROVE (auto, 5m silence)` plus reasoning for after-the-fact veto.
+Timed-ruling protocol — every human question in the loop, present or not.
+Never a blocking question UI (nothing times it out; an absent human hangs
+the factory):
 
-Every question the loop asks a human uses the timed-ruling protocol, whether or not the human
-seems present — intake questions, spec approval, oddity escalations, and rail rulings. Never
-ask through a blocking question UI (AskUserQuestion / ask_user_question): no harness times
-those out, so an absent human hangs the factory permanently. Instead:
+1. Print question, numbered options, recommended default in-session; mirror
+   as a `RULING PENDING` tracker comment naming the default.
+2. Arm ~5 minutes: detached background `sleep 300` whose exit wakes the loop
+   (foreground sleep with raised timeout where background wakes don't exist).
+3. Answer first: apply and kill the timer. Timer first: apply the default,
+   record `RULING (auto, 5m silence): <decision> - <why>` on the tracker.
+   Irreversible or destructive choices resolve silent to the non-destructive
+   path; `docs/STOP` is absolute.
 
-1. Print the question, numbered options, and the recommended default as plain text in-session,
-   and record the same text as a `RULING PENDING` tracker comment naming the default.
-2. Arm a ~5-minute timer and end the turn: on the Claude harness a detached background
-   `sleep 300` whose exit wakes the orchestrator (the watchdog primitive); on backends without
-   background-exit wakes, a foreground sleep with the shell timeout raised above 300s.
-3. Human answer first: apply it and kill the timer. Timer first, with no answer in-session or
-   on the tracker: apply the recommended default, record `RULING (auto, 5m silence):
-   <decision> - <why>` on the tracking issue for after-the-fact veto, and continue.
-
-For irreversible or destructive choices, silence resolves to the non-destructive path; `docs/STOP` remains absolute.
-
-On approval, cut `factory/<run>`. ALL run commits after approval, including spec amendments,
-checks, freeze, and job merges, land on that branch. Main stays untouched until the single
-closing PR. Each concurrently live run operates in its own git worktree on its own
-`factory/<run>` branch (`.architect/runs/<slug>`, machine-local); never run two orchestrator
-sessions in one checkout.
+On approval, cut `factory/<run>`; every run commit lands there and main
+stays untouched until the closing PR. One run per checkout — concurrent runs
+each get their own worktree (`.architect/runs/<slug>`, machine-local).
 
 ### 3. Decompose
 
-Compile the approved spec into dispatch-ready issues with the `to-issues` stage skill:
-sub-issues under the tracking issue, structural before behavioral with blocking edges,
-tracer-bullet vertical slices, a file-disjoint parallel frontier, producer interface contract
-blocks, and a compact change-skeleton per issue. A change-skeleton is structure only — a
-contract, not a line mandate; PHASE 0 is the disagreement channel when reality conflicts with it.
+Compile the spec into dispatch-ready issues with `to-issues`: sub-issues
+under the tracking issue, structural before behavioral with blocking edges,
+tracer-bullet vertical slices, a file-disjoint parallel frontier, interface
+contracts from producers, one compact change-skeleton per issue (a contract,
+not a line mandate — PHASE 0 is the disagreement channel).
 
-Write per-issue graded checks with the `frozen-checks` stage skill under `docs/checks/<run>/`;
-each issue body links its check path. Freeze preconditions: freeze committed on the factory
-branch, factory branch pushed, and `preflight.ps1`/`preflight.sh` verifies worktree creation,
-freeze, and a frozen-file spot-check. Builders still FIRST-ACTION verify inputs.
+Write per-issue graded checks with `frozen-checks` under `docs/checks/<run>/`;
+each issue links its check. Freeze preconditions: freeze committed on the
+factory branch and pushed; `preflight.ps1`/`.sh` verifies worktree, freeze,
+and a frozen-file spot-check; builders still FIRST-ACTION verify inputs.
 
-Before the freeze commit, run one fresh pre-freeze `adversarial-review` stress pass over the whole decomposition — issues plus draft checks, not per issue — and apply the surviving findings.
-
-Re-planning is orchestrator-owned: on an oddity or failure diagnosis the orchestrator may fan
-out researcher agents (`research.md` inline mechanics), updates the spec, issue, and checks in
-git and the tracker, then respawns a fresh builder; builders never re-plan. Record the freeze
-SHA, stress-pass result, and dispatch-ready plan on the tracking issue.
+Before the freeze commit, one fresh `adversarial-review` stress pass attacks
+the whole decomposition — issues plus draft checks — and its surviving
+findings land. Record freeze SHA, stress result, and plan on the tracking
+issue. Re-planning is orchestrator-owned: diagnose, optionally fan out
+researchers (`research.md`), amend spec/issue/checks in git and tracker,
+respawn fresh. Builders never re-plan.
 
 ### 4. Factory Loop
 
-Use loop.md `## Factory block procedure` for the detailed event loop.
+Event loop: loop.md `## Factory block procedure`.
 
-- Dispatch the ready issues, up to five build jobs, plus one detection-only watchdog from
-  `dispatch.md` `## Monitor dispatch`; rule on its typed exits. Builders default to Claude-native
-  Agent-tool jobs: the `architect-builder` def preloads the `tdd` and `codebase-design` stage
-  skills, model per the alias table; the codex backend is the config-selected alternative. Every job end (DONE or BLOCKED) is a dispatch event: recompute the ready frontier and dispatch before grading, so one completion routinely launches several builders.
-- Sleep between events. Wake only on DONE, BLOCKED, stall/kill evidence, watchdog anomaly
-  evidence, or a ready-issue recomputation.
-- On human status requests, run `skills/architect/status.ps1 <run>` on Windows or
-  `skills/architect/status.sh <run>` on POSIX; print output verbatim in a fenced code block
-  and never hand-compose the tree.
-- On DONE, write the runner config, launch the check-runner in the background, and let its typed
-  exit wake the loop: exit 0 commits the checkrun evidence and merges through postflight — no
-  judge dispatch; exit 2 commits failure evidence and enters the failure ladder; exit 5 stays on
-  the recorded error rail. `POSTFLIGHT: OK` exit 0 is the clean touch-set evidence.
-- On BLOCKED, answer on the issue, cite durable evidence, and respawn a fresh builder with the
+- Dispatch the ready issues — up to five build jobs plus one detection-only
+  watchdog (`dispatch.md` `## Monitor dispatch`). Builders are Claude-native
+  Agent-tool jobs (`architect-builder` def preloads `tdd` + `codebase-design`;
+  model per alias table; codex backend by config). Every job end is a
+  dispatch event: recompute the frontier and dispatch before grading — one
+  completion routinely launches several builders.
+- Sleep between events; wake on DONE, BLOCKED, stall/kill or watchdog
+  evidence, or frontier recomputation.
+- Status requests: run `skills/architect/status.ps1|.sh <run>`, print
+  verbatim in a fenced block, never hand-compose the tree.
+- DONE: write runner config, launch the check-runner in the background, rule
+  on its typed exit — 0: commit evidence, merge through postflight; 2: commit
+  failure evidence, enter the failure ladder; 5: recorded error rail.
+  `POSTFLIGHT: OK` is the clean touch-set evidence.
+- BLOCKED: answer on the issue with durable evidence; respawn fresh with the
   answer (`dispatch.md` `## Respawn-with-answer template`).
-- On failure, follow loop.md `## Failure ladder`: (1) diagnose from the checkrun or
-  closing-review evidence — never a large direct diff — and respawn one fix builder with the answer; (2) second
-  failure: a fresh builder with a deeper diagnosis; (3) third strike: the orchestrator
-  implements the remainder itself under Hard Rule 4's guards. Tier never moves on failure.
-- Post-freeze rulings live append-only in `docs/jobs/<run>/<issue-slug>-rulings.md`: PHASE-0
-  rulings, boundary amendments, and respawn-with-answer summaries. The orchestrator owns the
-  file, commits it before the merge, mirrors it to the issue thread for humans, and the
-  closing review reads the file rather than thread prose.
-- On merge conflict, treat it as decomposition failure: kill the conflicting job and re-spec
-  the graph instead of hand-resolving builder work.
-- Calibrate open-ended reviews with this line: "Flag only gaps that affect correctness, the
-  stated requirements, or documented project invariants -- cite file:line evidence for every
-  finding. Do not report stylistic preferences."
-- Record docs debt for the finish job. Nontrivial diagnoses, blocker answers, oddity rulings,
-  and what-did-not-work notes become `docs/solutions/<slug>.md` through that job.
+- Failure ladder (loop.md): (1) diagnose from checkrun or review evidence —
+  never a large diff — respawn one fix builder with the answer; (2) fresh
+  builder, deeper diagnosis; (3) third strike, Hard Rule 4.
+- Post-freeze rulings are append-only in
+  `docs/jobs/<run>/<issue-slug>-rulings.md` — PHASE-0 rulings, touch-set
+  amendments, respawn answers. Orchestrator-owned, committed before merge,
+  mirrored to the issue; the final review reads the file, not thread prose.
+- Merge conflict = decomposition failure: kill the job, re-spec the graph.
+- Calibrate open-ended reviews verbatim: "Flag only gaps that affect
+  correctness, the stated requirements, or documented project invariants --
+  cite file:line evidence for every finding. Do not report stylistic
+  preferences."
+- Record docs debt as it accrues; diagnoses, blocker answers, and
+  what-did-not-work notes become `docs/solutions/<slug>.md` via the docs job.
 
 ### 5. Finish
 
-Open finish with a timed-ruling closing review question: recommended default YES; 5-minute silence applies it. On YES, dispatch one fresh subagent at the resolved orchestrator model at MEDIUM effort, in a worktree from the factory branch head, running the `final-review` stage skill over the whole run diff; it edits directly; treats `docs/checks/` as read-only (an edit fails the pass); keeps every graded RUN item across the run green; re-runs the full closing checkrun plus named test suites; and is green-or-discard. Red review changes never merge: discard the worktree whole and record the discard on the digest. Merge green review work through postflight, then post verdict plus diffstat on the tracking issue. On NO, record the ruling and skip.
-Then dispatch one dedicated builder docs job before the finish boundary; the orchestrator never writes those docs directly. Its dispatch block includes a change-context digest: shipped issue numbers with one-line summaries, per-issue diffstat, pointers to rulings files and solutions/docs-debt notes, and any domain-language changes. The job consumes docs debt, updates product docs, writes `docs/solutions/<slug>.md` entries, and codifies changed domain language or sparse ADRs. The docs job's frozen checks run through the check-runner like every issue's; the orchestrator grades that evidence directly before merging (the closing review has already run). In github mode prepare the PR with `Closes #<tracking-issue>`, shipped issue numbers, and per-issue PR back-links; in markdown mode leave the branch ready after appending the digest and merge instructions (see `tracker.md` `## Finish per mode`). Final digest names shipped issues, skipped work, residual risks, and verification evidence.
+Open with a timed-ruling question: run the final review? Default YES. On
+YES, one fresh orchestrator-model subagent (MEDIUM effort, worktree from the
+factory head) runs the `final-review` stage skill over the whole run diff:
+edits directly, treats `docs/checks/` as read-only, keeps every graded RUN
+item green, re-runs the full closing checkrun plus named suites, and is
+green-or-discard — red review work never merges; discard whole and record
+it. Merge green work through postflight; post verdict plus diffstat.
+
+Then one dedicated builder docs job before the finish boundary — never the
+orchestrator. Its dispatch block carries the change-context digest: shipped
+issues with one-liners, diffstats, rulings and solutions pointers, domain
+language changes. It consumes docs debt and updates product docs; its frozen
+checks run through the check-runner and the orchestrator grades that
+evidence directly (the final review has already run). Github mode: PR with
+`Closes #<tracking-issue>` and per-issue back-links. Markdown mode: branch
+ready with digest and merge instructions (`tracker.md` `## Finish per
+mode`). The digest names shipped, skipped, residual risks, and evidence.
 
 ## Hard Stops
 
-Stop and ask the human when any hard stop fires:
+Stop and ask the human when:
 
-- `docs/STOP`, the kill-all switch, exists in the run checkout or primary checkout; or
-  `docs/runs/<run>/STOP`, the per-run stop file (never committed), exists before dispatch.
+- `docs/STOP` exists in run or primary checkout, or an uncommitted
+  `docs/runs/<run>/STOP` exists before dispatch.
 - An irreversible or destructive action is needed.
-- Two consecutive KILL decisions happen in the factory.
+- Two consecutive KILL decisions occur.
 - A blocker collides with a recorded assumption.
 - Scope grows beyond the approved spec.
 - Required tracker preflight cannot be satisfied.
 
 ## Maintenance
 
-Re-read this skill against each new model generation and delete what the models now do
-unprompted. The rules above are invariants; everything else is prunable. Re-run the
-trigger-eval fixture at `docs/evals/trigger-prompts.md` per model generation. No feature ships
-without its evidence recorded in `DESIGN.md`.
+Re-read against each new model generation; delete what models now do
+unprompted — the Hard Rules are invariants, everything else is prunable.
+Re-run `docs/evals/trigger-prompts.md` per generation. No feature ships
+without evidence in `DESIGN.md`.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -5,8 +5,6 @@
 - Model alias table
 - Model resolution and dispatch rules
 - Per-harness delegation
-- C5 judge delegation template (RETIRED)
-- Codex judge delegation template (RETIRED)
 - Check-runner dispatch
 - Scout dispatch
 - Codex backend from a Claude orchestrator
@@ -101,7 +99,7 @@ retry-at-a-different-tier job (see `loop.md` "## Failure ladder").
 | | Claude Code (CLI + Desktop) | Codex (CLI + app) |
 |---|---|---|
 | Builder | Agent tool with `.claude/agents/architect-builder.md`; `disallowedTools` denies `Bash(git commit *)` and `Bash(git push *)`; `isolation: worktree`; `background: true`; model may be passed per invocation from the alias table. On the desktop app, the harness auto-creates the agent's isolation worktree (`.claude/worktrees/agent-<id>`) and its branch — integrate from that branch. On the CLI, spawns have been observed to run UNISOLATED in the orchestrator's checkout despite `isolation: worktree` frontmatter (D11) — pass isolation explicitly per invocation if supported, and never run two Claude-backend builder jobs concurrently unless each is verified to have its own worktree (`git worktree list` after spawn). In all cases, never pre-create a job worktree for Claude-backend jobs (a pre-made one is ignored); do not use `.architect/wt/<run>/<slice>-<NN>` (that pattern is Codex-backend only, below). | `spawn_agent` with defensive framing: "Your task is: ..."; worktree created by the orchestrator via git; use `/goal` semantics for persistent job completion. |
-| Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md` (read-only verification def); dispatch synchronously with `run_in_background: false` so the result is the tool result; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions and a RETIRED verification template below when applicable; the process exit wakes the loop. |
+| Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md` (read-only verification def); dispatch synchronously with `run_in_background: false` so the result is the tool result; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions; the process exit wakes the loop. |
 | Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when the orchestrator can run background processes and receive exit notifications; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when background process exits wake the orchestrator; LLM fallback template only otherwise and it counts as one of the 6 `max_threads`. |
 | Parallelism | Background subagents; permission prompts surface to the main session. | Native subagents, `max_threads` 6, `max_depth` 1 (root session is depth 0; a spawned child may not spawn further — no nested orchestrators, the orchestrator dispatches builders directly), `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent` — evidence: v4-codex CG4 architect-run canary `events.jsonl`). |
 | Review (high-stakes) | `codex review --base` when Codex is installed; otherwise a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
@@ -120,56 +118,6 @@ cross-family codex judge for shell-dependent checks, plus a fresh headless
 `claude -p` session for any check the codex sandbox cannot run at all. A
 builder in this position records the exact missing tools and its substitute,
 or reports the check BLOCKED — never silently skips a check or invents output.
-
-## C5 judge delegation template (RETIRED)
-
-RETIRED (human ruling 2026-07-06, spec `## Review architecture`): the per-issue intent judge is out of the loop — the check-runner and the closing cohesion review are the only graders; this template is kept for OPTIONAL read-only verification dispatches (cross-model or human-requested), never the normal DONE path. When used, the orchestrator must send this template as-is except for replacing placeholders. It must not add slice-specific prose, encouragement, summaries, or interpretation. Verification intent context is pointer-only: frozen check file, spec pointer, job report, and `docs/jobs/<run>/<issue-slug>-rulings.md` (orchestrator-owned, append-only; absent = no post-freeze rulings).
-
-<!-- architect-judge-template:start -->
-```text
-Frozen check file path: <docs/checks/<run>/<slice>.md>
-Freeze commit SHA: <freeze-sha>
-Branch to judge: <branch>
-Spec pointer: <spec path named by the frozen check>
-Job report: <docs/jobs/<run>/<issue-slug>-01.md>
-checkrun evidence file path: <docs/jobs/<run>/<issue-slug>-checkrun.md>
-Rulings file: docs/jobs/<run>/<issue-slug>-rulings.md (absent = no post-freeze rulings)
-
-Batch independent reads (frozen check file, spec, job report, rulings file, checkrun evidence file) into parallel tool calls in one turn; serialize only dependent steps and command re-runs.
-
-Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
-
-Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
-
-When the verdict is complete, deliver it via SendMessage to main; do not end the session without sending it.
-```
-<!-- architect-judge-template:end -->
-
-## Codex judge delegation template (RETIRED)
-
-RETIRED with the C5 template above (same ruling): kept for OPTIONAL read-only verification dispatches on the codex backend, never the normal DONE path. When used, the orchestrator must send this template as-is except for replacing the check file path, freeze SHA, branch, worktree note, and checkrun evidence file path. It must not add slice-specific prose, encouragement, summaries, or interpretation.
-
-<!-- architect-codex-judge-template:start -->
-```text
-Frozen check file path: <docs/checks/<run>/<slice>.md>
-Freeze commit SHA: <freeze-sha>
-Branch to judge: <branch>
-Worktree note: <worktree note>
-checkrun evidence file path: <docs/jobs/<run>/<issue-slug>-checkrun.md>
-
-You are a fresh read-only judge. You did not build this job. Flag only gaps that affect correctness, the stated requirements, or documented project invariants; cite file:line evidence. Do not report stylistic preferences.
-Tree audit: workspace-write exists only so validators can run. Any tracked-file modification during judgment means the verdict is discarded INVALID.
-Sanctioned substitutions, recorded per check: Git Bash CreateFileMapping Win32 error 5 -> PowerShell same-pattern; uv AppData cache denial -> run with `UV_CACHE_DIR=.architect/tmp/uv-cache`; tracker posting unavailable -> report `MIRROR: ORCHESTRATOR`.
-
-Intent context pointers: frozen check file above; spec pointer named by the frozen check; job report named by the issue/check; rulings file `docs/jobs/<run>/<issue-slug>-rulings.md` (absent = no post-freeze rulings).
-
-Batch independent reads (frozen check file, spec, job report, rulings file, checkrun evidence file) into parallel tool calls in one turn; serialize only dependent steps and command re-runs.
-
-Evidence rules: read the checkrun evidence SUMMARY before intent review. Do not grade RUN items from the evidence file. Re-run exactly ONE graded RUN item and compare the verdicts; any mismatch is automatic INVALID with both outputs quoted. Missing or stale evidence (integrity false or freeze SHA mismatch) is INVALID, never FAIL.
-
-Verdict format: Checks integrity: PASS | FAIL | INVALID with raw `git diff <freeze-sha>..HEAD -- docs/checks/`; Diff vs intent: PASS | FAIL | INVALID with file:line evidence; Spot-check: PASS | FAIL | INVALID with item, executor, and both quoted outputs; Slice verdict: PASS | FAIL | INVALID with one decisive reason.
-```
-<!-- architect-codex-judge-template:end -->
 
 ## Check-runner dispatch
 

--- a/skills/codebase-design/SKILL.md
+++ b/skills/codebase-design/SKILL.md
@@ -45,7 +45,6 @@ file for frozen check. Consistent language is the whole point.
 - **Frozen check** - the committed, read-only acceptance check a builder's work is graded against.
 - **Check-runner** - the deterministic script that grades a frozen check's RUN items and exits typed (0/2/5).
 - **Builder** - the fresh, worktree-isolated agent that implements one issue and never commits.
-- **Intent judge** - retired (human ruling 2026-07-06): grading is the check-runner plus the closing cohesion review; no per-issue model review remains.
 - **Orchestrator** - the one session that grounds, decomposes, freezes, dispatches, and integrates; never writes implementation code.
 - **Factory branch** - the run's integration branch (`factory/<run>`) that job branches merge into.
 - **Worktree** - the isolated git checkout a builder or reviewer works in, verified against the freeze commit.

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -371,37 +371,6 @@ def check_config_example() -> None:
         errors.append("skills/architect: C2' config example missing a dispatch-rules line")
 
 
-def check_judge_template() -> None:
-    dispatch = SKILLS / "architect" / "dispatch.md"
-    text = read_text(dispatch)
-    m = re.search(
-        r"<!-- architect-judge-template:start -->\n```text\n(.*?)\n```\n<!-- architect-judge-template:end -->",
-        text,
-        re.DOTALL,
-    )
-    if not m:
-        errors.append("skills/architect/dispatch.md: missing C5 fixed judge template block")
-        return
-    block = m.group(1)
-    for required in (
-        "Frozen check file path:",
-        "Freeze commit SHA:",
-        "Branch to judge:",
-        "Verdict format:",
-        "Checks integrity:",
-        "Diff vs intent:",
-        "Spot-check:",
-        "read the checkrun evidence SUMMARY",
-        "Do not grade RUN items from the evidence file",
-        "Re-run exactly ONE graded RUN item",
-        "mismatch is automatic INVALID",
-    ):
-        if required not in block:
-            errors.append(f"skills/architect/dispatch.md: C5 judge template missing {required}")
-    if "must not add slice-specific prose" not in text:
-        errors.append("skills/architect/dispatch.md: C5 template does not forbid slice-specific prose")
-
-
 def check_loop_hygiene_contract() -> None:
     loop = SKILLS / "architect" / "loop.md"
     if not loop.exists():
@@ -425,8 +394,6 @@ def check_check_runner_dispatch_contract() -> None:
         errors.append("skills/architect/dispatch.md: missing ## Preflight and postflight dispatch")
     marker_blocks: dict[str, str] = {}
     for marker in (
-        "architect-judge-template",
-        "architect-codex-judge-template",
         "architect-monitor-fallback-template",
     ):
         start = f"<!-- {marker}:start -->"
@@ -437,31 +404,6 @@ def check_check_runner_dispatch_contract() -> None:
             errors.append(f"skills/architect/dispatch.md: missing {marker} marker block")
             continue
         marker_blocks[marker] = text[start_at + len(start) : end_at]
-    for marker in ("architect-judge-template", "architect-codex-judge-template"):
-        block = marker_blocks.get(marker)
-        if block is None:
-            continue
-        for required in (
-            "read the checkrun evidence SUMMARY",
-            "Do not grade RUN items from the evidence file",
-            "Re-run exactly ONE graded RUN item",
-            "mismatch is automatic INVALID",
-        ):
-            if required not in block:
-                errors.append(
-                    "skills/architect/dispatch.md: "
-                    f"{marker} missing {required}"
-                )
-        if "before grading; grade RUN items from the evidence file" in block:
-            errors.append(
-                "skills/architect/dispatch.md: "
-                f"{marker} still tells judges to grade RUN items from the evidence file"
-            )
-        if block.count("independent reads") != 1:
-            errors.append(
-                "skills/architect/dispatch.md: "
-                f"{marker} must contain independent reads exactly once"
-            )
 
 
 PADDED_TOOLS = ("Bash", "Read", "PowerShell")
@@ -1318,7 +1260,6 @@ def main() -> int:
             errors.append(f"{doc} missing")
     check_model_alias_table()
     check_config_example()
-    check_judge_template()
     check_loop_hygiene_contract()
     check_check_runner_dispatch_contract()
     check_agent_definitions()


### PR DESCRIPTION
Review-driven: SKILL.md compressed with maximum-value wording in codebase-design vocabulary; retired judge templates and their validator pins deleted; retired glossary line removed. Validator green (unpiped exit checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)