### PR TITLE
rename: ship -> integrate (dissolve gstack /ship collision)

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -192,7 +192,7 @@ checks run through the check-runner and the orchestrator grades that
 evidence directly (the final review has already run).
 
 After the final review merges, or a recorded ruling skips it, dispatch one
-ship subagent running the `ship` stage skill. It owns remaining merges,
+integration subagent running the `integrate` stage skill. It owns remaining merges,
 ship-time conflict resolution, PR prep or markdown-mode finish prep, and the
 digest draft. The orchestrator rules on the result and posts the digest,
 naming shipped, skipped, residual risks, and evidence.

--- a/skills/integrate/SKILL.md
+++ b/skills/integrate/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: ship
+name: integrate
 description: >
-  Factory-context ship stage for one dedicated builder subagent dispatched by
+  Factory-context integrate stage (end-of-run shipping) for one dedicated builder subagent dispatched by
   the orchestrator after final review has merged, or has been skipped by a
   recorded ruling. Owns end-of-run integration, postflight, PR or markdown
   finish prep, and a digest DRAFT; returns evidence for the orchestrator to
   rule on.
 ---
 
-# Ship
+# Integrate
 
-You are the ship subagent for one factory run. You may be dispatched as a
+You are the integrate subagent for one factory run. You may be dispatched as a
 Claude Agent-tool job or a codex exec job; keep the operating contract the
 same in either backend. The orchestrator dispatches you after the final review
 has merged, or after a recorded ruling skips final review.

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -67,7 +67,7 @@ LIBRARY_SKILLS = {
     "tdd": ["tests.md", "mocking.md"],
     "adversarial-review": [],
     "final-review": [],
-    "ship": [],
+    "integrate": [],
 }
 # s9 per-skill non-blank-line budgets, caps named in each stage skill's
 # frozen check (docs/checks/skill-library/). The architect entry (SKILL.md
@@ -85,7 +85,7 @@ LIBRARY_LINE_BUDGETS = {
     "tdd": (("SKILL.md", "tests.md", "mocking.md"), 220),
     "adversarial-review": (("SKILL.md",), 110),
     "final-review": (("SKILL.md",), 110),
-    "ship": (("SKILL.md",), 90),
+    "integrate": (("SKILL.md",), 90),
     "architect": (("SKILL.md",), 220),
 }
 # License ruling (docs/spec/skill-library.md `## Open human decisions`):


### PR DESCRIPTION
The factory's ship skill clobbered gstack's /ship at ~/.claude/skills/ship on install. Renamed to /integrate (end-of-run integration); frontmatter, H1, orchestrator Finish reference, validator keys. Ship-time semantics unchanged; 'ship' survives as a verb. Validator: OK - 10 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)