### PR TITLE
[codex] harden watchdog liveness

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -538,14 +538,14 @@ runner's first live use finished 7/7.
   superseded the earlier tier-up-over-retry heuristic, P6.)
 - **No per-command kill ceilings (human ruling, 2026-07-02).** Long test
   suites are legitimate work. Liveness is output-file growth plus
-  process-tree activity, never wall-clock alone; issues may carry duration
+  output/report growth and worktree file mtimes, never wall-clock alone; issues may carry duration
   *hints* that suppress false flags but are never enforced ceilings.
 - **A repeated identical action is a stall signal (P4).** Even while output
   still grows. Evidence: the worst scaffold in
   [SWE-Marathon](https://arxiv.org/abs/2606.07682) repeated 32% of its tool
   calls and produced 63/83 timeouts; OpenHands ships the same detector.
 - **The watchdog detects; the orchestrator rules (D6).** Detection is a
-  deterministic script that reads file growth, process activity, and repeated
+  deterministic script that reads file growth, file mtimes, and repeated
   command tails, then exits with typed evidence. Reasoning stays with the
   orchestrator. Gas Town draws the same boundary between "is session alive?"
   and "requires reasoning"; GitLab's one-hour no-output rule is the CI
@@ -784,7 +784,7 @@ What it drops, and why the drops are safe at the size ceiling (≤3 issues,
   memory).
 - **No watchdog script.** One per-wave timed background sleep is the
   stall-fallback wake; on a fallback wake with jobs still in flight the
-  orchestrator judges liveness from report growth and process activity
+  orchestrator judges liveness from report growth and file mtimes
   directly. The residual risk — a stall inside the sleep window extends to
   the window's end — is accepted at this scale.
 
@@ -808,7 +808,7 @@ Full flow, the substitution table, and the recorded assumptions:
 | Fabricated status reports | Every status claim audited against a tool result, both sides |
 | Check-passing but unmergeable work | Closing review reads diff vs intent, not check output alone (METR) |
 | Builder gaming visible checks | Frozen read-only checks; no iterate-against-judge loop (ImpossibleBench 33%→38%) |
-| Stalled jobs | Watchdog script: growth + process + repeated-action checks; orchestrator rules on typed evidence; no kill ceilings |
+| Stalled jobs | Watchdog script: growth + mtime + repeated-action checks; orchestrator rules on typed evidence; no kill ceilings |
 | Wrong run selected by tracker scan | `docs/runs/<run>/manifest.md` pins the tracking issue; status commands take the run slug and never compute a tracker-wide max |
 | Foreign sub-issue under a run parent | Authenticated-author filter in status plus dispatch-time run marker check; wrong-author or missing-marker issues go to the digest |
 | Runaway factory | `docs/STOP` kill-all switch; `docs/runs/<run>/STOP` per-run stop; two-consecutive-KILL hard stop; assumption-collision hard stop; tracking issue digest as the human channel |
@@ -921,8 +921,9 @@ cleanup. Both namespaces are load-bearing in shipped text.)
   `uv run --no-project python tests/validate_skills.py`.
 - **Loop-hygiene cross-platform audit (2026-07-04).** Twelve scripts were
   audited across Windows PowerShell 5.1+, macOS bash 3.2+, and Linux bash.
-  Fixes: `status.ps1` and `watchdog.ps1` prefer `Get-CimInstance` over
-  `Get-WmiObject`; `watchdog.sh` uses split `ps -eo time= -o args=`; and
+  Earlier fixes made `status.ps1` prefer `Get-CimInstance` over `Get-WmiObject`
+  and made `watchdog.sh` parse `ps -eo`; the current watchdog avoids process
+  listings entirely because tool-call sessions cannot see each other's children.
   `check-runner.sh` plus `postflight.sh` keep temp files under `.architect/tmp`.
   A live check-runner defect was also found: on Windows, bare `bash` resolved
   to WSL System32 bash, producing `powershell`/`uv` exit 127 and git worktree

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
   numbers, never verdicts; auditing every status claim against tool output
   nearly eliminates fabricated reports.
 - **Stall detection is a deterministic watchdog script.**
-  A ~70-line script watches output growth, process activity, and repeated
-  commands; the LLM monitor it replaced measured 0 true positives and 2
-  false positives. It never kills — the orchestrator rules on its evidence.
+  A small script watches output growth, file mtimes, and repeated commands;
+  the LLM monitor it replaced measured 0 true positives and 2 false positives.
+  It never kills — the orchestrator rules on its evidence.
 - **Frozen checks run through a deterministic check-runner.** *token
   savings* — ~9 mechanical commands per check file were burning
   frontier-priced judge turns; a script grades expected exits and fixed
@@ -222,7 +222,7 @@ git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
 - **A per-wave timed fallback wake replaces the watchdog script.** *token
   savings* — most waves finish before the timer fires, so no script runs at
   all; on a fallback wake with jobs still in flight, the orchestrator
-  judges liveness from report growth and process activity directly.
+  judges liveness from report growth and file mtimes directly.
 - **The dispatch-head SHA is the postflight base.** Each job's dispatch-head
   commit is recorded on its issue at dispatch and doubles as its ffcheck
   target and its postflight merge-guard base, in place of a freeze SHA —

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -6,7 +6,7 @@
 - Model resolution and dispatch rules
 - Per-harness delegation
 - Check-runner dispatch
-- Codex backend from a Claude orchestrator
+- CLI-launched subagent dispatch
 - Preflight and postflight dispatch
 - Integration commands
 - Issue conventions
@@ -101,7 +101,7 @@ retry-at-a-different-tier job (see `loop.md` "## Failure ladder").
 |---|---|---|
 | Builder | Agent tool with `.claude/agents/architect-builder.md`; `disallowedTools` denies `Bash(git commit *)` and `Bash(git push *)`; `isolation: worktree`; `background: true`; model may be passed per invocation from the alias table. On the desktop app, the harness auto-creates the agent's isolation worktree (`.claude/worktrees/agent-<id>`) and its branch — integrate from that branch. On the CLI, spawns have been observed to run UNISOLATED in the orchestrator's checkout despite `isolation: worktree` frontmatter (D11) — pass isolation explicitly per invocation if supported, and never run two Claude-backend builder jobs concurrently unless each is verified to have its own worktree (`git worktree list` after spawn). In all cases, never pre-create a job worktree for Claude-backend jobs (a pre-made one is ignored); do not use `.architect/wt/<run>/<slice>-<NN>` (that pattern is Codex-backend only, below). | `spawn_agent` with defensive framing: "Your task is: ..."; worktree created by the orchestrator via git; use `/goal` semantics for persistent job completion. |
 | Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md` (read-only verification def); dispatch synchronously with `run_in_background: false` so the result is the tool result; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions; the process exit wakes the loop. |
-| Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when the orchestrator can run background processes and receive exit notifications; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) when background process exits wake the orchestrator; LLM fallback template only otherwise and it consumes one native subagent slot. |
+| Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) under a long-lived Bash task when the orchestrator can wait on task exit; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) under a long-lived Bash task when task exits wake the orchestrator; LLM fallback template only otherwise and it consumes one native subagent slot. |
 | Parallelism | CLI-launched builder backends, including Claude Code orchestrating Codex, run up to 10 background jobs. Claude Agent-tool builders are harness-native: use the harness cap (currently 5), verify isolated worktrees before concurrent spawns, and expect permission prompts in the main session. | CLI-launched builder backends run up to 10 background jobs. Native `spawn_agent` builders use the harness cap (currently 5), `max_depth` 1 (root session is depth 0; a spawned child may not spawn further), and `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent`). |
 | Review (high-stakes) | `codex review --base` when Codex is installed; otherwise a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
 | Skill packaging | `skills/architect/` plus Claude skill install locations. | `.agents/skills/architect/SKILL.md` (and any other `skills/*/`); same source text copied by installer. |
@@ -127,18 +127,19 @@ Example line: ``- RUN: `git grep -F -c "needle" -- path/to/file.md` -> exit:0 ma
 
 Evidence contains per-item `expected:` and `verdict:` lines, then `CHECKRUN SUMMARY: run_items=<n> pass=<n> fail=<n>`.
 Typed exits: 0 = all RUN items pass; 2 = any RUN item fails; 5 = error, no partial evidence file left behind.
-Launch pattern: write the runner config JSON — fields `check_file`, `workdir`, `freeze_sha`, `evidence_out`, `executor` (`powershell`|`bash`), `max_output_lines` (default 60) — then run `skills/architect/check-runner.ps1 -Config <path>` or `check-runner.sh <path>` in the background; on exit 0 commit `docs/jobs/<run>/<issue-slug>-checkrun.md`, then merge through postflight. Exit 2 routes to the failure ladder; `loop.md` owns the full rule.
+Launch pattern: write the runner config JSON — fields `check_file`, `workdir`, `freeze_sha`, `evidence_out`, `executor` (`powershell`|`bash`), `max_output_lines` (default 60) — then run `skills/architect/check-runner.ps1 -Config <path>` or `check-runner.sh <path>` as a foreground child of a long-lived Bash task; on exit 0 commit `docs/jobs/<run>/<issue-slug>-checkrun.md`, then merge through postflight. Exit 2 routes to the failure ladder; `loop.md` owns the full rule.
 
-## Codex backend from a Claude orchestrator
+## CLI-launched subagent dispatch
 
-The worktree pre-creation and dispatch commands in this section are
-Codex-backend only. Claude-backend jobs never pre-create a worktree — see
+The worktree pre-creation and `codex exec` commands in this section are
+Codex-backend builder jobs, regardless of whether the orchestrator is Claude
+Code or Codex. Claude-backend harness jobs never pre-create a worktree — see
 the Per-harness delegation table above.
 
-When the orchestrator is Claude Code and the resolved builders backend is
-Codex (the default), write the
-builder block to a file first, then pass it via stdin (`-`). Big prompt blocks
-contain quotes that shells, especially Windows PowerShell, can mangle.
+For any CLI-launched subagent (`codex exec`, `claude -p`, or equivalent), write
+the prompt block to a file/stdin, redirect the machine event stream directly to
+the watchdog events file; never pipe the stream through `tail` or another
+live-display filter.
 
 Single-job slice in the current checkout, resolved builders `codex/best`:
 
@@ -147,7 +148,7 @@ codex exec -C <repo-root> --sandbox workspace-write \
   -m gpt-5.5 -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/last-run.md \
-  - < .architect/dispatch-block.md
+  - < .architect/dispatch-block.md > .architect/last-run.events.jsonl
 ```
 
 If the effort call resolves to `codex/tier-down`, change only the effort pin:
@@ -157,7 +158,7 @@ codex exec -C <repo-root> --sandbox workspace-write \
   -m gpt-5.5 -c model_reasoning_effort="high" \
   -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/last-run.md \
-  - < .architect/dispatch-block.md
+  - < .architect/dispatch-block.md > .architect/last-run.events.jsonl
 ```
 
 For 2-10 CLI-launched jobs, the orchestrator owns worktree creation and parallelism:
@@ -170,7 +171,7 @@ codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox workspace-w
   -m gpt-5.5 -c model_reasoning_effort="xhigh" \
   -c service_tier="fast" -c features.fast_mode=true \
   --json -o .architect/wt/<run>/<slice>-<NN>.last-run.md \
-  - < .architect/wt/<run>/<slice>-<NN>.block.md
+  - < .architect/wt/<run>/<slice>-<NN>.block.md > .architect/wt/<run>/<slice>-<NN>.events.jsonl
 ```
 
 A worktree's `.git` is a pointer file and the resolved git dir is
@@ -326,10 +327,13 @@ answer reaches the builder only through a fresh respawn's spawn context (see
 
 ## Monitor dispatch
 
-The orchestrator writes one watchdog config JSON per dispatch wave, then
-launches the platform script as a background process: `watchdog.ps1` on
-Windows, `watchdog.sh` on POSIX. The config uses the spec's Interface
-contract:
+Every dispatch event re-arms the watchdog: initial wave, job END
+recompute-and-dispatch, blocker respawn, and fix-wave dispatch. The
+orchestrator writes a fresh config covering every in-flight CLI-launched
+builder/subagent from either a Claude Code or Codex orchestrator, then launches
+the platform script as a foreground child of a long-lived Bash task:
+`watchdog.ps1` on Windows, `watchdog.sh` on POSIX. The config uses the spec's
+Interface contract:
 
 ```json
 {
@@ -349,11 +353,11 @@ The watchdog never kills, nudges, or judges. It exits with typed evidence:
 |---|---|---|
 | 0 | `WATCHDOG: ALL_DONE` | every job report exists, with path and byte size evidence |
 | 2 | `WATCHDOG: INTEGRATED` | a job worktree or events file vanished because the orchestrator integrated it mid-sweep |
-| 3 | `WATCHDOG: STALL` | file growth and process activity both stopped beyond `stall_after_min` plus any duration hint |
+| 3 | `WATCHDOG: STALL` | events/report bytes and file mtimes stopped advancing beyond `stall_after_min` plus any duration hint |
 | 4 | `WATCHDOG: REPEAT` | the last four parsed command events were identical and need an intentional-vs-stuck ruling |
 
-Use the LLM fallback only for backends where the orchestrator cannot launch a
-background process whose exit wakes the loop.
+Use the LLM fallback only for backends where the orchestrator cannot launch or
+wait on a long-lived Bash task whose exit wakes the loop.
 
 ## Status display
 
@@ -376,9 +380,8 @@ In-flight jobs:
   (one line per job)
 
 Sweep every ~10 minutes. For each job, check events/report byte growth,
-process activity by command-line/worktree match, and repeated identical
-commands in the tail. A quiet events file on a single sweep is normal model
-thinking, not a stall.
+worktree file mtimes, and repeated identical commands in the tail. A quiet
+events file on a single sweep is normal model thinking, not a stall.
 
 Quiet exit is allowed ONLY when, for every job, you list the report path and
 byte size as evidence. If a worktree or events file vanished because the
@@ -387,14 +390,15 @@ and list the vanished path. If you cannot verify something from this sandbox,
 state what you cannot verify instead of assuming the job is done.
 
 Any stall or repeat concern exits immediately with the job id, minutes since
-last growth, CPU/process activity evidence, repeated command if present, and
-tail excerpt. Do not wait for other jobs to finish before reporting it.
+last file activity, byte/mtime evidence, repeated command if present, and tail
+excerpt. Do not wait for other jobs to finish before reporting it.
 ```
 <!-- architect-monitor-fallback-template:end -->
 
 Native harness note: built-in subagents cap at 5 concurrent jobs. CLI-launched
-`codex exec` builders cap at 10 and do not consume native subagent slots; if
-an LLM fallback monitor is running in native-harness mode, reserve one slot.
+`codex exec`/`claude -p` style jobs cap at 10 and do not consume native
+subagent slots; if an LLM fallback monitor is running in native-harness mode,
+reserve one slot.
 
 ## Duration hints and liveness
 
@@ -429,17 +433,17 @@ verification, and config blocks with file tools, never heredocs. Never rely on a
 persisted cwd across commands; run #30 lost three commands to current-directory
 drift before this rule was written down.
 
-Liveness is judged from report/output file growth plus process-tree
-activity — never from wall-clock alone:
+Liveness is judged from report/output file growth, worktree file mtimes, and
+the harness task lifecycle — never from process listings:
 
 - Silent gaps between events are normal model thinking. A low context
   reading is not wedging; harnesses auto-compact and keep going.
 - A job repeatedly issuing the same command or query with identical
   arguments is stalled even while its event/report file is still growing
   (the monitor's tail-of-output repeat-command check).
-- A job is a genuine liveness concern only once its report/output file has
-  stopped growing AND the process tree shows no activity, weighed against
-  any duration hint the issue or check file carries.
+- A job is a genuine liveness concern only once its report/output files and
+  worktree file mtimes have stopped advancing, weighed against any duration
+  hint the issue or check file carries.
 
 On Windows PowerShell 5.1, `>`, `*>`, and `Tee-Object` write UTF-16. Liveness
 and rescue checks over event files must read encoding-aware (`Get-Content`,
@@ -573,9 +577,9 @@ SANDBOX EXECUTION POLICY - All temp, basetemp, and cache paths MUST be inside
 the workspace (`.architect/tmp/<purpose>`); never the system temp. Run test/check
 commands SEQUENTIALLY - never two invocations in flight at once. The spec or issue may declare duration hints for known-long commands (e.g. "full suite ~ 20m");
 they are context, not kill ceilings. If a command appears stalled - no output
-growth and no process activity well past its duration hint - record the exact
-command and observed state in the job report and stop the job; the monitor
-and orchestrator own stall handling. A filesystem/sandbox error on a path is
+growth and no file mtime movement well past its duration hint - record the
+exact command and observed state in the job report and stop the job; the
+monitor and orchestrator own stall handling. A filesystem/sandbox error on a path is
 environmental: record the exact failure and route around it - never retry the same path.
 
 When a known-bad pattern exists, the spec must name it as forbidden with

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -21,18 +21,19 @@ Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap
 1. **Dispatch the ready issues.** Compute the ready issues of the approved
    plan: up to 10 CLI-launched builder jobs, or 5 harness-native builder
    subagents (see Monitor protocol, and `dispatch.md` "## Monitor dispatch"). Check `docs/STOP` and
-   `docs/runs/<run>/STOP` before every wave.
+   `docs/runs/<run>/STOP` before every wave. Re-arm one watchdog over all
+   in-flight CLI-launched jobs at every dispatch event.
 2. **Sleep.** Zero orchestrator work between dispatch and the next event —
    no polling.
 3. **Wake on one event**, exactly one of:
-   - **Job DONE.** A job END (DONE or BLOCKED) is a dispatch event: before grading the finished job, recompute the full ready frontier — run `skills/architect/ground.ps1|.sh <run>` and read its `FRONTIER:` line as the source, covering newly unblocked issues AND previously-ready issues queued beyond the concurrency cap — and dispatch every ready issue into a free slot; one completion may launch multiple builders. Merges still recompute the frontier too, since a merge can unblock issues no END could. Ordering: after that recompute-and-dispatch, write the runner config; launch `check-runner.ps1` or `check-runner.sh` as a background process whose typed exit is the next wake. Exit 0: post the checkrun result on the issue (the evidence file `docs/jobs/<run>/<issue-slug>-checkrun.md` is a local run artifact; the tracker comment is the durable record), then run `postflight.ps1` or `postflight.sh` — no per-issue model review exists on this path: exit 0 `POSTFLIGHT: OK` means merge completed with clean touch-set evidence; exit 2 `POSTFLIGHT: VIOLATION` is automatic FAIL evidence; exit 3 `POSTFLIGHT: CONFLICT` is the decomposition-failure rail; exit 5 `POSTFLIGHT: ERROR` falls back to the recorded manual integration sequence in `dispatch.md`. Exit 2: post failure evidence and enter the Failure ladder. Exit 5: stay on the recorded error rail.
+   - **Job DONE.** A job END (DONE or BLOCKED) is a dispatch event: before grading the finished job, recompute the full ready frontier — run `skills/architect/ground.ps1|.sh <run>` and read its `FRONTIER:` line as the source, covering newly unblocked issues AND previously-ready issues queued beyond the concurrency cap — dispatch every ready issue into a free slot, and re-arm the watchdog over all in-flight CLI-launched jobs; one completion may launch multiple builders. Merges still recompute the frontier too, since a merge can unblock issues no END could. Ordering: after that recompute-and-dispatch, write the runner config; launch `check-runner.ps1` or `check-runner.sh` as a foreground child of a long-lived Bash task whose exit is the next wake. Exit 0: post the checkrun result on the issue (the evidence file `docs/jobs/<run>/<issue-slug>-checkrun.md` is a local run artifact; the tracker comment is the durable record), then run `postflight.ps1` or `postflight.sh` — no per-issue model review exists on this path: exit 0 `POSTFLIGHT: OK` means merge completed with clean touch-set evidence; exit 2 `POSTFLIGHT: VIOLATION` is automatic FAIL evidence; exit 3 `POSTFLIGHT: CONFLICT` is the decomposition-failure rail; exit 5 `POSTFLIGHT: ERROR` falls back to the recorded manual integration sequence in `dispatch.md`. Exit 2: post failure evidence and enter the Failure ladder. Exit 5: stay on the recorded error rail.
    - **Job BLOCKED.** A blocker comment on the issue is a completion event.
      Read it, rule an answer, and respawn a fresh builder job on the same
      issue with the answer in its spawn context (see `dispatch.md`
      "## Respawn-with-answer template"). A running job never re-reads its
      own comments — the spawn context is the only delivery channel.
    - **Monitor ANOMALY.** Read the evidence report and rule one of:
-     healthy-long-run (redispatch the monitor, sleep again), needs a nudge
+     healthy-long-run (re-arm the watchdog, sleep again), needs a nudge
      or answer, or wedged (kill the job, discard its worktree, respawn
      from the frozen check with a route-around).
    - **Ruling timer expiry.** A pending timed ruling's timer exit is a wake:
@@ -47,10 +48,11 @@ Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap
 
 ## Monitor protocol
 
-Launch the script watchdog at wave dispatch from `dispatch.md` "## Monitor
-dispatch". The watchdog runs as a background process and its typed exit wakes
-the orchestrator. It detects mechanically and never kills, nudges, or judges;
-the orchestrator rules on the evidence.
+Launch the script watchdog at every dispatch event from `dispatch.md` "## Monitor dispatch",
+with every currently in-flight CLI-launched job in the config. The watchdog
+runs as a foreground child of a long-lived Bash task and its exit wakes the orchestrator.
+It detects mechanically and never kills, nudges, or judges; the orchestrator
+rules on the evidence.
 
 Ruling options:
 

--- a/skills/architect/status.ps1
+++ b/skills/architect/status.ps1
@@ -229,16 +229,6 @@ function TrackerLines($Manifest, $ManifestMissing) {
     if ($Manifest.Tracker -eq "github") { return (GithubLines $Manifest) }
     return @{ Reachable = $false; Lines = @(); Error = "unknown tracker mode in manifest: $($Manifest.Tracker)" }
 }
-function Win32Processes() {
-    $cim = Get-Command Get-CimInstance -ErrorAction SilentlyContinue
-    if ($cim) {
-        try { return @(Get-CimInstance Win32_Process -ErrorAction Stop) } catch {}
-    }
-    $wmi = Get-Command Get-WmiObject -ErrorAction SilentlyContinue
-    if ($wmi) { return @(Get-WmiObject Win32_Process -ErrorAction SilentlyContinue) }
-    return @()
-}
-
 $root = [System.IO.Path]::GetFullPath($RepoRoot)
 if (-not (Test-Path -LiteralPath $root -PathType Container)) { Write-Output "unreadable repo: $RepoRoot"; exit 1 }
 if (-not (IsValidRunSlug $RunSlug)) { Write-Output "invalid run slug: $RunSlug"; exit 1 }
@@ -311,8 +301,7 @@ Write-Output "ORCHESTRATOR: local view"
 $wdDir = J $root ".architect/tmp"
 $wdCfg = @()
 if (Test-Path -LiteralPath $wdDir -PathType Container) { $wdCfg = @(Get-ChildItem -LiteralPath $wdDir -Filter "wd-*.json") }
-$wdProc = @(Win32Processes | Where-Object { $_.CommandLine -match 'watchdog\.(ps1|sh)' })
-Write-Output "WATCHDOG: process=$($wdProc.Count -gt 0) config=$($wdCfg.Count)"
+Write-Output "WATCHDOG: config=$($wdCfg.Count)"
 if ($trackerReachable -and $tracking) {
     foreach ($issue in $subIssues) {
         $slug = Slugify $issue.Title

--- a/skills/architect/status.sh
+++ b/skills/architect/status.sh
@@ -310,9 +310,7 @@ fi
 printf 'ORCHESTRATOR: local view\n'
 cfg=0
 [ -d "$root/.architect/tmp" ] && cfg=$(find "$root/.architect/tmp" -maxdepth 1 -type f -name 'wd-*.json' 2>/dev/null | wc -l | tr -d ' ')
-proc=False
-case "$(ps -eo args= 2>/dev/null)" in *watchdog.ps1*|*watchdog.sh*) proc=True;; esac
-printf 'WATCHDOG: process=%s config=%s\n' "$proc" "$cfg"
+printf 'WATCHDOG: config=%s\n' "$cfg"
 if [ "$tracker" -eq 1 ] && [ -n "$tracking" ]; then
   printf '%s\n' "$tracker_tsv" | while IFS= read -r line; do
     kind=$(printf '%s\n' "$line" | awk -F '	' '{print $1}')

--- a/skills/architect/watchdog.ps1
+++ b/skills/architect/watchdog.ps1
@@ -26,7 +26,7 @@ function ReadText($Path) {
 function HasTerminalStatus($Path) {
     $lines = (ReadText $Path) -split "`r?`n"
     for ($i = $lines.Count - 1; $i -ge 0; $i--) {
-        $t = $lines[$i].Trim()
+        $t = $lines[$i].Trim().TrimStart([char]0xFEFF)
         if ($t.Length -gt 0) { return $t.StartsWith("STATUS:", [StringComparison]::Ordinal) }
     }
     return $false
@@ -34,24 +34,26 @@ function HasTerminalStatus($Path) {
 
 function FileSize($Path) { if (Test-Path -LiteralPath $Path) { return (Get-Item -LiteralPath $Path).Length }; return 0 }
 
-function Win32Processes {
-    $cim = Get-Command Get-CimInstance -ErrorAction SilentlyContinue
-    if ($cim) {
-        try { return @(Get-CimInstance Win32_Process -ErrorAction Stop) } catch {}
-    }
-    $wmi = Get-Command Get-WmiObject -ErrorAction SilentlyContinue
-    if ($wmi) { return @(Get-WmiObject Win32_Process -ErrorAction SilentlyContinue) }
-    return @()
-}
-
-function CpuTotal($Needle) {
-    $sum = [int64]0
-    foreach ($p in (Win32Processes)) {
-        if ($p.CommandLine -and $p.CommandLine.IndexOf($Needle, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
-            $sum += [int64]$p.KernelModeTime + [int64]$p.UserModeTime
+function NewestMTime($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return [int64]0 }
+    $item = Get-Item -LiteralPath $Path -Force
+    $max = [int64]$item.LastWriteTimeUtc.Ticks
+    if ($item.PSIsContainer) {
+        foreach ($child in (Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction SilentlyContinue)) {
+            $ticks = [int64]$child.LastWriteTimeUtc.Ticks
+            if ($ticks -gt $max) { $max = $ticks }
         }
     }
-    return $sum
+    return $max
+}
+
+function ActivityMTime($Job) {
+    $max = [int64]0
+    foreach ($path in @($Job.events_file, $Job.report_path, $Job.worktree)) {
+        $ticks = NewestMTime $path
+        if ($ticks -gt $max) { $max = $ticks }
+    }
+    return $max
 }
 
 $cfg = Get-Content -LiteralPath $Config -Raw | ConvertFrom-Json
@@ -59,7 +61,7 @@ $sweep = [int]$cfg.sweep_sec
 $stall = [double]$cfg.stall_after_min
 $state = @{}
 foreach ($j in $cfg.jobs) {
-    $state[$j.id] = @{ Done = $false; Size = ((FileSize $j.events_file) + (FileSize $j.report_path)); Growth = (Get-Date); Cpu = (CpuTotal $j.worktree) }
+    $state[$j.id] = @{ Done = $false; Size = ((FileSize $j.events_file) + (FileSize $j.report_path)); MTime = (ActivityMTime $j); Growth = (Get-Date) }
 }
 
 while ($true) {
@@ -73,14 +75,12 @@ while ($true) {
             exit 2
         }
         $size = (FileSize $j.events_file) + (FileSize $j.report_path)
-        $cpu = CpuTotal $j.worktree
-        if ($size -gt $s.Size) { $s.Size = $size; $s.Growth = Get-Date }
+        $mtime = ActivityMTime $j
+        if ($size -ne $s.Size -or $mtime -gt $s.MTime) { $s.Size = $size; $s.MTime = $mtime; $s.Growth = Get-Date }
         $mins = ((Get-Date) - $s.Growth).TotalMinutes
-        $cpuDelta = $cpu - $s.Cpu
-        $s.Cpu = $cpu
         $grace = $stall + [double]$j.duration_hint_min
-        if ($mins -gt $grace -and $cpuDelta -eq 0) {
-            Write-Output "WATCHDOG: STALL $id minutes_since_growth=$([Math]::Round($mins, 3)) cpu_delta=$cpuDelta"
+        if ($mins -gt $grace) {
+            Write-Output "WATCHDOG: STALL $id minutes_since_activity=$([Math]::Round($mins, 3)) bytes=$size mtime_ticks=$mtime"
             foreach ($line in ((TailText $j.events_file) -split "`r?`n" | Select-Object -Last 5)) { Write-Output $line }
             exit 3
         }

--- a/skills/architect/watchdog.sh
+++ b/skills/architect/watchdog.sh
@@ -15,29 +15,35 @@ numfield(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\([0-9
 fsize(){ stat -c %s "$1" 2>/dev/null || stat -f %z "$1" 2>/dev/null || printf 0; }
 now(){ date +%s; }
 tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000\377\376'; }
-report_done(){ [ -f "$1" ] || return 1; last=$(tail_text "$1" | awk 'NF{line=$0} END{gsub(/^[[:space:]]+|[[:space:]]+$/,"",line); print line}'); case "$last" in STATUS:*) return 0;; *) return 1;; esac; }
-cpu_sum(){
-  w=$1
-  if [ -d /proc ]; then
-    total=0
-    for p in /proc/[0-9]*; do
-      [ -r "$p/cmdline" ] || continue
-      cmd=$(tr '\000' ' ' < "$p/cmdline")
-      case "$cmd" in *"$w"*) v=$(awk '{print $14+$15}' "$p/stat" 2>/dev/null); total=$((total+${v:-0}));; esac
-    done
-    printf '%s' "$total"
-  else
-    ps -eo time= -o args= | awk -v w="$w" 'index($0,w){split($1,a,":"); n=split($1,b,"-"); t=(n==2?b[2]:$1); split(t,c,":"); if(length(c)==3)s+=c[1]*3600+c[2]*60+c[3]; else s+=c[1]*60+c[2]} END{print s+0}'
+report_done(){ [ -f "$1" ] || return 1; last=$(tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk 'NF{line=$0} END{gsub(/^[[:space:]]+|[[:space:]]+$/,"",line); print line}'); case "$last" in STATUS:*) return 0;; *) return 1;; esac; }
+mtime_one(){
+  [ -e "$1" ] || { printf 0; return; }
+  own=$(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf 0)
+  max=$own
+  if [ -d "$1" ]; then
+    files=$(find "$1" -type f -exec stat -c %Y {} \; 2>/dev/null || find "$1" -type f -exec stat -f %m {} \; 2>/dev/null)
+    newest=$(printf '%s\n' "$files" | sort -nr | sed -n '1p')
+    case "$newest" in ''|*[!0-9]*) newest=0;; esac
+    [ "$newest" -gt "$max" ] && max=$newest
   fi
+  printf '%s' "$max"
+}
+activity_mtime(){
+  max=0
+  for p in "$@"; do
+    m=$(mtime_one "$p")
+    [ "$m" -gt "$max" ] && max=$m
+  done
+  printf '%s' "$max"
 }
 
-declare -a ids events reports trees hints done sizes growth cpus
+declare -a ids events reports trees hints done sizes mtimes growth
 i=0
 while IFS= read -r job; do
   ids[$i]=$(field "$job" id); events[$i]=$(field "$job" events_file)
   reports[$i]=$(field "$job" report_path); trees[$i]=$(field "$job" worktree)
   hints[$i]=$(numfield "$job" duration_hint_min); done[$i]=0
-  ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sizes[$i]=$((ev+rp)); growth[$i]=$(now); cpus[$i]=$(cpu_sum "${trees[$i]}")
+  ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sizes[$i]=$((ev+rp)); mtimes[$i]=$(activity_mtime "${events[$i]}" "${reports[$i]}" "${trees[$i]}"); growth[$i]=$(now)
   i=$((i+1))
 done <<EOF
 $jobs
@@ -52,13 +58,12 @@ while :; do
     if [ ! -e "${events[$i]}" ] && [ ! -e "${trees[$i]}" ]; then
       printf 'WATCHDOG: INTEGRATED %s\n' "${ids[$i]}"; exit 2
     fi
-    ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sz=$((ev+rp)); cpu=$(cpu_sum "${trees[$i]}")
-    [ "$sz" -gt "${sizes[$i]}" ] && { sizes[$i]=$sz; growth[$i]=$(now); }
+    ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sz=$((ev+rp)); mt=$(activity_mtime "${events[$i]}" "${reports[$i]}" "${trees[$i]}")
+    if [ "$sz" -ne "${sizes[$i]}" ] || [ "$mt" -gt "${mtimes[$i]}" ]; then sizes[$i]=$sz; mtimes[$i]=$mt; growth[$i]=$(now); fi
     mins=$(awk -v a="$(now)" -v b="${growth[$i]}" 'BEGIN{printf "%.3f",(a-b)/60}')
-    delta=$((cpu-cpus[$i])); cpus[$i]=$cpu
     grace=$(awk -v a="$stall" -v b="${hints[$i]:-0}" 'BEGIN{print a+b}')
-    if awk -v m="$mins" -v g="$grace" 'BEGIN{exit !(m>g)}' && [ "$delta" -eq 0 ]; then
-      printf 'WATCHDOG: STALL %s minutes_since_growth=%s cpu_delta=%s\n' "${ids[$i]}" "$mins" "$delta"
+    if awk -v m="$mins" -v g="$grace" 'BEGIN{exit !(m>g)}'; then
+      printf 'WATCHDOG: STALL %s minutes_since_activity=%s bytes=%s mtime=%s\n' "${ids[$i]}" "$mins" "$sz" "$mt"
       tail_text "${events[$i]}" | tail -n 5; exit 3
     fi
     last4=$(tail_text "${events[$i]}" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | tail -n 4)

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -606,6 +606,8 @@ def check_codex_install_step() -> None:
 def check_watchdog_contract() -> None:
     ps1 = SKILLS / "architect" / "watchdog.ps1"
     sh = SKILLS / "architect" / "watchdog.sh"
+    dispatch = read_text(SKILLS / "architect" / "dispatch.md")
+    loop = read_text(SKILLS / "architect" / "loop.md")
     for path in (ps1, sh):
         if not path.exists():
             errors.append(f"{path.relative_to(ROOT)}: missing watchdog file")
@@ -623,6 +625,50 @@ def check_watchdog_contract() -> None:
         errors.append("skills/architect/watchdog.sh: missing shebang")
     if ps1.exists() and "ConvertFrom-Json" not in read_text(ps1):
         errors.append("skills/architect/watchdog.ps1: missing ConvertFrom-Json")
+    if ps1.exists() and "TrimStart([char]0xFEFF)" not in read_text(ps1):
+        errors.append("skills/architect/watchdog.ps1: terminal STATUS check must tolerate BOM")
+    if sh.exists() and r"\xEF\xBB\xBF" not in read_text(sh):
+        errors.append("skills/architect/watchdog.sh: terminal STATUS check must tolerate UTF-8 BOM")
+    if "Every dispatch event re-arms the watchdog" not in dispatch:
+        errors.append("skills/architect/dispatch.md: watchdog must re-arm on every dispatch event")
+    if "Codex backend from a Claude orchestrator" in dispatch:
+        errors.append("skills/architect/dispatch.md: CLI dispatch must not be Claude-orchestrator-specific")
+    for marker in ("`codex exec`, `claude -p`, or equivalent", "Claude Code or Codex orchestrator", "long-lived Bash task", "worktree file mtimes"):
+        if marker not in dispatch:
+            errors.append(f"skills/architect/dispatch.md: missing CLI watchdog contract marker {marker!r}")
+    if not re.search(r"all\s+in-flight CLI-launched jobs at every dispatch event", loop):
+        errors.append("skills/architect/loop.md: dispatch events must cover all in-flight CLI-launched jobs")
+    banned_watchdog_terms = ("process_match", "Win32_Process", "Get-CimInstance", "Get-WmiObject", "CpuTotal", "cpu_sum", "/proc", "ps -eo")
+    for path in (ps1, sh):
+        if not path.exists():
+            continue
+        text = read_text(path)
+        for term in banned_watchdog_terms:
+            if term in text:
+                errors.append(f"{path.relative_to(ROOT)}: process-list liveness term must stay out of watchdog: {term}")
+    if "process activity" in dispatch or "process tree" in dispatch:
+        errors.append("skills/architect/dispatch.md: watchdog liveness must not use process activity")
+    codex_json_blocks = [
+        block
+        for block in re.findall(r"```bash\n(.*?)```", dispatch, re.DOTALL)
+        if "codex exec" in block and "--json" in block
+    ]
+    if not codex_json_blocks:
+        errors.append("skills/architect/dispatch.md: missing Codex --json dispatch examples")
+    for i, block in enumerate(codex_json_blocks, start=1):
+        if not re.search(r"(?m)^\s+- < .+ > .+\.events\.jsonl$", block):
+            errors.append(
+                "skills/architect/dispatch.md: Codex --json dispatch example "
+                f"{i} must redirect stdout to an .events.jsonl file"
+            )
+        for pin in ('-c service_tier="fast"', "-c features.fast_mode=true"):
+            if pin not in block:
+                errors.append(
+                    "skills/architect/dispatch.md: Codex dispatch example "
+                    f"{i} missing Fast-mode pin {pin}"
+                )
+    if re.search(r"codex exec[\s\S]*?\|\s*tail", dispatch):
+        errors.append("skills/architect/dispatch.md: Codex dispatch examples must not pipe through tail")
 
 
 def check_status_contract() -> None:
@@ -655,6 +701,8 @@ def check_status_contract() -> None:
         ):
             if marker not in text:
                 errors.append(f"skills/architect/{name}: missing {marker}")
+        if "WATCHDOG: process=" in text or "watchdog.ps1" in text and "ps -eo" in text:
+            errors.append(f"skills/architect/{name}: status must not report watchdog process visibility")
         if name == "status.sh" and not text.startswith("#!"):
             errors.append("skills/architect/status.sh: missing shebang")
         if name == "status.sh":


### PR DESCRIPTION
## Summary

- Route long-running watchdog and check-runner work through long-lived Bash task lifecycle guidance instead of detached/background PowerShell assumptions.
- Make watchdog liveness file-based across platforms: events/report byte changes, worktree mtimes, terminal `STATUS:` reports, and repeated command detection.
- Remove watchdog process visibility from status output and add validator guards against reintroducing process-list liveness.
- Preserve Codex fast-mode dispatch pins and `.events.jsonl` event stream routing.

## Root Cause

Tool-call shells can run in isolated sessions, so OS process listings from one call can miss children started by another. Process-counting liveness was therefore unreliable. File artifacts and task completion are the portable truth.

## Validation

- `uv run python tests/validate_skills.py`
- `git diff --check`
- PowerShell watchdog smoke test
- Bash watchdog smoke test