### PR TITLE
fix: builders-flip stragglers + stale glossary paths + README dedupe

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ Glossary only. No implementation details, no spec content.
   and continues. Irreversible or destructive silence takes the non-destructive
   path; `docs/STOP` remains absolute.
 - **Check** - a frozen, committed, exact acceptance check
-  (`docs/checks/<issue-slug>.md`). Read-only for everyone once frozen. RUN
+  (`docs/checks/<run>/<slice>.md`). Read-only for everyone once frozen. RUN
   items are graded by machine-readable expectations.
 - **Graded RUN** - a check RUN item with `-> exit:<n>` and optional fixed
   stdout `match:"substring"` expectation. Runner exits are typed: 0 all pass,
@@ -90,7 +90,7 @@ Glossary only. No implementation details, no spec content.
   it is not implementation code.
 - **Freeze commit** - the commit that locks a run's checks; it is pushed before
   any dispatch, and worktrees are verified against it after spawn.
-- **Rulings file** (`docs/jobs/<issue-slug>-rulings.md`) - orchestrator-owned,
+- **Rulings file** (`docs/jobs/<run>/<issue-slug>-rulings.md`) - orchestrator-owned,
   append-only post-freeze intent: PHASE-0 rulings, boundary amendments,
   respawn answers. Read by the closing review instead of thread prose.
 - **Verdict comment** - the grading record posted on the issue at close:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ npm i -g @openai/codex@latest            # optional: Codex CLI (>= 0.133)
 
 One installer, both ecosystems: the same skills land in Claude Code and in
 Codex's `.agents/skills`. You need [Claude Code](https://claude.com/claude-code)
-on any paid plan; the Codex CLI on a ChatGPT plan is optional — set
-`builders = codex/best` to route builders there. No API keys.
+on any paid plan; the Codex CLI on a ChatGPT plan powers the default
+builders — without it, builders fall back to Claude (`claude/tier-down`).
+No API keys.
 
 ## Design
 
@@ -146,12 +147,10 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
 - **Dispatch and merge mechanics are scripted.** Worktree
   setup, freeze verification, touch-set audit, merge, and cleanup each
   collapse from 4–5 orchestrator calls into one typed-exit line.
-- **A deterministic check-runner owns every issue's grading.**
-  It executes and grades frozen RUN items with typed exits; a closing
-  review — one fresh orchestrator-tier subagent over the whole run diff —
-  runs read-only before the docs job, decomposing any findings into a fix
-  wave instead of editing the diff itself; zero findings short-circuits to
-  done.
+- **The closing review decomposes findings instead of editing.** One
+  fresh orchestrator-tier subagent reads the whole run diff read-only
+  before the docs job; verified findings become a review spec cut into fix
+  issues for a parallel fix wave; zero findings short-circuits to done.
 - **Reviewed diffs target ≤~400 changed lines per issue.**
   Review effectiveness collapses past a few hundred lines, so bigger specs
   split into more issues.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -145,11 +145,12 @@ respawn fresh. Builders never re-plan.
 Event loop: loop.md `## Factory block procedure`.
 
 - Dispatch the ready issues — up to five build jobs plus one detection-only
-  watchdog (`dispatch.md` `## Monitor dispatch`). Builders are Claude-native
-  Agent-tool jobs (`architect-builder` def preloads `tdd` + `codebase-design`;
-  model per alias table; codex backend by config). Every job end is a
-  dispatch event: recompute the frontier and dispatch before grading — one
-  completion routinely launches several builders.
+  watchdog (`dispatch.md` `## Monitor dispatch`). Builders default to
+  codex-CLI jobs (`codex/best`); Claude-native Agent-tool jobs
+  (`architect-builder` def preloads `tdd` + `codebase-design`; model per
+  alias table) are the config alternative and codex-absent fallback. Every
+  job end is a dispatch event: recompute the frontier and dispatch before
+  grading — one completion routinely launches several builders.
 - Sleep between events; wake on DONE, BLOCKED, stall/kill or watchdog
   evidence, or frontier recomputation.
 - Status requests: run `skills/architect/status.ps1|.sh <run>`, print

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -74,7 +74,7 @@ when broad ambiguous refactor -> codex/best:xhigh # deeper search and edit budge
 ```
 
 Format: `when <task-class description> -> <cli>/<model-spec>[:<effort>] # why`.
-The trailing reason is optional but preferred. Absent file = the Claude-native
+The trailing reason is optional but preferred. Absent file = the `codex/best`
 default above. Absent dispatch rules = the same default. A matching rule is
 still a judgment aid; the orchestrator records which rule was used and may
 override it with a reason recorded on the issue.
@@ -87,8 +87,8 @@ intake canary; API-key auth cannot use Fast mode — drop the two pins and
 record the substitution on the tracking issue (no silent fallback). The
 default is builder-only; verification subagents and the monitor never carry the Fast pins.
 
-Configured builders CLI absent at preflight -> fall back to the Claude-native
-default (`claude/tier-down`) and write one tracking-issue comment naming
+Configured builders CLI absent at preflight -> fall back to `claude/tier-down`
+(the Claude-native fallback) and write one tracking-issue comment naming
 requested vs substituted. Cross-family
 review backend absent -> run review in a fresh same-CLI context and log the
 same-family bias caveat. Never hard-fail on model availability alone. Tier is


### PR DESCRIPTION
Deep-review follow-ups from the review-fanout + builders-flip merge. PR #147 flipped the builders default to `codex/best` but missed two spots, and two glossary paths predated multi-run namespacing.

- `skills/architect/SKILL.md` §4: builders described as Claude-native Agent-tool jobs with "codex backend by config" — inverted vs the flipped default. Now: codex-CLI jobs default, Claude-native is the config alternative and codex-absent fallback.
- `skills/architect/dispatch.md`: "Absent file = the Claude-native default above" contradicted the `codex/best` default named earlier in the same section; codex-absent fallback no longer called a "default".
- `README.md` Installation: Codex CLI no longer framed as an opt-in route — it powers the default builders; without it, builders fall back to `claude/tier-down`.
- `README.md` Details: two near-duplicate check-runner bullets; the second re-headed onto the closing review it actually describes.
- `CONTEXT.md`: **Check** and **Rulings file** paths gain the `<run>/` namespace segment (stale since multi-run isolation).

Combined architect skill budget 988/989; `tests/validate_skills.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
