### PR TITLE
[codex] Refresh architect README flow docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -240,8 +240,8 @@ architect-v5 and architect-v5.1 specs, and loop-improvements research
   boundaries, and native parent/blocked-by edges
   ([mattpocock/skills](https://github.com/mattpocock/skills) `/to-issues`;
   [Anthropic multi-agent](https://www.anthropic.com/engineering/multi-agent-research-system)).
-  The parallel set is always the plan's ready issues, capped at five
-  jobs plus one watchdog sweep.
+  The parallel set is always the plan's ready issues, capped at 10
+  CLI-launched jobs or the built-in harness cap (currently 5).
   Tracking issue #43's 2026-07-03 DIGEST comment, reflected in the
   loop-tuning spec and status-scripts rulings (evidence: git history before
   the 2026-07-04 cleanup), tightened run mechanics: the old "judges dispatch
@@ -706,12 +706,12 @@ decisions, from the 2026-06 evidence review and the r2 calibration pass
   ([OAgents](https://arxiv.org/abs/2506.15741) 47.88→51.52;
   [AOrchestra](https://arxiv.org/abs/2602.03786) +16.28% relative). A cheap
   scout (~10 searches) maps terminology, load-bearing systems, and fault
-  lines; the orchestrator designs 3–6 researchers from that map, drawing
+  lines; the orchestrator designs 3–10 researchers from that map, drawing
   source-class tactics from `tactics.md`. Perspective discovery was STORM's
   largest measured lever (unique references 99.83 vs 54.36,
   [STORM](https://arxiv.org/abs/2402.14207)). Fact-finds and comparisons
   skip the scout.
-- **Hard budgets per researcher.** Researcher counts scale 1/2–4/4–6 by tier;
+- **Hard budgets per researcher.** Researcher counts scale 1/2–4/4–10 by tier;
   tool-call budgets 3–10/10–15/15–25; ≤5 subjects per researcher (a
   researcher that fills its window dies without writing output); saturation
   stop; ≤2 gap rounds. Numbers from Anthropic's published orchestrator

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # architect-loop
 
 **Set-it-and-forget-it research and software factory loop with best
-practices built in. Save 80% of Fable token usage, lose no quality.**
+practices built in. Cut frontier-model usage while keeping the quality gates.**
 
 ## Usage
 
 ```
 /architect-research <topic>
-/architect <what you want>
+/architect <hours+ feature/product request>
 /architect-fast <small change>
 ```
 
-Ask for work, come back when it's done. Your one job is approving the spec —
-in-session, or by commenting `APPROVE` on the tracking issue from your phone.
-`/architect-fast` is the light lane for small, few-file changes you want done
-in one sitting — same shape as `/architect`, without the per-issue grading
-machinery; anything bigger routes itself to `/architect` instead.
+`/architect-research` to explore ideas or features  
+`/architect-fast` to do a quick change  
+`/architect` for long, multi-hour runs. Start it and walk away.
 
 ## Installation
 
@@ -25,18 +23,11 @@ cd architect-loop && ./install.sh        # Windows: .\install.ps1
 npm i -g @openai/codex@latest            # optional: Codex CLI (>= 0.133)
 ```
 
-One installer, both ecosystems: the same skills land in Claude Code and in
-Codex's `.agents/skills`. You need [Claude Code](https://claude.com/claude-code)
-on any paid plan; the Codex CLI on a ChatGPT plan powers the default
-builders — without it, builders fall back to Claude (`claude/tier-down`).
-No API keys.
-
 ## Design
 
-A configurable **orchestrator** model (default: Fable, high) designs,
-assigns, and reviews. A configurable **builder** model (default: GPT-5.5,
-xhigh, Fast mode) does the heavy lifting. Both are overridable — see
-[Config](#config).
+The current session is the **orchestrator** by default: it designs, assigns,
+and reviews. A configurable **builder** model (default: GPT-5.5, xhigh, Fast
+mode) does the heavy lifting. Both are overridable — see [Config](#config).
 
 ### /architect
 
@@ -46,11 +37,11 @@ xhigh, Fast mode) does the heavy lifting. Both are overridable — see
   (shared vocabulary), `to-spec`, `adversarial-review`, `to-issues`,
   `frozen-checks`; builders preload `tdd`; `final-review` audits the run
   read-only and decomposes findings into fix issues for a fix wave;
-  `integrate` updates the docs and preps the ship.
+  builder-tier `integrate` updates the docs and preps the ship.
 - Orchestrator grounds in the vocabulary, then writes a spec doc and asks
   you no more than 5 questions.
 - A fresh orchestrator-tier subagent adversarially reviews the spec.
-- Orchestrator breaks the work into parallelizable, vertical-slice GitHub
+- Orchestrator breaks the work into parallelizable, vertical-slice tracker
   issues.
 - Orchestrator freezes the acceptance checks in git.
 - A run manifest in `docs/runs/<run>/manifest.md` pins the tracking issue,
@@ -58,8 +49,8 @@ xhigh, Fast mode) does the heavy lifting. Both are overridable — see
   read that pin instead of scanning every issue.
 - Orchestrator loops through the issues, assigning builders until every
   issue is fully complete:
-  - builders work test-first and run their own tests, with progress landing
-    on the GitHub issue;
+  - builders work test-first and run their own tests, with progress mirrored
+    to the tracker issue when the backend allows it;
   - a deterministic check-runner grades each issue's frozen checks;
   - on failure, the orchestrator diagnoses why, updates the issue and its
     requirements, and respawns a fresh builder — otherwise it comments,
@@ -100,13 +91,15 @@ xhigh, Fast mode) does the heavy lifting. Both are overridable — see
 
 ![research flow](assets/research-flow.svg)
 
-- Orchestrator launches a scouting agent for the overhead view of the topic.
+- For brainstorm-scale work, orchestrator launches a scout for the overhead
+  view of the topic; quick fact-finds and focused comparisons skip it.
 - Orchestrator designs research lanes along the topic's fault lines.
-- Orchestrator launches a researcher agent per lane, in parallel.
-- Orchestrator drafts a skeleton report.
-- A fresh orchestrator-tier model adversarially reviews the draft.
-- Orchestrator launches a targeted second round of researchers at the gaps.
-- Orchestrator verifies the claims and compiles the final report.
+- Orchestrator launches researchers per lane, in parallel: up to 10 through
+  CLI-launched workers or the harness cap for built-in subagents.
+- Orchestrator drafts a skeleton report marked SUPPORTED / THIN / EMPTY.
+- THIN / EMPTY sections trigger targeted gap researchers, up to 2 rounds.
+- Orchestrator verifies load-bearing claims against raw sources and writes
+  the final report.
 
 ## Details
 
@@ -147,15 +140,16 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
 - **Acceptance checks freeze in git before any builder exists.**
   Criteria written after results exist always pass; a builder touching a
   check file is an automatic FAIL.
-- **Issues are vertical slices with disjoint file sets, ≤5 in parallel.**
-  Merge conflicts are the top multi-agent failure mode; a
-  conflict means the plan was wrong, so the job is killed and re-sliced,
-  never hand-merged.
+- **Issues are vertical slices with disjoint file sets, up to 10 in parallel.**
+  CLI-launched builders run 10-wide; built-in harness subagents use their
+  native cap, currently 5. Merge conflicts are the top multi-agent failure
+  mode; a conflict means the plan was wrong, so the job is killed and
+  re-sliced, never hand-merged.
 - **Builders get their own git worktree and no commit rights.**
   A broken builder can't reach a branch; the orchestrator owns every commit
   and merge.
 - **Run identity is pinned, not discovered.** Each run has a
-  committed `docs/runs/<run>/manifest.md` plus a run marker in every issue
+  local `docs/runs/<run>/manifest.md` plus a run marker in every issue
   body. Status reads `skills/architect/status.ps1 <run>` or
   `skills/architect/status.sh <run>` from that manifest; foreign issues under
   the same parent are escalated instead of dispatched.
@@ -290,7 +284,7 @@ subagents follow `builders`; adversarial reviewers
 and closing review follow the orchestrator tier; `/architect-research`
 researchers follow `builders`. `when <task
 class> -> <model>` lines route classes of work to a tier. A configured CLI
-missing at dispatch falls back to the default with a note on the tracking
+missing at dispatch uses the recorded fallback with a note on the tracking
 issue — never a hard fail.
 
 ### Local issues without GitHub

--- a/assets/architect-fast-flow.svg
+++ b/assets/architect-fast-flow.svg
@@ -66,11 +66,11 @@
   <line x1="380" y1="574" x2="380" y2="616" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
   <!-- 6 INTEGRATE -->
-  <rect x="230" y="624" width="300" height="56" rx="10" fill="#7c3aed"/>
+  <rect x="230" y="624" width="300" height="56" rx="10" fill="#0d9488"/>
   <text x="380" y="647" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
-  <text x="380" y="665" font-size="10.5" fill="#ede9fe" text-anchor="middle">docs pass first · the existing integrate stage skill</text>
-  <text x="560" y="644" font-size="11" fill="#475569">the review verdict stands in for final-review by recorded</text>
-  <text x="560" y="658" font-size="11" fill="#475569">ruling; graded-RUN set is empty by design, validator still runs</text>
+  <text x="380" y="665" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder-tier subagent · docs pass · PR handoff</text>
+  <text x="560" y="644" font-size="11" fill="#475569">the review verdict stands in for final-review by recorded ruling;</text>
+  <text x="560" y="658" font-size="11" fill="#475569">a builder-tier integrate subagent runs docs, validation, and PR prep</text>
 
   <!-- arrow to PR -->
   <line x1="380" y1="680" x2="380" y2="722" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
@@ -78,7 +78,7 @@
   <!-- 7 PR -->
   <rect x="230" y="730" width="300" height="56" rx="10" fill="#16a34a"/>
   <text x="380" y="753" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PR</text>
-  <text x="380" y="771" font-size="10.5" fill="#dcfce7" text-anchor="middle">one PR + digest, same as /architect</text>
+  <text x="380" y="771" font-size="10.5" fill="#dcfce7" text-anchor="middle">opened by integrate with the run digest</text>
   <text x="560" y="750" font-size="11" fill="#475569">the tracking issue gets the review verdict and</text>
   <text x="560" y="764" font-size="11" fill="#475569">diffstat before the PR — docs shipped by integrate</text>
 
@@ -86,9 +86,9 @@
   <rect x="45" y="830" width="12" height="12" rx="3" fill="#7c3aed"/>
   <text x="63" y="840" font-size="11" fill="#475569">orchestrator + its fresh subagents (frontier model)</text>
   <rect x="360" y="830" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="378" y="840" font-size="11" fill="#475569">builders (cheap model)</text>
-  <rect x="540" y="830" width="12" height="12" rx="3" fill="#d97706"/>
-  <text x="558" y="840" font-size="11" fill="#475569">human</text>
-  <rect x="640" y="830" width="12" height="12" rx="3" fill="#16a34a"/>
-  <text x="658" y="840" font-size="11" fill="#475569">the shipped PR</text>
+  <text x="378" y="840" font-size="11" fill="#475569">builders + integrate (cheap model)</text>
+  <rect x="650" y="830" width="12" height="12" rx="3" fill="#d97706"/>
+  <text x="668" y="840" font-size="11" fill="#475569">human</text>
+  <rect x="750" y="830" width="12" height="12" rx="3" fill="#16a34a"/>
+  <text x="768" y="840" font-size="11" fill="#475569">the shipped PR</text>
 </svg>

--- a/assets/architect-flow.svg
+++ b/assets/architect-flow.svg
@@ -52,7 +52,7 @@
   <text x="518" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
   <text x="656" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
   <text x="740" y="404" font-size="11" fill="#475569">fresh builder per ready issue,</text>
-  <text x="740" y="418" font-size="11" fill="#475569">≤5 at once; a job ending</text>
+  <text x="740" y="418" font-size="11" fill="#475569">10 via CLI; harness cap 5</text>
   <text x="740" y="432" font-size="11" fill="#475569">dispatches the next instantly</text>
 
   <!-- builder → checks arrows -->
@@ -114,27 +114,27 @@
   <text x="392" y="702" font-size="11" font-weight="700" fill="#16a34a">GREEN — or fix wave merged</text>
 
   <!-- 7 INTEGRATE -->
-  <rect x="230" y="728" width="300" height="56" rx="10" fill="#7c3aed"/>
+  <rect x="230" y="728" width="300" height="56" rx="10" fill="#0d9488"/>
   <text x="380" y="751" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
-  <text x="380" y="769" font-size="10.5" fill="#ede9fe" text-anchor="middle">docs pass first · merges green branches · preps the ship</text>
-  <text x="560" y="748" font-size="11" fill="#475569">one fresh subagent: updates product docs from the run digest,</text>
-  <text x="560" y="762" font-size="11" fill="#475569">then merges, re-verifies, and drafts the PR + digest</text>
+  <text x="380" y="769" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder-tier subagent · docs pass · PR handoff</text>
+  <text x="560" y="748" font-size="11" fill="#475569">one fresh builder-tier subagent consumes the docs-debt digest,</text>
+  <text x="560" y="762" font-size="11" fill="#475569">then merges, re-verifies, and opens the PR + digest</text>
 
   <!-- 8 PR -->
   <line x1="380" y1="784" x2="380" y2="826" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <rect x="230" y="834" width="300" height="56" rx="10" fill="#16a34a"/>
   <text x="380" y="857" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PR</text>
-  <text x="380" y="875" font-size="10.5" fill="#dcfce7" text-anchor="middle">one PR + digest of what shipped</text>
-  <text x="560" y="854" font-size="11" fill="#475569">the digest lists shipped, skipped, residual risks, and evidence;</text>
+  <text x="380" y="875" font-size="10.5" fill="#dcfce7" text-anchor="middle">opened by integrate with the run digest</text>
+  <text x="560" y="854" font-size="11" fill="#475569">the PR digest lists shipped, skipped, residual risks, and evidence;</text>
   <text x="560" y="868" font-size="11" fill="#475569">the issue trail is the durable memory of the whole run</text>
 
   <!-- legend -->
   <rect x="45" y="940" width="12" height="12" rx="3" fill="#7c3aed"/>
   <text x="63" y="950" font-size="11" fill="#475569">orchestrator + its fresh reviewers (frontier model)</text>
   <rect x="360" y="940" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="378" y="950" font-size="11" fill="#475569">builders (cheap model)</text>
-  <rect x="540" y="940" width="12" height="12" rx="3" fill="#64748b"/>
-  <text x="558" y="950" font-size="11" fill="#475569">deterministic script</text>
-  <rect x="700" y="940" width="12" height="12" rx="3" fill="#16a34a"/>
-  <text x="718" y="950" font-size="11" fill="#475569">the shipped PR</text>
+  <text x="378" y="950" font-size="11" fill="#475569">builders + integrate (cheap model)</text>
+  <rect x="620" y="940" width="12" height="12" rx="3" fill="#64748b"/>
+  <text x="638" y="950" font-size="11" fill="#475569">deterministic script</text>
+  <rect x="800" y="940" width="12" height="12" rx="3" fill="#16a34a"/>
+  <text x="818" y="950" font-size="11" fill="#475569">the shipped PR</text>
 </svg>

--- a/assets/research-flow.svg
+++ b/assets/research-flow.svg
@@ -1,95 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 840" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 810" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
   <defs>
     <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#334155"/></marker>
-    <marker id="arrAmber" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#d97706"/></marker>
+    <marker id="arrPurple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#7c3aed"/></marker>
   </defs>
-  <rect width="1000" height="840" fill="#ffffff"/>
+  <rect width="1000" height="810" fill="#ffffff"/>
 
-  <text x="80" y="44" font-size="20" font-weight="700" fill="#0f172a">/architect-research</text>
-  <text x="288" y="44" font-size="12.5" fill="#64748b">scout → design lanes → gather → draft → verify → one author writes</text>
+  <text x="45" y="44" font-size="20" font-weight="700" fill="#0f172a">/architect-research</text>
+  <text x="260" y="44" font-size="12" fill="#64748b">scout → lane design → parallel researchers → draft/gap round → verify → report</text>
 
-  <!-- spine arrows -->
+  <!-- spine arrows (single-column section) -->
   <line x1="380" y1="126" x2="380" y2="168" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="232" x2="380" y2="262" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="338" x2="380" y2="380" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="444" x2="380" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="550" x2="380" y2="592" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="656" x2="380" y2="698" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-
-  <!-- wave-2 loop: review back to gather -->
-  <path d="M 230 522 H 150 V 310 H 222" fill="none" stroke="#d97706" stroke-width="2.5" stroke-dasharray="6 4" marker-end="url(#arrAmber)"/>
-  <text x="190" y="400" font-size="10" font-weight="700" fill="#b45309" text-anchor="middle">gaps send a</text>
-  <text x="190" y="414" font-size="10" font-weight="700" fill="#b45309" text-anchor="middle">targeted wave 2</text>
-  <text x="190" y="428" font-size="10" fill="#b45309" text-anchor="middle">(max 2 rounds)</text>
+  <line x1="380" y1="232" x2="380" y2="274" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
   <!-- 1 SCOUT -->
   <rect x="230" y="70" width="300" height="56" rx="10" fill="#0d9488"/>
   <text x="380" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SCOUT</text>
-  <text x="380" y="111" font-size="10.5" fill="#ccfbf1" text-anchor="middle">one cheap agent maps the topic</text>
-  <rect x="560" y="72" width="112" height="17" rx="8.5" fill="#d97706"/>
-  <text x="616" y="84" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">TOKEN SAVINGS</text>
-  <text x="560" y="104" font-size="11" fill="#475569">~10 searches map terminology, load-bearing systems, and where</text>
-  <text x="560" y="118" font-size="11" fill="#475569">experts disagree; skipped entirely for quick fact-finds</text>
+  <text x="380" y="111" font-size="10.5" fill="#ccfbf1" text-anchor="middle">cheap agent maps the topic before lanes exist</text>
+  <text x="560" y="90" font-size="11" fill="#475569">~10 searches find the topic vocabulary, load-bearing systems,</text>
+  <text x="560" y="104" font-size="11" fill="#475569">and expert fault lines; skipped entirely for quick fact-finds</text>
 
   <!-- 2 DESIGN LANES -->
   <rect x="230" y="176" width="300" height="56" rx="10" fill="#7c3aed"/>
   <text x="380" y="199" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DESIGN LANES</text>
-  <text x="380" y="217" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator cuts 3–6 research lanes</text>
-  <rect x="560" y="178" width="66" height="17" rx="8.5" fill="#16a34a"/>
-  <text x="593" y="190" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">QUALITY</text>
-  <text x="560" y="210" font-size="11" fill="#475569">lanes follow the topic's own fault lines, never a fixed taxonomy —</text>
-  <text x="560" y="224" font-size="11" fill="#475569">perspective-diverse and overlap-checked before anything launches</text>
+  <text x="380" y="217" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator cuts topic-shaped research lanes</text>
+  <text x="560" y="196" font-size="11" fill="#475569">lanes follow the topic's own fault lines, never a fixed taxonomy;</text>
+  <text x="560" y="210" font-size="11" fill="#475569">overlap is checked before any researcher launches</text>
 
-  <!-- 3 GATHER (parallel stack) -->
-  <rect x="242" y="270" width="300" height="56" rx="10" fill="#ccfbf1" stroke="#0d9488" stroke-width="1"/>
-  <rect x="236" y="276" width="300" height="56" rx="10" fill="#ccfbf1" stroke="#0d9488" stroke-width="1"/>
-  <rect x="230" y="282" width="300" height="56" rx="10" fill="#0d9488"/>
-  <text x="380" y="305" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">GATHER</text>
-  <text x="380" y="323" font-size="10.5" fill="#ccfbf1" text-anchor="middle">parallel researchers under hard budgets</text>
-  <rect x="560" y="284" width="112" height="17" rx="8.5" fill="#d97706"/>
-  <text x="616" y="296" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">TOKEN SAVINGS</text>
-  <text x="560" y="316" font-size="11" fill="#475569">10–25 tool calls, ≤5 subjects, returns capped near 2,500 tokens;</text>
-  <text x="560" y="330" font-size="11" fill="#475569">every finding carries URL + date + quote; NOT FOUND is an answer</text>
+  <!-- 3 RESEARCHERS (parallel gather) -->
+  <rect x="45" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
+  <rect x="182" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
+  <rect x="321" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
+  <rect x="459" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
+  <rect x="597" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
+  <text x="104" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="241" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="380" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="518" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="656" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="104" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 1</text>
+  <text x="241" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 2</text>
+  <text x="380" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 3</text>
+  <text x="518" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 4</text>
+  <text x="656" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 5</text>
+  <text x="740" y="298" font-size="11" fill="#475569">up to 10 researchers run side by side</text>
+  <text x="740" y="312" font-size="11" fill="#475569">under hard budgets: 10–25 tool calls,</text>
+  <text x="740" y="326" font-size="11" fill="#475569">≤5 subjects, NOT FOUND allowed</text>
+
+  <!-- researcher findings converge to the draft -->
+  <line x1="104" y1="338" x2="104" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="241" y1="338" x2="241" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="380" y1="338" x2="380" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="518" y1="338" x2="518" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="656" y1="338" x2="656" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="104" y1="362" x2="656" y2="362" stroke="#334155" stroke-width="2"/>
+  <line x1="380" y1="362" x2="380" y2="404" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <text x="392" y="388" font-size="11" font-weight="700" fill="#16a34a">FINDINGS RETURN</text>
 
   <!-- 4 DRAFT -->
-  <rect x="230" y="388" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="411" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DRAFT</text>
-  <text x="380" y="429" font-size="10.5" fill="#ede9fe" text-anchor="middle">skeleton report · SUPPORTED / THIN / EMPTY</text>
-  <rect x="560" y="390" width="112" height="17" rx="8.5" fill="#d97706"/>
-  <text x="616" y="402" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">TOKEN SAVINGS</text>
-  <text x="560" y="422" font-size="11" fill="#475569">the draft is the state: SUPPORTED / THIN / EMPTY marks aim the</text>
-  <text x="560" y="436" font-size="11" fill="#475569">next wave only at gaps — nothing already found gets re-chased</text>
+  <rect x="230" y="412" width="300" height="56" rx="10" fill="#7c3aed"/>
+  <text x="380" y="435" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DRAFT</text>
+  <text x="380" y="453" font-size="10.5" fill="#ede9fe" text-anchor="middle">one author marks SUPPORTED / THIN / EMPTY</text>
+  <text x="560" y="432" font-size="11" fill="#475569">the draft is the state between waves; gaps are visible,</text>
+  <text x="560" y="446" font-size="11" fill="#475569">and evidence already found is not re-chased</text>
 
-  <!-- 5 ADVERSARIAL REVIEW -->
-  <rect x="230" y="494" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="517" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ADVERSARIAL REVIEW</text>
-  <text x="380" y="535" font-size="10.5" fill="#ede9fe" text-anchor="middle">a fresh model attacks the draft</text>
-  <rect x="560" y="496" width="66" height="17" rx="8.5" fill="#16a34a"/>
-  <text x="593" y="508" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">QUALITY</text>
-  <text x="560" y="528" font-size="11" fill="#475569">fresh context with no attachment to the draft; researchers gather</text>
-  <text x="560" y="542" font-size="11" fill="#475569">evidence but never recommend — synthesis stays in one place</text>
+  <!-- gap loop: draft back to targeted researchers -->
+  <path d="M 230 440 H 20 V 310 H 42" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrPurple)"/>
+  <text x="82" y="390" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">THIN / EMPTY</text>
+  <text x="82" y="404" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">gap researchers</text>
+  <text x="82" y="418" font-size="8.5" fill="#64748b" text-anchor="middle">max 2 rounds</text>
 
-  <!-- 6 VERIFY -->
-  <rect x="230" y="600" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="623" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">VERIFY</text>
-  <text x="380" y="641" font-size="10.5" fill="#ede9fe" text-anchor="middle">claims re-checked against raw sources</text>
-  <rect x="560" y="602" width="66" height="17" rx="8.5" fill="#16a34a"/>
-  <text x="593" y="614" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">QUALITY</text>
-  <text x="560" y="634" font-size="11" fill="#475569">≥2 independent sources per load-bearing claim, plus adversarial</text>
-  <text x="560" y="648" font-size="11" fill="#475569">falsification searches; citations only from URLs actually fetched</text>
+  <!-- arrow to verify -->
+  <line x1="380" y1="468" x2="380" y2="510" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 7 REPORT -->
-  <rect x="230" y="706" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="729" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">REPORT</text>
-  <text x="380" y="747" font-size="10.5" fill="#ede9fe" text-anchor="middle">one author writes · answer-first</text>
-  <rect x="560" y="708" width="66" height="17" rx="8.5" fill="#16a34a"/>
-  <text x="593" y="720" font-size="9.5" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="0.6">QUALITY</text>
-  <text x="560" y="740" font-size="11" fill="#475569">gathering parallelizes, synthesis never does — one author,</text>
-  <text x="560" y="754" font-size="11" fill="#475569">answer-first; the committed report feeds /architect specs</text>
+  <!-- 5 VERIFY -->
+  <rect x="230" y="518" width="300" height="56" rx="10" fill="#7c3aed"/>
+  <text x="380" y="541" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">VERIFY</text>
+  <text x="380" y="559" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator re-checks load-bearing claims</text>
+  <text x="560" y="538" font-size="11" fill="#475569">claims need independent support plus falsification searches;</text>
+  <text x="560" y="552" font-size="11" fill="#475569">citations only come from URLs fetched in this session</text>
+
+  <!-- arrow to report -->
+  <line x1="380" y1="574" x2="380" y2="616" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+
+  <!-- 6 REPORT -->
+  <rect x="230" y="624" width="300" height="56" rx="10" fill="#16a34a"/>
+  <text x="380" y="647" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">REPORT</text>
+  <text x="380" y="665" font-size="10.5" fill="#dcfce7" text-anchor="middle">committed answer-first report</text>
+  <text x="560" y="644" font-size="11" fill="#475569">gathering parallelizes, synthesis does not: one author writes,</text>
+  <text x="560" y="658" font-size="11" fill="#475569">and the report becomes the handoff into /architect specs</text>
 
   <!-- legend -->
-  <rect x="80" y="792" width="12" height="12" rx="3" fill="#7c3aed"/>
-  <text x="98" y="802" font-size="11" fill="#475569">orchestrator + its fresh reviewers (frontier model)</text>
-  <rect x="420" y="792" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="438" y="802" font-size="11" fill="#475569">scout / researchers (cheap model)</text>
+  <rect x="45" y="760" width="12" height="12" rx="3" fill="#7c3aed"/>
+  <text x="63" y="770" font-size="11" fill="#475569">orchestrator + verification (frontier model)</text>
+  <rect x="360" y="760" width="12" height="12" rx="3" fill="#0d9488"/>
+  <text x="378" y="770" font-size="11" fill="#475569">scout + researchers (cheap model)</text>
+  <rect x="590" y="760" width="12" height="12" rx="3" fill="#16a34a"/>
+  <text x="608" y="770" font-size="11" fill="#475569">committed report</text>
 </svg>

--- a/skills/architect-fast/SKILL.md
+++ b/skills/architect-fast/SKILL.md
@@ -97,6 +97,8 @@ silent fallback — every precondition, blocker, and substitution is recorded.
    with jobs still in flight, judge liveness from report growth and
    process activity directly. On DONE, merge through postflight
    (`skills/architect/dispatch.md` `## Preflight and postflight dispatch`).
+   The size ceiling, not backend capacity, is the active cap here; the shared
+   dispatch cap remains 10 CLI-launched jobs or 5 harness-native subagents.
    On BLOCKED, answer durably and respawn fresh, unchanged.
 
 6. **Orchestrator review.** After all issues merge, the orchestrator itself

--- a/skills/architect-research/SKILL.md
+++ b/skills/architect-research/SKILL.md
@@ -27,7 +27,7 @@ A tool call is one search OR one page fetch.
   perspectives, 10-15 tool calls each, no scout — you already know the
   terrain.
 - **Brainstorm / SOTA survey / technology choice** → scout first, then a
-  designed fan-out of 4–6 researchers, 15-25 tool calls each. Google's
+  designed fan-out of 4–10 researchers, 15-25 tool calls each. Google's
   published research envelope brackets this tier: ~80 searches ≈ $1–3/task
   standard, ~160 ≈ $3–7 max.
 
@@ -52,7 +52,7 @@ which source classes look rich vs empty, and the topic's natural fault lines.
 The scout returns a map, not findings. Skip the scout when you already know the
 terrain (comparisons, fact-finds).
 
-**Design (you, from the scout report):** decompose into 3–6 sub-questions
+**Design (you, from the scout report):** decompose into 3–10 sub-questions
 along the topic's own fault lines — distinct perspectives, never keyword
 variants of one query. For each researcher assignment pick the source-class tactics it needs
 from `tactics.md` (academic snowballing, dependents-not-stars repo evidence,
@@ -72,7 +72,7 @@ Resolve the researcher model as builders, same order as `/architect`: repo
 config-resolved default in `skills/architect/dispatch.md` — `codex/best`
 (gpt-5.5 at xhigh) via the codex CLI; the Claude-native rows
 (`builders = claude/...`) are the config-selected alternative. One fresh
-researcher per assignment, all parallel, in the background — this is the
+researcher per assignment, up to 10 in parallel for CLI launches — this is the
 default codex/best form:
 
 ```bash
@@ -89,8 +89,9 @@ never as a shell argument; quote-mangling shells make codex hang on stdin.
 Older CLIs: `--enable web_search` (0.13x) or `-c tools.web_search=true`
 (< 0.133); `--search` is TUI-only — exec rejects it. Launch ONE canary researcher
 and confirm it starts cleanly before fanning out. If resolved builders is a
-claude row, or Codex is unavailable, run researchers as read-only Claude subagents
-with web search — the researcher blocks work verbatim.)
+claude row, or Codex is unavailable, run researchers as read-only Claude
+subagents with web search, respecting the built-in harness cap (currently 5) —
+the researcher blocks work verbatim.)
 
 Every researcher block carries the full contract — objective, output format, source
 guidance, boundaries — plus:
@@ -118,8 +119,8 @@ not a coverage score kept in your head. Every NOT FOUND from prior researchers
 carries forward into a **do-not-rechase list** that every gap-researcher block must
 include, so gap researchers don't re-spend budget chasing a dead end. This is
 also where the **expert-opinion researcher** dispatches: extract the expert roster
-from the first wave (survey authors, maintainers, recurring names) and send
-the researcher 6 after them. Hard stop after two refinement rounds —
+from the first wave (survey authors, maintainers, recurring names) and send a
+targeted researcher after them. Hard stop after two refinement rounds —
 past that you're chasing nonexistent information.
 
 ### 5. Verify (your work, against raw sources)

--- a/skills/architect-research/tactics.md
+++ b/skills/architect-research/tactics.md
@@ -8,7 +8,7 @@
 - Researcher 3 — Cutting-edge repos (emerging, not hype)
 - Researcher 4 — Production-grade design patterns
 - Researcher 5 — General web
-- Researcher 6 — Expert opinion (second wave — dispatch after researchers 1-5 return)
+- Expert opinion — second wave, after the first researchers return
 
 Researcher assignments are DESIGNED per topic by the orchestrator (SKILL.md step 2); the
 sections below are search tactics and verified endpoints per source class —
@@ -50,7 +50,7 @@ Return: (1) canonical terminology and the names the field itself uses;
 (2) the 5–10 load-bearing systems/papers/repos/vendors, one line each on why
 they matter; (3) the named people whose positions recur; (4) which source
 classes look rich vs empty for this topic (papers? repos? vendor blogs?
-forums?); (5) the topic's natural fault lines — the 3–6 sub-questions an
+forums?); (5) the topic's natural fault lines — the 3–10 sub-questions an
 expert would split it into. Budget ~10 searches; breadth over depth; snippet
 over page. Output is a MAP for the orchestrator to design researcher assignments from —
 structure matters more than completeness.
@@ -166,7 +166,7 @@ docs/changelogs, pricing/operational constraints.
   aggregators are pointers, never citations — chase them to the primary
   source or drop the claim.
 
-## Researcher 6 — Expert opinion (second wave — dispatch after researchers 1-5 return)
+## Expert opinion — second wave
 
 Objective: what the named experts in <topic> are saying right now — positions,
 warnings, predictions, and especially disagreements — from their blogs, talks,

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -139,9 +139,9 @@ respawn fresh. Builders never re-plan.
 
 Event loop: loop.md `## Factory block procedure`.
 
-- Dispatch the ready issues — up to five build jobs plus one detection-only
-  watchdog (`dispatch.md` `## Monitor dispatch`). Builders default to
-  codex-CLI jobs (`codex/best`); Claude-native Agent-tool jobs
+- Dispatch the ready issues to the backend cap: up to 10 CLI-launched build
+  jobs, or the built-in harness subagent cap (currently 5). Builders default
+  to codex-CLI jobs (`codex/best`); Claude-native Agent-tool jobs
   (`architect-builder` def preloads `tdd` + `codebase-design`; model per
   alias table) are the config alternative and codex-absent fallback. Every
   job end is a dispatch event: recompute the frontier and dispatch before

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -101,8 +101,8 @@ retry-at-a-different-tier job (see `loop.md` "## Failure ladder").
 |---|---|---|
 | Builder | Agent tool with `.claude/agents/architect-builder.md`; `disallowedTools` denies `Bash(git commit *)` and `Bash(git push *)`; `isolation: worktree`; `background: true`; model may be passed per invocation from the alias table. On the desktop app, the harness auto-creates the agent's isolation worktree (`.claude/worktrees/agent-<id>`) and its branch — integrate from that branch. On the CLI, spawns have been observed to run UNISOLATED in the orchestrator's checkout despite `isolation: worktree` frontmatter (D11) — pass isolation explicitly per invocation if supported, and never run two Claude-backend builder jobs concurrently unless each is verified to have its own worktree (`git worktree list` after spawn). In all cases, never pre-create a job worktree for Claude-backend jobs (a pre-made one is ignored); do not use `.architect/wt/<run>/<slice>-<NN>` (that pattern is Codex-backend only, below). | `spawn_agent` with defensive framing: "Your task is: ..."; worktree created by the orchestrator via git; use `/goal` semantics for persistent job completion. |
 | Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md` (read-only verification def); dispatch synchronously with `run_in_background: false` so the result is the tool result; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions; the process exit wakes the loop. |
-| Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when the orchestrator can run background processes and receive exit notifications; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when background process exits wake the orchestrator; LLM fallback template only otherwise and it counts as one of the 6 `max_threads`. |
-| Parallelism | Background subagents; permission prompts surface to the main session. | Native subagents, `max_threads` 6, `max_depth` 1 (root session is depth 0; a spawned child may not spawn further — no nested orchestrators, the orchestrator dispatches builders directly), `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent` — evidence: v4-codex CG4 architect-run canary `events.jsonl`). |
+| Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when the orchestrator can run background processes and receive exit notifications; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when background process exits wake the orchestrator; LLM fallback template only otherwise and it consumes one native subagent slot. |
+| Parallelism | CLI-launched builder backends, including Claude Code orchestrating Codex, run up to 10 background jobs. Claude Agent-tool builders are harness-native: use the harness cap (currently 5), verify isolated worktrees before concurrent spawns, and expect permission prompts in the main session. | CLI-launched builder backends run up to 10 background jobs. Native `spawn_agent` builders use the harness cap (currently 5), `max_depth` 1 (root session is depth 0; a spawned child may not spawn further), and `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent`). |
 | Review (high-stakes) | `codex review --base` when Codex is installed; otherwise a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
 | Skill packaging | `skills/architect/` plus Claude skill install locations. | `.agents/skills/architect/SKILL.md` (and any other `skills/*/`); same source text copied by installer. |
 
@@ -160,7 +160,7 @@ codex exec -C <repo-root> --sandbox workspace-write \
   - < .architect/dispatch-block.md
 ```
 
-For 2-4 jobs, the orchestrator owns worktree creation and parallelism:
+For 2-10 CLI-launched jobs, the orchestrator owns worktree creation and parallelism:
 
 ```bash
 git -C <repo-root> worktree add .architect/wt/<run>/<slice>-<NN> \
@@ -392,9 +392,9 @@ tail excerpt. Do not wait for other jobs to finish before reporting it.
 ```
 <!-- architect-monitor-fallback-template:end -->
 
-Codex backend note: `max_threads` is 6. Five builder jobs plus one monitor is
-exactly at that cap only when the LLM fallback is used - never add a sixth
-concurrent subagent while that fallback monitor is running.
+Native harness note: built-in subagents cap at 5 concurrent jobs. CLI-launched
+`codex exec` builders cap at 10 and do not consume native subagent slots; if
+an LLM fallback monitor is running in native-harness mode, reserve one slot.
 
 ## Duration hints and liveness
 

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -14,13 +14,13 @@ The loop is one orchestrator session that runs the factory to completion after
 the spec approval approves the issue plan. Tracker issues carry coordination
 state; git carries specs and frozen checks. The orchestrator dispatches the
 ready issues, sleeps, and wakes only on an event.
-Parallel rules: harness-native result-bearing subagents (Claude Agent tool) dispatch synchronously with `run_in_background: false` so the result returns as the tool result; codex-backend subagents keep the background `codex exec -o <file>` typed-exit path, whose process exit wakes the loop; a job END (DONE or BLOCKED) is a dispatch event that recomputes the full ready frontier and dispatches every ready issue into a free slot before grading (Factory block procedure step 3); merges recompute the frontier too, since a merge can unblock issues no END could; independent orchestrator bookkeeping batches into parallel calls; merges, synthesis, and the pre-freeze `adversarial-review` stress pass stay serial by design.
+Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap at 10 concurrent jobs; harness-native result-bearing subagents (Claude Agent tool, Codex `spawn_agent`) use the harness cap, currently 5, and Claude Agent-tool verification still dispatches synchronously with `run_in_background: false`; a job END (DONE or BLOCKED) is a dispatch event that recomputes the full ready frontier and dispatches every ready issue into a free slot before grading (Factory block procedure step 3); merges recompute the frontier too, since a merge can unblock issues no END could; independent orchestrator bookkeeping batches into parallel calls; merges, synthesis, and the pre-freeze `adversarial-review` stress pass stay serial by design.
 
 ## Factory block procedure
 
 1. **Dispatch the ready issues.** Compute the ready issues of the approved
-   plan: up to 5 builder jobs plus one monitor subagent (see Monitor protocol,
-   and `dispatch.md` "## Monitor dispatch"). Check `docs/STOP` and
+   plan: up to 10 CLI-launched builder jobs, or 5 harness-native builder
+   subagents (see Monitor protocol, and `dispatch.md` "## Monitor dispatch"). Check `docs/STOP` and
    `docs/runs/<run>/STOP` before every wave.
 2. **Sleep.** Zero orchestrator work between dispatch and the next event —
    no polling.

--- a/skills/architect/research.md
+++ b/skills/architect/research.md
@@ -11,13 +11,13 @@ Resolve the researcher model as builders, same order as `/architect`: repo
 `.architect/config`, then user `~/.architect/config`, then the `codex/best`
 default in `skills/architect/dispatch.md`.
 
-Decompose the question into 3–5 narrow, NON-OVERLAPPING research questions.
+Decompose the question into 3–10 narrow, NON-OVERLAPPING research questions.
 Cover different angles, not the same angle five times — typical split:
 official docs/reference, changelog/breaking changes, community failure reports,
 alternatives/comparisons, security/operational constraints.
 
-One fresh `codex exec` per question, all launched in parallel, in the
-background — codex/tier-down shown; the builders default is `codex/best`
+One fresh `codex exec` per question, all launched in parallel, up to 10
+CLI-launched researchers — codex/tier-down shown; the builders default is `codex/best`
 (`dispatch.md` `## Model resolution and dispatch rules`):
 
 ```bash
@@ -39,8 +39,8 @@ stdin otherwise.
   it. Launch ONE canary researcher and confirm it starts cleanly before
   fanning out — these flags have churned three times in 2026 alone.
 - If resolved builders is a claude row, or Codex is unavailable, run the
-  fan-out as read-only Claude subagents with web search — the research
-  block template below works verbatim.
+  fan-out as read-only Claude subagents with web search, respecting the
+  built-in harness cap (currently 5) — the research block works verbatim.
 - Effort `high`, not `xhigh` — research is coverage work; xhigh buys nothing
   here. Synthesis happens on the architect's side.
 - Scope each researcher to ≤5 subjects and put hard context rules in the


### PR DESCRIPTION
## Summary
- refresh README usage text and remove outdated ecosystem/install claims
- update architect, architect-fast, and architect-research SVG flows for consistent architect styling and accurate builder/integrate roles
- align skill docs and DESIGN parallelism language with 10 CLI-launched subagents vs 5 harness-native subagents

## Validation
- uv run python tests\validate_skills.py
- SVG XML parse for all three README flow assets
- Edge/Playwright render smoke for all three README flow assets