### PR TITLE
flip builders default: codex/best (gpt-5.5 xhigh + Fast) from any harness

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,7 +123,7 @@ Glossary only. No implementation details, no spec content.
   `tracker = github | markdown`, `orchestrator = cli/model`,
   `builders = cli/model:effort`, and optional
   `when -> cli/model:effort - why` dispatch rules. Absent `tracker =` means
-  GitHub mode; absent builder routing means tier-down default.
+  GitHub mode; absent builder routing means the `codex/best` default.
 - **Post-flight** - the orchestrator's mechanical checks on a completed job
   (boundaries, check-file integrity, raw-only report, status-line form) before
   integration. Distinct from judgment.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -580,13 +580,15 @@ runner's first live use finished 7/7.
   spot-check, and optional read-only verification dispatches keep that tier.
   The closing review uses the orchestrator model, and cross-family judgment
   remains an explicit high-stakes route.
-- **Default builders are Claude-native** since the skill-library run (spec
-  assumption 2, 2026-07-05): `claude/tier-down` (Sonnet, high) as Agent-tool
-  jobs with preloaded stage skills; `codex/best` (gpt-5.5, xhigh) is the
-  config-selected alternative whenever the Codex CLI is on PATH — its
-  economics case (typing hours on the flat-rate subscription with verified
-  `.git` sandbox protection; §2 economics, PR #28) is why the option stays
-  first-class.
+- **Default builders are codex-frontier** (human ruling 2026-07-06,
+  flipping the skill-library-era Claude-native default): `codex/best`
+  (gpt-5.5, xhigh, Fast pins under ChatGPT auth) via the codex CLI from
+  either orchestrator harness — the economics case (typing hours on the
+  flat-rate subscription with verified `.git` sandbox protection; §2
+  economics, PR #28) now backs the default, not just the option.
+  `claude/tier-down` (Sonnet, high) as Agent-tool jobs with preloaded
+  stage skills is the config-selected alternative and the recorded
+  fallback when the codex CLI is absent.
 - **xhigh for unattended builders.** Effort-curve data shows xhigh winning
   the metrics that matter unattended — semantic equivalence to the human PR
   (88% vs 69%) and review-pass rate (69% vs 38%) at ~2.2× the cost of high

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ on any paid plan; the Codex CLI on a ChatGPT plan is optional — set
 ## Design
 
 A configurable **orchestrator** model (default: Fable, high) designs,
-assigns, and reviews. A configurable **builder** model (default: Sonnet,
-high) does the heavy lifting. Both are overridable — see
+assigns, and reviews. A configurable **builder** model (default: GPT-5.5,
+xhigh, Fast mode) does the heavy lifting. Both are overridable — see
 [Config](#config).
 
 ### /architect
@@ -231,8 +231,9 @@ Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` `claude` or
 `codex`. `best` and `tier-down` are per-family aliases (Fable at high /
 GPT-5.5 at xhigh, and Sonnet at high / GPT-5.5 at high); any concrete model
 works too. Unconfigured, the orchestrator is your current session and
-builders are `claude/tier-down`; `codex/best` is the config-selected
-alternative when the Codex CLI is installed. Optional read-only verification
+builders are `codex/best` (Fast mode under ChatGPT auth); `claude/tier-down`
+is the config-selected alternative, and the recorded fallback when the
+Codex CLI is absent. Optional read-only verification
 subagents follow `builders`; adversarial reviewers
 and closing review follow the orchestrator tier; `/architect-research`
 researchers follow `builders`. `when <task

--- a/skills/architect-research/SKILL.md
+++ b/skills/architect-research/SKILL.md
@@ -69,11 +69,11 @@ dispatch. State the plan in a few lines; proceed unless the user redirects.
 
 Resolve the researcher model as builders, same order as `/architect`: repo
 `.architect/config`, then user `~/.architect/config`, then the
-config-resolved default in `skills/architect/dispatch.md` — `claude/tier-down`
-(Sonnet at high) as the Claude-native default; `codex/best` (gpt-5.5, xhigh)
-is the config-selected alternative (`builders = codex/best`). One fresh
+config-resolved default in `skills/architect/dispatch.md` — `codex/best`
+(gpt-5.5 at xhigh) via the codex CLI; the Claude-native rows
+(`builders = claude/...`) are the config-selected alternative. One fresh
 researcher per assignment, all parallel, in the background — this is the
-codex/best example, when that alternative is configured:
+default codex/best form:
 
 ```bash
 codex exec --sandbox read-only -c web_search="live" \

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -50,13 +50,15 @@ flags in every command; this table is the source of those pins.
 Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` in `{claude,
 codex}`. Resolution order per role is repo `.architect/config`, then user
 `~/.architect/config`, then defaults: orchestrator = the running session;
-builders = `claude/tier-down` (Sonnet at high) as Claude-native Agent-tool
-jobs — the `architect-builder` def preloads the `tdd` and `codebase-design`
-stage skills via its `skills:` field, and the model is passed per invocation
-from the alias table (config-raisable, e.g. `builders = claude/best`). The
-codex backend (`builders = codex/best`) is the config-selected alternative;
-its dispatch path in the sections below is unchanged. Flat `key = value`
-lines are the supported format for role keys. Unknown keys warn and never fail.
+builders = `codex/best` (gpt-5.5 at xhigh, Fast pins per the Builder speed
+default below) as codex-CLI jobs — Claude Code and Codex orchestrators both
+dispatch builders through the codex command lines in the sections below.
+The Claude-native backend (`builders = claude/tier-down`, Sonnet at high,
+Agent-tool jobs; the `architect-builder` def preloads `tdd` and
+`codebase-design` via its `skills:` field, model per invocation from the
+alias table) is the config-selected alternative and the recorded fallback
+when the codex CLI is absent. Flat `key = value` lines are the supported
+format for role keys. Unknown keys warn and never fail.
 
 A pin is a request, not proof — served-model verification and its resume/env-var caveats: `docs/solutions/served-model-verification.md`.
 
@@ -147,7 +149,8 @@ The worktree pre-creation and dispatch commands in this section are
 Codex-backend only. Claude-backend jobs never pre-create a worktree — see
 the Per-harness delegation table above.
 
-When the orchestrator is Claude Code and the chosen builders backend is Codex, write the
+When the orchestrator is Claude Code and the resolved builders backend is
+Codex (the default), write the
 builder block to a file first, then pass it via stdin (`-`). Big prompt blocks
 contain quotes that shells, especially Windows PowerShell, can mangle.
 

--- a/skills/architect/research.md
+++ b/skills/architect/research.md
@@ -8,8 +8,8 @@ load-bearing claims and writes the spec itself.
 ## Fan out
 
 Resolve the researcher model as builders, same order as `/architect`: repo
-`.architect/config`, then user `~/.architect/config`, then the tier-down
-defaults in `skills/architect/dispatch.md`.
+`.architect/config`, then user `~/.architect/config`, then the `codex/best`
+default in `skills/architect/dispatch.md`.
 
 Decompose the question into 3–5 narrow, NON-OVERLAPPING research questions.
 Cover different angles, not the same angle five times — typical split:
@@ -17,9 +17,8 @@ official docs/reference, changelog/breaking changes, community failure reports,
 alternatives/comparisons, security/operational constraints.
 
 One fresh `codex exec` per question, all launched in parallel, in the
-background — this is the codex-backend example (codex/tier-down; the
-builders default is Claude-native, see `dispatch.md` `## Model resolution
-and dispatch rules`):
+background — codex/tier-down shown; the builders default is `codex/best`
+(`dispatch.md` `## Model resolution and dispatch rules`):
 
 ```bash
 codex exec -C <repo-root> --sandbox read-only -c web_search="live" \


### PR DESCRIPTION
Human-directed follow-up to #142 (stacked on `factory/review-fanout`; retarget/merge after #142 lands).

Flips the shipped builders default from `claude/tier-down` (Sonnet high) to **`codex/best`** — gpt-5.5 at xhigh with the Fast pins (`service_tier=fast`, `features.fast_mode=true`) auto-applied under ChatGPT auth per the existing Builder speed default. Applies from either orchestrator harness (Claude Code or Codex): builders dispatch through the codex CLI command lines. `claude/tier-down` becomes the config-selected alternative and stays the recorded fallback when the codex CLI is absent. Config override chain unchanged (`.architect/config` -> `~/.architect/config` -> default).

Changed in lockstep: `skills/architect/dispatch.md` (resolution rules + codex-backend intro), `skills/architect/research.md`, `skills/architect-research/SKILL.md`, `README.md` (Design + Models), `CONTEXT.md` (config vocabulary), `DESIGN.md` (default-builders bullet, dated ruling).

Evidence: combined architect five-file budget 987/989 non-blank; `uv run python tests/validate_skills.py` -> `OK - 10 skills validated, v4 contracts clean`; all review-fanout frozen-check greps re-verified green on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)