### PR TITLE
[codex] Make watchdog deterministic

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -560,6 +560,11 @@ runner's first live use finished 7/7.
   existence alone produced twice-observed false `ALL_DONE` evidence in the
   run #36 respawn case and the run #43 incremental-write case recorded in
   the loop-tuning spec (evidence: git history before the 2026-07-04 cleanup).
+  The 2026-07-06 watchdog-determinism incident added wrapper-owned CLI job
+  evidence (`job.meta.json`, heartbeat, exit file, raw events) so child exit,
+  liveness, and legacy/unwrapped failures are file facts across Claude Code and
+  Codex CLI launches; process enumeration and harness wakeups are corroborating
+  at most.
 - **Hard stops (D11).** the `docs/STOP` kill-all switch before any wave;
   `docs/runs/<run>/STOP` for one run; irreversible actions; two consecutive
   KILLs; a blocker colliding with a recorded assumption (a spec-approval

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -131,47 +131,37 @@ Launch pattern: write the runner config JSON — fields `check_file`, `workdir`,
 
 ## CLI-launched subagent dispatch
 
-The worktree pre-creation and `codex exec` commands in this section are
-Codex-backend builder jobs, regardless of whether the orchestrator is Claude
-Code or Codex. Claude-backend harness jobs never pre-create a worktree — see
-the Per-harness delegation table above.
+Worktree pre-creation and `codex exec` are Codex-backend builder jobs even under Claude Code; Claude-backend harness jobs use the Per-harness delegation table.
 
-For any CLI-launched subagent (`codex exec`, `claude -p`, or equivalent), write
-the prompt block to a file/stdin, redirect the machine event stream directly to
-the watchdog events file; never pipe the stream through `tail` or another
-live-display filter.
+All long-lived CLI builders run through `run-job.ps1|.sh`; the wrapper writes `job.meta.json`, `job.heartbeat`, `job.exit.json`, and `events.jsonl`. It accepts an opaque command, so the child can be `codex exec`, `claude -p`, or a long check-runner under a Claude Code or Codex orchestrator. Never pipe live stdout through display filters such as `tail`; the wrapper owns redirection. Every dispatch event re-arms the watchdog over all in-flight CLI jobs.
 
-Single-job slice in the current checkout, resolved builders `codex/best`:
+Single Codex-backed job:
 
 ```bash
-codex exec -C <repo-root> --sandbox workspace-write \
-  -m gpt-5.5 -c model_reasoning_effort="xhigh" \
-  -c service_tier="fast" -c features.fast_mode=true \
-  --json -o .architect/last-run.md \
-  - < .architect/dispatch-block.md > .architect/last-run.events.jsonl
+<repo-root>/skills/architect/run-job.sh --job-dir <repo-root>/.architect/jobs/<run>/<slice>-<NN> --workdir <repo-root>/.architect/wt/<run>/<slice>-<NN> --backend codex-cli --report-path <repo-root>/docs/jobs/<run>/<slice>-01.md --stdin-file <repo-root>/.architect/jobs/<run>/<slice>-<NN>/block.md -- \
+  codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox workspace-write -m gpt-5.5 -c model_reasoning_effort="xhigh" -c service_tier="fast" -c features.fast_mode=true --json -o <repo-root>/.architect/jobs/<run>/<slice>-<NN>/last-run.md \
+  -
 ```
 
-If the effort call resolves to `codex/tier-down`, change only the effort pin:
+Claude-CLI-backed jobs use the same wrapper and change only the child:
 
 ```bash
-codex exec -C <repo-root> --sandbox workspace-write \
-  -m gpt-5.5 -c model_reasoning_effort="high" \
-  -c service_tier="fast" -c features.fast_mode=true \
-  --json -o .architect/last-run.md \
-  - < .architect/dispatch-block.md > .architect/last-run.events.jsonl
+<repo-root>/skills/architect/run-job.sh --job-dir <repo-root>/.architect/jobs/<run>/<slice>-<NN> --workdir <repo-root>/.architect/wt/<run>/<slice>-<NN> --backend claude-cli --report-path <repo-root>/docs/jobs/<run>/<slice>-01.md --stdin-file <repo-root>/.architect/jobs/<run>/<slice>-<NN>/block.md -- \
+  claude -p --model fable --effort high --output-format stream-json --verbose
+```
+
+PowerShell uses `-ArgvJson` so child argv stays opaque:
+
+```powershell
+$argv = @("claude","-p","--model","fable","--effort","high","--output-format","stream-json","--verbose") | ConvertTo-Json -Compress
+& <repo-root>\skills\architect\run-job.ps1 -JobDir <repo-root>\.architect\jobs\<run>\<slice>-<NN> -Workdir <repo-root>\.architect\wt\<run>\<slice>-<NN> -Backend claude-cli -ReportPath <repo-root>\docs\jobs\<run>\<slice>-01.md -StdinFile <repo-root>\.architect\jobs\<run>\<slice>-<NN>\block.md -ArgvJson $argv
 ```
 
 For 2-10 CLI-launched jobs, the orchestrator owns worktree creation and parallelism:
 
 ```bash
-git -C <repo-root> worktree add .architect/wt/<run>/<slice>-<NN> \
-  -b job/<run>/<slice>-<NN> <freeze-sha>
-
-codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox workspace-write \
-  -m gpt-5.5 -c model_reasoning_effort="xhigh" \
-  -c service_tier="fast" -c features.fast_mode=true \
-  --json -o .architect/wt/<run>/<slice>-<NN>.last-run.md \
-  - < .architect/wt/<run>/<slice>-<NN>.block.md > .architect/wt/<run>/<slice>-<NN>.events.jsonl
+git -C <repo-root> worktree add <repo-root>/.architect/wt/<run>/<slice>-<NN> -b job/<run>/<slice>-<NN> <freeze-sha>
+<repo-root>/skills/architect/run-job.sh ... -- <codex-or-claude command for that worktree>
 ```
 
 A worktree's `.git` is a pointer file and the resolved git dir is
@@ -340,8 +330,8 @@ Interface contract:
   "sweep_sec": 120,
   "stall_after_min": 10,
   "jobs": [
-    { "id": "issue-31", "events_file": "<path>", "report_path": "<path>",
-      "worktree": "<path>", "duration_hint_min": 0 }
+    { "id": "issue-31", "job_dir": "<path>", "events_file": "<path>",
+      "report_path": "<path>", "worktree": "<path>", "duration_hint_min": 0 }
   ]
 }
 ```
@@ -353,8 +343,14 @@ The watchdog never kills, nudges, or judges. It exits with typed evidence:
 |---|---|---|
 | 0 | `WATCHDOG: ALL_DONE` | every job report exists, with path and byte size evidence |
 | 2 | `WATCHDOG: INTEGRATED` | a job worktree or events file vanished because the orchestrator integrated it mid-sweep |
-| 3 | `WATCHDOG: STALL` | events/report bytes and file mtimes stopped advancing beyond `stall_after_min` plus any duration hint |
+| 3 | `WATCHDOG: STALL` | wrapper heartbeat is fresh but event/report growth stopped beyond `stall_after_min` plus any duration hint |
 | 4 | `WATCHDOG: REPEAT` | the last four parsed command events were identical and need an intentional-vs-stuck ruling |
+| 5 | `WATCHDOG: ERROR` | watchdog config is missing or unreadable |
+| 6 | `WATCHDOG: REPORT_READY` | terminal `STATUS:` exists but `job.exit.json` did not arrive after one sweep |
+| 7 | `WATCHDOG: ORPHANED` | wrapper heartbeat is stale but event/report output still grows |
+| 8 | `WATCHDOG: DEAD` | wrapper heartbeat is stale and no event/report output is growing |
+| 9 | `WATCHDOG: DONE_FAILED` | child exited nonzero, or exited 0 without terminal `STATUS:` |
+| 10 | `WATCHDOG: LEGACY_UNWRAPPED` | job lacks wrapper metadata and cannot provide deterministic exit truth |
 
 Use the LLM fallback only for backends where the orchestrator cannot launch or
 wait on a long-lived Bash task whose exit wakes the loop.
@@ -433,17 +429,22 @@ verification, and config blocks with file tools, never heredocs. Never rely on a
 persisted cwd across commands; run #30 lost three commands to current-directory
 drift before this rule was written down.
 
-Liveness is judged from report/output file growth, worktree file mtimes, and
-the harness task lifecycle — never from process listings:
+Liveness is judged from wrapper-owned files, never cross-session process
+enumeration. On Windows under Claude Code, launch long-lived CLI jobs through
+its Bash wrapper when available; the PowerShell wrapper exists for harnesses
+where Bash is stripped.
 
-- Silent gaps between events are normal model thinking. A low context
-  reading is not wedging; harnesses auto-compact and keep going.
+- `DONE_OK` requires `job.exit.json` exit 0 AND a report whose final nonblank
+  line starts with `STATUS:`; every other child exit is `DONE_FAILED`.
+- `job.state.json` persists growth clocks across watchdog re-arms.
 - A job repeatedly issuing the same command or query with identical
   arguments is stalled even while its event/report file is still growing
   (the monitor's tail-of-output repeat-command check).
-- A job is a genuine liveness concern only once its report/output files and
-  worktree file mtimes have stopped advancing, weighed against any duration
-  hint the issue or check file carries.
+- Stale heartbeat plus growing output is `ORPHANED`, not `DEAD`; the
+  orchestrator rules from artifacts.
+- The PowerShell wrapper redirects stdout live to `events.jsonl` and appends
+  stderr when the child exits; use the Bash wrapper when live merged stderr is
+  required for diagnosis.
 
 On Windows PowerShell 5.1, `>`, `*>`, and `Tee-Object` write UTF-16. Liveness
 and rescue checks over event files must read encoding-aware (`Get-Content`,

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -48,11 +48,8 @@ Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap
 
 ## Monitor protocol
 
-Launch the script watchdog at every dispatch event from `dispatch.md` "## Monitor dispatch",
-with every currently in-flight CLI-launched job in the config. The watchdog
-runs as a foreground child of a long-lived Bash task and its exit wakes the orchestrator.
-It detects mechanically and never kills, nudges, or judges; the orchestrator
-rules on the evidence.
+Launch the script watchdog at every dispatch event from `dispatch.md` "## Monitor dispatch", with every currently in-flight CLI-launched job in the config. The watchdog runs as a foreground child of a long-lived Bash task and its exit wakes the orchestrator.
+It detects mechanically and never kills, nudges, or judges; the orchestrator rules on the evidence. CLI jobs must be wrapped by `run-job.ps1|.sh`; unwrapped jobs are legacy evidence and cannot be accepted as `DONE_OK`.
 
 Ruling options:
 
@@ -60,11 +57,22 @@ Ruling options:
   per report) for every report listed by path and byte size.
 - Exit 2 `WATCHDOG: INTEGRATED` -> benign mid-sweep integration; relaunch the
   watchdog if any jobs remain in flight.
-- Exit 3 `WATCHDOG: STALL` -> run the rescue ladder: inspect the named job,
-  kill stuck children if needed, discard wedged worktrees, and respawn from
-  the frozen check with a route-around.
+- Exit 3 `WATCHDOG: STALL` -> inspect the named job and choose healthy-long-run
+  vs route-around respawn.
 - Exit 4 `WATCHDOG: REPEAT` -> rule intentional-vs-stuck before action; the
   OpenHands false-positive caveat applies to deliberate polling loops.
+- Exit 5 `WATCHDOG: ERROR` -> fix the watchdog config; no partial verdict.
+- Exit 6 `WATCHDOG: REPORT_READY` -> report is terminal but exit truth is
+  missing after one sweep; proceed to check-runner grading only with the
+  missing-exit-truth caveat recorded on the issue.
+- Exit 7 `WATCHDOG: ORPHANED` -> wrapper died while output still grows; let it
+  finish only with a recorded ruling.
+- Exit 8 `WATCHDOG: DEAD` -> no wrapper heartbeat, no terminal report, no
+  growing output; discard and respawn with evidence.
+- Exit 9 `WATCHDOG: DONE_FAILED` -> grade as failed or respawn under the
+  wrapper; never accept it as done.
+- Exit 10 `WATCHDOG: LEGACY_UNWRAPPED` -> respawn under the wrapper unless a
+  recorded ruling accepts legacy evidence for diagnosis only.
 
 Backends without background-exit notifications use the LLM fallback template
 in `dispatch.md` "## Monitor dispatch". The fallback keeps the same

--- a/skills/architect/run-job.ps1
+++ b/skills/architect/run-job.ps1
@@ -1,0 +1,156 @@
+param(
+    [Parameter(Mandatory=$true)][string]$JobDir,
+    [Parameter(Mandatory=$true)][string]$Workdir,
+    [string]$Backend = "cli",
+    [string]$ReportPath = "",
+    [string]$EventsFile = "",
+    [string]$ArgvJson = "",
+    [string]$StdinFile = "",
+    [int]$HeartbeatSec = 30,
+    [Parameter(ValueFromRemainingArguments=$true)][string[]]$Command
+)
+
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+function Utf8NoBom {
+    return New-Object System.Text.UTF8Encoding($false)
+}
+
+function WriteUtf8($Path, $Text) {
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText($Path, $Text, (Utf8NoBom))
+}
+
+function AppendUtf8($Path, $Text) {
+    [System.IO.File]::AppendAllText($Path, $Text, (Utf8NoBom))
+}
+
+function QuoteArg($Text) {
+    $r = '"'
+    $slashes = 0
+    foreach ($ch in $Text.ToCharArray()) {
+        if ($ch -eq '\') { $slashes += 1; continue }
+        if ($ch -eq '"') {
+            if ($slashes -gt 0) { $r += ('\' * ($slashes * 2)) }
+            $r += '\"'
+            $slashes = 0
+            continue
+        }
+        if ($slashes -gt 0) { $r += ('\' * $slashes); $slashes = 0 }
+        $r += $ch
+    }
+    if ($slashes -gt 0) { $r += ('\' * ($slashes * 2)) }
+    return $r + '"'
+}
+
+function ResolveExecutable($Name) {
+    $text = [string]$Name
+    if ((Test-Path -LiteralPath $text -PathType Leaf) -or $text.Contains("\") -or $text.Contains("/")) {
+        try { return (Resolve-Path -LiteralPath $text).Path } catch { return $text }
+    }
+    try {
+        $cmd = @(Get-Command $text -CommandType Application -ErrorAction Stop | Select-Object -First 1)[0]
+        if ($cmd.Source) { return [string]$cmd.Source }
+        if ($cmd.Path) { return [string]$cmd.Path }
+    } catch {}
+    return $text
+}
+
+if ($Command.Count -gt 0 -and $Command[0] -eq "--") {
+    if ($Command.Count -eq 1) { $Command = @() } else { $Command = @($Command[1..($Command.Count - 1)]) }
+}
+if ($ArgvJson) {
+    try {
+        $parsed = ConvertFrom-Json -InputObject $ArgvJson
+        $Command = @()
+        foreach ($item in $parsed) { $Command += [string]$item }
+    } catch { $Command = @() }
+}
+if ($Command.Count -eq 0) {
+    Write-Output "RUNJOB: ERROR missing command"
+    exit 64
+}
+
+$JobDir = [System.IO.Path]::GetFullPath($JobDir)
+$Workdir = [System.IO.Path]::GetFullPath($Workdir)
+if (-not $EventsFile) { $EventsFile = Join-Path $JobDir "events.jsonl" }
+$EventsFile = [System.IO.Path]::GetFullPath($EventsFile)
+if ($StdinFile) { $StdinFile = [System.IO.Path]::GetFullPath($StdinFile) }
+$metaPath = Join-Path $JobDir "job.meta.json"
+$heartbeatPath = Join-Path $JobDir "job.heartbeat"
+$exitPath = Join-Path $JobDir "job.exit.json"
+
+New-Item -ItemType Directory -Path $JobDir -Force | Out-Null
+if (-not (Test-Path -LiteralPath $Workdir -PathType Container)) {
+    WriteUtf8 $exitPath (@{ exit_code = 127; ended_at = (Get-Date).ToUniversalTime().ToString("o"); error = "missing workdir" } | ConvertTo-Json -Depth 4)
+    Write-Output "RUNJOB: ERROR missing workdir"
+    exit 127
+}
+if ($StdinFile -and -not (Test-Path -LiteralPath $StdinFile -PathType Leaf)) {
+    WriteUtf8 $exitPath (@{ exit_code = 127; ended_at = (Get-Date).ToUniversalTime().ToString("o"); error = "missing stdin file" } | ConvertTo-Json -Depth 4)
+    Write-Output "RUNJOB: ERROR missing stdin file"
+    exit 127
+}
+
+$exe = ResolveExecutable $Command[0]
+$childArgs = @()
+if ($Command.Count -gt 1) {
+    foreach ($arg in @($Command[1..($Command.Count - 1)])) { $childArgs += (QuoteArg $arg) }
+}
+$argString = ($childArgs -join " ")
+$stderrFile = $EventsFile + ".stderr"
+WriteUtf8 $EventsFile ""
+WriteUtf8 $stderrFile ""
+
+try {
+    $startArgs = @{
+        FilePath = $exe
+        ArgumentList = $argString
+        WorkingDirectory = $Workdir
+        RedirectStandardOutput = $EventsFile
+        RedirectStandardError = $stderrFile
+        NoNewWindow = $true
+        PassThru = $true
+    }
+    if ($StdinFile) { $startArgs.RedirectStandardInput = $StdinFile }
+    $p = Start-Process @startArgs
+    $null = $p.Handle
+    $meta = [ordered]@{
+        backend = $Backend
+        command = @($Command)
+        cwd = $Workdir
+        events_file = $EventsFile
+        report_path = $ReportPath
+        job_dir = $JobDir
+        wrapper_pid = $PID
+        child_pid = $p.Id
+        started_at = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    WriteUtf8 $metaPath ($meta | ConvertTo-Json -Depth 6)
+    while (-not $p.HasExited) {
+        WriteUtf8 $heartbeatPath ((Get-Date).ToUniversalTime().ToString("o") + [Environment]::NewLine)
+        Start-Sleep -Seconds ([Math]::Max(1, $HeartbeatSec))
+    }
+    $p.WaitForExit()
+    $code = [int]$p.ExitCode
+} catch {
+    $code = 127
+    AppendUtf8 $EventsFile ("RUNJOB: ERROR " + $_.Exception.Message + [Environment]::NewLine)
+} finally {
+    try { WriteUtf8 $heartbeatPath ((Get-Date).ToUniversalTime().ToString("o") + [Environment]::NewLine) } catch {}
+    try {
+        if ((Test-Path -LiteralPath $stderrFile -PathType Leaf) -and (Get-Item -LiteralPath $stderrFile).Length -gt 0) {
+            AppendUtf8 $EventsFile ([System.IO.File]::ReadAllText($stderrFile, [System.Text.Encoding]::UTF8))
+        }
+    } catch {}
+}
+
+$exitObj = [ordered]@{
+    exit_code = $code
+    ended_at = (Get-Date).ToUniversalTime().ToString("o")
+}
+WriteUtf8 $exitPath ($exitObj | ConvertTo-Json -Depth 4)
+exit $code

--- a/skills/architect/run-job.ps1
+++ b/skills/architect/run-job.ps1
@@ -82,8 +82,27 @@ if ($StdinFile) { $StdinFile = [System.IO.Path]::GetFullPath($StdinFile) }
 $metaPath = Join-Path $JobDir "job.meta.json"
 $heartbeatPath = Join-Path $JobDir "job.heartbeat"
 $exitPath = Join-Path $JobDir "job.exit.json"
+$stderrFile = $EventsFile + ".stderr"
+
+function WriteMeta($ChildPid) {
+    $meta = [ordered]@{
+        backend = $Backend
+        command = @($Command)
+        cwd = $Workdir
+        events_file = $EventsFile
+        report_path = $ReportPath
+        job_dir = $JobDir
+        wrapper_pid = $PID
+        child_pid = $ChildPid
+        started_at = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    WriteUtf8 $metaPath ($meta | ConvertTo-Json -Depth 6)
+}
 
 New-Item -ItemType Directory -Path $JobDir -Force | Out-Null
+WriteUtf8 $EventsFile ""
+WriteUtf8 $stderrFile ""
+WriteMeta $null
 if (-not (Test-Path -LiteralPath $Workdir -PathType Container)) {
     WriteUtf8 $exitPath (@{ exit_code = 127; ended_at = (Get-Date).ToUniversalTime().ToString("o"); error = "missing workdir" } | ConvertTo-Json -Depth 4)
     Write-Output "RUNJOB: ERROR missing workdir"
@@ -101,9 +120,6 @@ if ($Command.Count -gt 1) {
     foreach ($arg in @($Command[1..($Command.Count - 1)])) { $childArgs += (QuoteArg $arg) }
 }
 $argString = ($childArgs -join " ")
-$stderrFile = $EventsFile + ".stderr"
-WriteUtf8 $EventsFile ""
-WriteUtf8 $stderrFile ""
 
 try {
     $startArgs = @{
@@ -118,18 +134,7 @@ try {
     if ($StdinFile) { $startArgs.RedirectStandardInput = $StdinFile }
     $p = Start-Process @startArgs
     $null = $p.Handle
-    $meta = [ordered]@{
-        backend = $Backend
-        command = @($Command)
-        cwd = $Workdir
-        events_file = $EventsFile
-        report_path = $ReportPath
-        job_dir = $JobDir
-        wrapper_pid = $PID
-        child_pid = $p.Id
-        started_at = (Get-Date).ToUniversalTime().ToString("o")
-    }
-    WriteUtf8 $metaPath ($meta | ConvertTo-Json -Depth 6)
+    WriteMeta $p.Id
     while (-not $p.HasExited) {
         WriteUtf8 $heartbeatPath ((Get-Date).ToUniversalTime().ToString("o") + [Environment]::NewLine)
         Start-Sleep -Seconds ([Math]::Max(1, $HeartbeatSec))

--- a/skills/architect/run-job.sh
+++ b/skills/architect/run-job.sh
@@ -46,16 +46,7 @@ command_json(){
 }
 
 mkdir -p "$job_dir" "$(dirname "$events_file")" || exit 64
-if [ ! -d "$workdir" ]; then
-  write_exit 127
-  printf 'RUNJOB: ERROR missing workdir\n'
-  exit 127
-fi
-if [ -n "$stdin_file" ] && [ ! -f "$stdin_file" ]; then
-  write_exit 127
-  printf 'RUNJOB: ERROR missing stdin file\n'
-  exit 127
-fi
+: > "$events_file" || exit 64
 
 (
   printf '{'
@@ -71,27 +62,51 @@ fi
   printf '}\n'
 ) > "$job_dir/job.meta.json"
 
-if [ -n "$stdin_file" ]; then
-  "$@" < "$stdin_file" > "$events_file" 2>&1 &
-else
-  "$@" > "$events_file" 2>&1 &
+if [ ! -d "$workdir" ]; then
+  write_exit 127
+  printf 'RUNJOB: ERROR missing workdir\n'
+  exit 127
 fi
+if [ -n "$stdin_file" ] && [ ! -f "$stdin_file" ]; then
+  write_exit 127
+  printf 'RUNJOB: ERROR missing stdin file\n'
+  exit 127
+fi
+
+wait_file="$job_dir/job.wait"
+wait_tmp="$job_dir/job.wait.tmp"
+rm -f "$wait_file" "$wait_tmp"
+(
+  if [ -n "$stdin_file" ]; then
+    "$@" < "$stdin_file" > "$events_file" 2>&1
+  else
+    "$@" > "$events_file" 2>&1
+  fi
+  child_code=$?
+  printf '%s\n' "$child_code" > "$wait_tmp"
+  mv "$wait_tmp" "$wait_file"
+  exit "$child_code"
+) &
 child=$!
 tmp_meta="$job_dir/job.meta.json.tmp"
 sed "s/\"started_at\"/\"child_pid\":$child,\"started_at\"/" "$job_dir/job.meta.json" > "$tmp_meta" && mv "$tmp_meta" "$job_dir/job.meta.json"
 
-(
-  while kill -0 "$child" 2>/dev/null; do
-    write_heartbeat
-    sleep "$heartbeat_sec"
-  done
-) &
-heartbeat_pid=$!
+trap 'exit 143' INT TERM HUP
 
-wait "$child"
-code=$?
-kill "$heartbeat_pid" 2>/dev/null || true
-wait "$heartbeat_pid" 2>/dev/null || true
+write_heartbeat
+last_heartbeat=$(date +%s)
+while [ ! -f "$wait_file" ]; do
+  sleep 1
+  now_epoch=$(date +%s)
+  if [ $((now_epoch - last_heartbeat)) -ge "$heartbeat_sec" ]; then
+    write_heartbeat
+    last_heartbeat=$now_epoch
+  fi
+done
+wait "$child" 2>/dev/null || true
+code=$(cat "$wait_file" 2>/dev/null || printf 127)
+rm -f "$wait_file" "$wait_tmp"
+trap - INT TERM HUP
 write_heartbeat
 write_exit "$code"
 exit "$code"

--- a/skills/architect/run-job.sh
+++ b/skills/architect/run-job.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -u
+
+job_dir=
+workdir=
+backend=cli
+report_path=
+events_file=
+stdin_file=
+heartbeat_sec=30
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --job-dir) job_dir=$2; shift 2;;
+    --workdir) workdir=$2; shift 2;;
+    --backend) backend=$2; shift 2;;
+    --report-path) report_path=$2; shift 2;;
+    --events-file) events_file=$2; shift 2;;
+    --stdin-file) stdin_file=$2; shift 2;;
+    --heartbeat-sec) heartbeat_sec=$2; shift 2;;
+    --) shift; break;;
+    *) break;;
+  esac
+done
+
+[ -n "$job_dir" ] || { printf 'RUNJOB: ERROR missing --job-dir\n'; exit 64; }
+[ -n "$workdir" ] || { printf 'RUNJOB: ERROR missing --workdir\n'; exit 64; }
+[ "$#" -gt 0 ] || { printf 'RUNJOB: ERROR missing command\n'; exit 64; }
+[ -n "$events_file" ] || events_file="$job_dir/events.jsonl"
+
+json_escape(){
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+now_iso(){ date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+write_heartbeat(){ printf '%s\n' "$(now_iso)" > "$job_dir/job.heartbeat"; }
+write_exit(){ printf '{"exit_code":%s,"ended_at":"%s"}\n' "$1" "$(now_iso)" > "$job_dir/job.exit.json"; }
+command_json(){
+  first=true
+  printf '['
+  for arg in "$@"; do
+    [ "$first" = true ] || printf ','
+    first=false
+    printf '"%s"' "$(json_escape "$arg")"
+  done
+  printf ']'
+}
+
+mkdir -p "$job_dir" "$(dirname "$events_file")" || exit 64
+if [ ! -d "$workdir" ]; then
+  write_exit 127
+  printf 'RUNJOB: ERROR missing workdir\n'
+  exit 127
+fi
+if [ -n "$stdin_file" ] && [ ! -f "$stdin_file" ]; then
+  write_exit 127
+  printf 'RUNJOB: ERROR missing stdin file\n'
+  exit 127
+fi
+
+(
+  printf '{'
+  printf '"backend":"%s",' "$(json_escape "$backend")"
+  printf '"command":'
+  command_json "$@"
+  printf ',"cwd":"%s",' "$(json_escape "$workdir")"
+  printf '"events_file":"%s",' "$(json_escape "$events_file")"
+  printf '"report_path":"%s",' "$(json_escape "$report_path")"
+  printf '"job_dir":"%s",' "$(json_escape "$job_dir")"
+  printf '"wrapper_pid":%s,' "$$"
+  printf '"started_at":"%s"' "$(now_iso)"
+  printf '}\n'
+) > "$job_dir/job.meta.json"
+
+if [ -n "$stdin_file" ]; then
+  "$@" < "$stdin_file" > "$events_file" 2>&1 &
+else
+  "$@" > "$events_file" 2>&1 &
+fi
+child=$!
+tmp_meta="$job_dir/job.meta.json.tmp"
+sed "s/\"started_at\"/\"child_pid\":$child,\"started_at\"/" "$job_dir/job.meta.json" > "$tmp_meta" && mv "$tmp_meta" "$job_dir/job.meta.json"
+
+(
+  while kill -0 "$child" 2>/dev/null; do
+    write_heartbeat
+    sleep "$heartbeat_sec"
+  done
+) &
+heartbeat_pid=$!
+
+wait "$child"
+code=$?
+kill "$heartbeat_pid" 2>/dev/null || true
+wait "$heartbeat_pid" 2>/dev/null || true
+write_heartbeat
+write_exit "$code"
+exit "$code"

--- a/skills/architect/watchdog.ps1
+++ b/skills/architect/watchdog.ps1
@@ -143,7 +143,8 @@ while ($true) {
         if (-not $jobDir -or -not (Test-Path -LiteralPath $meta -PathType Leaf)) {
             OutputAndExit 10 "WATCHDOG: LEGACY_UNWRAPPED $id deterministic_exit=false terminal_status=$terminal"
         }
-        if ($events -and $worktree -and -not (Test-Path -LiteralPath $events) -and -not (Test-Path -LiteralPath $worktree)) {
+        $exitObj = ReadJson $exitFile
+        if (-not $exitObj -and (($events -and -not (Test-Path -LiteralPath $events)) -or ($worktree -and -not (Test-Path -LiteralPath $worktree)))) {
             OutputAndExit 2 "WATCHDOG: INTEGRATED $id"
         }
 
@@ -159,7 +160,6 @@ while ($true) {
         }
         $lastGrowth = ParseUtc $state.last_growth_utc $now
 
-        $exitObj = ReadJson $exitFile
         if ($exitObj) {
             $code = [int](Prop $exitObj "exit_code" 127)
             if ($code -eq 0 -and $terminal) {

--- a/skills/architect/watchdog.ps1
+++ b/skills/architect/watchdog.ps1
@@ -1,18 +1,15 @@
 param([Parameter(Mandatory=$true)][string]$Config)
 
-function TailText($Path) {
-    if (-not (Test-Path -LiteralPath $Path)) { return "" }
-    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
-    try { $len = [Math]::Min([int64]4096, $fs.Length); [void]$fs.Seek(-$len, [System.IO.SeekOrigin]::End); $buf = New-Object byte[] $len; [void]$fs.Read($buf, 0, $len) }
-    finally { $fs.Close() }
-    return DecodeBytes $buf
-}
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+function Utf8NoBom { return New-Object System.Text.UTF8Encoding($false) }
 
 function DecodeBytes($Buf) {
-    if ($Buf.Length -ge 2 -and $Buf[0] -eq 255 -and $Buf[1] -eq 254) { return [System.Text.Encoding]::Unicode.GetString($Buf) }
-    if ($Buf.Length -ge 2 -and $Buf[0] -eq 254 -and $Buf[1] -eq 255) { return [System.Text.Encoding]::BigEndianUnicode.GetString($Buf) }
+    if ($Buf.Length -ge 3 -and $Buf[0] -eq 239 -and $Buf[1] -eq 187 -and $Buf[2] -eq 191) { return [System.Text.Encoding]::UTF8.GetString($Buf, 3, $Buf.Length - 3) }
+    if ($Buf.Length -ge 2 -and $Buf[0] -eq 255 -and $Buf[1] -eq 254) { return [System.Text.Encoding]::Unicode.GetString($Buf, 2, $Buf.Length - 2) }
+    if ($Buf.Length -ge 2 -and $Buf[0] -eq 254 -and $Buf[1] -eq 255) { return [System.Text.Encoding]::BigEndianUnicode.GetString($Buf, 2, $Buf.Length - 2) }
     $utf8 = New-Object System.Text.UTF8Encoding($false, $true)
-    try { return $utf8.GetString($buf) } catch { return [System.Text.Encoding]::Unicode.GetString($buf) }
+    try { return $utf8.GetString($Buf) } catch { return [System.Text.Encoding]::Default.GetString($Buf) }
 }
 
 function ReadText($Path) {
@@ -21,6 +18,47 @@ function ReadText($Path) {
     try { $buf = New-Object byte[] $fs.Length; [void]$fs.Read($buf, 0, $buf.Length) }
     finally { $fs.Close() }
     return DecodeBytes $buf
+}
+
+function TailText($Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $len = [Math]::Min([int64]4096, $fs.Length)
+        [void]$fs.Seek(-$len, [System.IO.SeekOrigin]::End)
+        $buf = New-Object byte[] $len
+        [void]$fs.Read($buf, 0, $len)
+    } finally { $fs.Close() }
+    return DecodeBytes $buf
+}
+
+function WriteUtf8($Path, $Text) {
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    [System.IO.File]::WriteAllText($Path, $Text, (Utf8NoBom))
+}
+
+function Prop($Obj, $Name, $Default = "") {
+    if ($Obj -and $Obj.PSObject.Properties.Name -contains $Name -and $Obj.PSObject.Properties[$Name].Value -ne $null) {
+        return $Obj.PSObject.Properties[$Name].Value
+    }
+    return $Default
+}
+
+function FileSize($Path) {
+    if ($Path -and (Test-Path -LiteralPath $Path -PathType Leaf)) { return [int64](Get-Item -LiteralPath $Path).Length }
+    return [int64]0
+}
+
+function EvidenceUtc($Paths) {
+    $max = [datetime]::MinValue
+    foreach ($path in $Paths) {
+        if ($path -and (Test-Path -LiteralPath $path)) {
+            $t = (Get-Item -LiteralPath $path -Force).LastWriteTimeUtc
+            if ($t -gt $max) { $max = $t }
+        }
+    }
+    return $max
 }
 
 function HasTerminalStatus($Path) {
@@ -32,72 +70,157 @@ function HasTerminalStatus($Path) {
     return $false
 }
 
-function FileSize($Path) { if (Test-Path -LiteralPath $Path) { return (Get-Item -LiteralPath $Path).Length }; return 0 }
+function ParseUtc($Text, $Fallback) {
+    if (-not $Text) { return $Fallback }
+    try { return ([datetime]::Parse($Text)).ToUniversalTime() } catch { return $Fallback }
+}
 
-function NewestMTime($Path) {
-    if (-not (Test-Path -LiteralPath $Path)) { return [int64]0 }
-    $item = Get-Item -LiteralPath $Path -Force
-    $max = [int64]$item.LastWriteTimeUtc.Ticks
-    if ($item.PSIsContainer) {
-        foreach ($child in (Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction SilentlyContinue)) {
-            $ticks = [int64]$child.LastWriteTimeUtc.Ticks
-            if ($ticks -gt $max) { $max = $ticks }
+function ReadJson($Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+    try { return (ReadText $Path) | ConvertFrom-Json } catch { return $null }
+}
+
+function ReadState($Path, $Size, $Now, $EvidenceUtc) {
+    $seed = $Now
+    if ($EvidenceUtc -gt [datetime]::MinValue) { $seed = $EvidenceUtc }
+    $raw = ReadJson $Path
+    if ($raw) {
+        return [ordered]@{
+            last_size = [int64](Prop $raw "last_size" $Size)
+            last_growth_utc = [string](Prop $raw "last_growth_utc" $seed.ToString("o"))
+            last_evidence_ticks = [int64](Prop $raw "last_evidence_ticks" $EvidenceUtc.Ticks)
+            report_ready_utc = [string](Prop $raw "report_ready_utc" "")
         }
     }
-    return $max
+    return [ordered]@{ last_size = [int64]$Size; last_growth_utc = $seed.ToString("o"); last_evidence_ticks = [int64]$EvidenceUtc.Ticks; report_ready_utc = "" }
 }
 
-function ActivityMTime($Job) {
-    $max = [int64]0
-    foreach ($path in @($Job.events_file, $Job.report_path, $Job.worktree)) {
-        $ticks = NewestMTime $path
-        if ($ticks -gt $max) { $max = $ticks }
-    }
-    return $max
+function SaveState($Path, $State) {
+    WriteUtf8 $Path ($State | ConvertTo-Json -Depth 4)
 }
 
-$cfg = Get-Content -LiteralPath $Config -Raw | ConvertFrom-Json
-$sweep = [int]$cfg.sweep_sec
-$stall = [double]$cfg.stall_after_min
-$state = @{}
-foreach ($j in $cfg.jobs) {
-    $state[$j.id] = @{ Done = $false; Size = ((FileSize $j.events_file) + (FileSize $j.report_path)); MTime = (ActivityMTime $j); Growth = (Get-Date) }
+function LastCommands($Path) {
+    $cmds = @()
+    foreach ($m in [regex]::Matches((TailText $Path), '"command"\s*:\s*"((?:\\.|[^"\\])*)"')) { $cmds += $m.Groups[1].Value }
+    return $cmds
 }
+
+function OutputAndExit($Code, $Line, $Extra = @()) {
+    Write-Output $Line
+    foreach ($x in $Extra) { if ($x -ne $null -and "$x" -ne "") { Write-Output $x } }
+    exit $Code
+}
+
+if (-not (Test-Path -LiteralPath $Config -PathType Leaf)) {
+    OutputAndExit 5 "WATCHDOG: ERROR missing config"
+}
+try { $cfg = (ReadText $Config) | ConvertFrom-Json } catch {
+    OutputAndExit 5 "WATCHDOG: ERROR unreadable config"
+}
+
+$sweep = [int](Prop $cfg "sweep_sec" 120)
+$stallMin = [double](Prop $cfg "stall_after_min" 10)
+$heartbeatStaleSec = [double](Prop $cfg "heartbeat_stale_sec" ([Math]::Max(90, $sweep * 2)))
+$reportReadyGraceSec = [double](Prop $cfg "report_ready_grace_sec" $sweep)
 
 while ($true) {
+    $allDone = $true
+    $doneLines = @()
     foreach ($j in $cfg.jobs) {
-        $id = [string]$j.id
-        $s = $state[$id]
-        if ($s.Done) { continue }
-        if (HasTerminalStatus $j.report_path) { $s.Done = $true; continue }
-        if ((-not (Test-Path -LiteralPath $j.events_file)) -and (-not (Test-Path -LiteralPath $j.worktree))) {
-            Write-Output "WATCHDOG: INTEGRATED $id"
-            exit 2
+        $now = (Get-Date).ToUniversalTime()
+        $id = [string](Prop $j "id" "")
+        $events = [string](Prop $j "events_file" "")
+        $report = [string](Prop $j "report_path" "")
+        $worktree = [string](Prop $j "worktree" "")
+        $jobDir = [string](Prop $j "job_dir" "")
+        if (-not $jobDir -and $events) { $jobDir = Split-Path -Parent $events }
+        $meta = if ($jobDir) { Join-Path $jobDir "job.meta.json" } else { "" }
+        $exitFile = [string](Prop $j "exit_file" $(if ($jobDir) { Join-Path $jobDir "job.exit.json" } else { "" }))
+        $heartbeat = [string](Prop $j "heartbeat_file" $(if ($jobDir) { Join-Path $jobDir "job.heartbeat" } else { "" }))
+        $stateFile = [string](Prop $j "state_file" $(if ($jobDir) { Join-Path $jobDir "job.state.json" } else { "" }))
+        $terminal = HasTerminalStatus $report
+
+        if (-not $jobDir -or -not (Test-Path -LiteralPath $meta -PathType Leaf)) {
+            OutputAndExit 10 "WATCHDOG: LEGACY_UNWRAPPED $id deterministic_exit=false terminal_status=$terminal"
         }
-        $size = (FileSize $j.events_file) + (FileSize $j.report_path)
-        $mtime = ActivityMTime $j
-        if ($size -ne $s.Size -or $mtime -gt $s.MTime) { $s.Size = $size; $s.MTime = $mtime; $s.Growth = Get-Date }
-        $mins = ((Get-Date) - $s.Growth).TotalMinutes
-        $grace = $stall + [double]$j.duration_hint_min
-        if ($mins -gt $grace) {
-            Write-Output "WATCHDOG: STALL $id minutes_since_activity=$([Math]::Round($mins, 3)) bytes=$size mtime_ticks=$mtime"
-            foreach ($line in ((TailText $j.events_file) -split "`r?`n" | Select-Object -Last 5)) { Write-Output $line }
-            exit 3
+        if ($events -and $worktree -and -not (Test-Path -LiteralPath $events) -and -not (Test-Path -LiteralPath $worktree)) {
+            OutputAndExit 2 "WATCHDOG: INTEGRATED $id"
         }
-        $cmds = @()
-        foreach ($m in [regex]::Matches((TailText $j.events_file), '"command"\s*:\s*"((?:\\.|[^"\\])*)"')) { $cmds += $m.Groups[1].Value }
+
+        $size = (FileSize $events) + (FileSize $report)
+        $evidence = EvidenceUtc @($events, $report)
+        $state = ReadState $stateFile $size $now $evidence
+        $grew = $false
+        if ($size -ne [int64]$state.last_size -or $evidence.Ticks -gt [int64]$state.last_evidence_ticks) {
+            $state.last_size = [int64]$size
+            $state.last_evidence_ticks = [int64]$evidence.Ticks
+            $state.last_growth_utc = $now.ToString("o")
+            $grew = $true
+        }
+        $lastGrowth = ParseUtc $state.last_growth_utc $now
+
+        $exitObj = ReadJson $exitFile
+        if ($exitObj) {
+            $code = [int](Prop $exitObj "exit_code" 127)
+            if ($code -eq 0 -and $terminal) {
+                SaveState $stateFile $state
+                $doneLines += "DONE_OK $id $report $(FileSize $report) bytes exit_code=0"
+                continue
+            }
+            SaveState $stateFile $state
+            OutputAndExit 9 "WATCHDOG: DONE_FAILED $id exit_code=$code terminal_status=$terminal report=$report"
+        }
+
+        $allDone = $false
+        if ($terminal) {
+            if (-not $state.report_ready_utc) {
+                $state.report_ready_utc = $now.ToString("o")
+                SaveState $stateFile $state
+                continue
+            }
+            $readyAt = ParseUtc $state.report_ready_utc $now
+            SaveState $stateFile $state
+            if (($now - $readyAt).TotalSeconds -ge $reportReadyGraceSec) {
+                OutputAndExit 6 "WATCHDOG: REPORT_READY $id terminal_status=true exit_file=false age_sec=$([Math]::Round(($now - $readyAt).TotalSeconds, 3))"
+            }
+            continue
+        }
+        $state.report_ready_utc = ""
+
+        $cmds = @(LastCommands $events)
         if ($cmds.Count -ge 4) {
-            $last = $cmds | Select-Object -Last 4
+            $last = @($cmds | Select-Object -Last 4)
             if (($last | Select-Object -Unique).Count -eq 1) {
-                Write-Output "WATCHDOG: REPEAT $id command=$($last[0]) count=4"
-                exit 4
+                SaveState $stateFile $state
+                OutputAndExit 4 "WATCHDOG: REPEAT $id command=$($last[0]) count=4"
             }
         }
+
+        $hbAge = [double]::PositiveInfinity
+        if ($heartbeat -and (Test-Path -LiteralPath $heartbeat -PathType Leaf)) {
+            $hbAge = ($now - (Get-Item -LiteralPath $heartbeat).LastWriteTimeUtc).TotalSeconds
+        } elseif ($meta -and (Test-Path -LiteralPath $meta -PathType Leaf)) {
+            $hbAge = ($now - (Get-Item -LiteralPath $meta).LastWriteTimeUtc).TotalSeconds
+        }
+        $growthAge = ($now - $lastGrowth).TotalSeconds
+        $hintMin = [double](Prop $j "duration_hint_min" 0)
+        $quietGrace = [Math]::Max(0, ($stallMin + $hintMin) * 60)
+        SaveState $stateFile $state
+
+        if ($hbAge -gt $heartbeatStaleSec) {
+            if ($grew -or $growthAge -le ([Math]::Max($sweep, 1) + 1)) {
+                OutputAndExit 7 "WATCHDOG: ORPHANED $id heartbeat_age_sec=$([Math]::Round($hbAge, 3)) last_growth_age_sec=$([Math]::Round($growthAge, 3))"
+            }
+            OutputAndExit 8 "WATCHDOG: DEAD $id heartbeat_age_sec=$([Math]::Round($hbAge, 3)) last_growth_age_sec=$([Math]::Round($growthAge, 3))"
+        }
+        if ($growthAge -gt $quietGrace) {
+            $tail = @((TailText $events) -split "`r?`n" | Select-Object -Last 5)
+            OutputAndExit 3 "WATCHDOG: STALL $id seconds_since_growth=$([Math]::Round($growthAge, 3)) heartbeat_age_sec=$([Math]::Round($hbAge, 3))" $tail
+        }
     }
-    $open = @($state.Values | Where-Object { -not $_.Done })
-    if ($open.Count -eq 0) {
+    if ($allDone) {
         Write-Output "WATCHDOG: ALL_DONE"
-        foreach ($j in $cfg.jobs) { Write-Output "$($j.id) $($j.report_path) $(FileSize $j.report_path) bytes" }
+        foreach ($line in $doneLines) { Write-Output $line }
         exit 0
     }
     Start-Sleep -Seconds $sweep

--- a/skills/architect/watchdog.sh
+++ b/skills/architect/watchdog.sh
@@ -47,7 +47,13 @@ while :; do
     if [ -z "$job_dir" ] || [ ! -f "$meta" ]; then
       out_exit 10 "WATCHDOG: LEGACY_UNWRAPPED $id deterministic_exit=false terminal_status=$terminal"
     fi
-    if [ -n "$events" ] && [ -n "$worktree" ] && [ ! -e "$events" ] && [ ! -e "$worktree" ]; then
+    code=$(exit_code "$exit_file")
+    integrated=false
+    if [ -z "$code" ]; then
+      if [ -n "$events" ] && [ ! -e "$events" ]; then integrated=true; fi
+      if [ -n "$worktree" ] && [ ! -e "$worktree" ]; then integrated=true; fi
+    fi
+    if [ "$integrated" = true ]; then
       out_exit 2 "WATCHDOG: INTEGRATED $id"
     fi
     ev=$(fsize "$events"); rp=$(fsize "$report"); size=$((ev+rp)); n=$(now); ev_mtime=$(evidence_mtime "$events" "$report")
@@ -57,7 +63,6 @@ while :; do
     report_ready=$(state_field "$state_file" report_ready_epoch); [ -n "$report_ready" ] || report_ready=0
     grew=false
     if [ "$size" != "$last_size" ] || [ "$ev_mtime" -gt "$last_evidence" ]; then last_size=$size; last_evidence=$ev_mtime; last_growth=$n; grew=true; fi
-    code=$(exit_code "$exit_file")
     if [ -n "$code" ]; then
       if [ "$code" = 0 ] && [ "$terminal" = true ]; then
         save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"

--- a/skills/architect/watchdog.sh
+++ b/skills/architect/watchdog.sh
@@ -3,77 +3,108 @@ set -u
 
 cfg=
 while [ "$#" -gt 0 ]; do
-  case "$1" in -Config) cfg=$2; shift 2;; *) shift;; esac
+  case "$1" in -Config) cfg=$2; shift 2;; *) cfg=${cfg:-$1}; shift;; esac
 done
 [ -n "$cfg" ] || exit 1
+[ -r "$cfg" ] || { printf 'WATCHDOG: ERROR missing config\n'; exit 5; }
 json=$(tr -d '\r\n' < "$cfg")
 sweep=$(printf '%s' "$json" | sed -n 's/.*"sweep_sec"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
 stall=$(printf '%s' "$json" | sed -n 's/.*"stall_after_min"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
+heartbeat_stale=$(printf '%s' "$json" | sed -n 's/.*"heartbeat_stale_sec"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
+report_ready_grace=$(printf '%s' "$json" | sed -n 's/.*"report_ready_grace_sec"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
+[ -n "$sweep" ] || sweep=120
+[ -n "$stall" ] || stall=10
+[ -n "$heartbeat_stale" ] || heartbeat_stale=$(awk -v s="$sweep" 'BEGIN{v=s*2; if(v<90)v=90; print v}')
+[ -n "$report_ready_grace" ] || report_ready_grace=$sweep
 jobs=$(printf '%s' "$json" | sed 's/.*"jobs"[[:space:]]*:[[:space:]]*\[//;s/\][^]]*$//;s/}[[:space:]]*,[[:space:]]*{/\}\n\{/g')
+
 field(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"; }
-numfield(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p"; }
+numfield(){ printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\([-0-9.]*\).*/\1/p"; }
 fsize(){ stat -c %s "$1" 2>/dev/null || stat -f %z "$1" 2>/dev/null || printf 0; }
+mtime(){ stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf 0; }
 now(){ date +%s; }
 tail_text(){ [ -f "$1" ] && tail -c 4096 "$1" | tr -d '\000\377\376'; }
 report_done(){ [ -f "$1" ] || return 1; last=$(tail_text "$1" | sed 's/^\xEF\xBB\xBF//' | awk 'NF{line=$0} END{gsub(/^[[:space:]]+|[[:space:]]+$/,"",line); print line}'); case "$last" in STATUS:*) return 0;; *) return 1;; esac; }
-mtime_one(){
-  [ -e "$1" ] || { printf 0; return; }
-  own=$(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf 0)
-  max=$own
-  if [ -d "$1" ]; then
-    files=$(find "$1" -type f -exec stat -c %Y {} \; 2>/dev/null || find "$1" -type f -exec stat -f %m {} \; 2>/dev/null)
-    newest=$(printf '%s\n' "$files" | sort -nr | sed -n '1p')
-    case "$newest" in ''|*[!0-9]*) newest=0;; esac
-    [ "$newest" -gt "$max" ] && max=$newest
-  fi
-  printf '%s' "$max"
-}
-activity_mtime(){
-  max=0
-  for p in "$@"; do
-    m=$(mtime_one "$p")
-    [ "$m" -gt "$max" ] && max=$m
-  done
-  printf '%s' "$max"
-}
-
-declare -a ids events reports trees hints done sizes mtimes growth
-i=0
-while IFS= read -r job; do
-  ids[$i]=$(field "$job" id); events[$i]=$(field "$job" events_file)
-  reports[$i]=$(field "$job" report_path); trees[$i]=$(field "$job" worktree)
-  hints[$i]=$(numfield "$job" duration_hint_min); done[$i]=0
-  ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sizes[$i]=$((ev+rp)); mtimes[$i]=$(activity_mtime "${events[$i]}" "${reports[$i]}" "${trees[$i]}"); growth[$i]=$(now)
-  i=$((i+1))
-done <<EOF
-$jobs
-EOF
+exit_code(){ [ -f "$1" ] && sed -n 's/.*"exit_code"[[:space:]]*:[[:space:]]*\([-0-9][0-9]*\).*/\1/p' "$1" | tail -n 1; }
+state_field(){ [ -f "$1" ] && sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\{0,1\}\([^\",}]*\)\"\{0,1\}.*/\1/p" "$1" | tail -n 1; }
+save_state(){ printf '{"last_size":%s,"last_growth_epoch":%s,"last_evidence_epoch":%s,"report_ready_epoch":%s}\n' "$2" "$3" "$4" "$5" > "$1"; }
+out_exit(){ code=$1; shift; printf '%s\n' "$1"; shift || true; for line in "$@"; do [ -n "${line:-}" ] && printf '%s\n' "$line"; done; exit "$code"; }
+evidence_mtime(){ a=$(mtime "$1"); b=$(mtime "$2"); [ "$b" -gt "$a" ] && printf '%s' "$b" || printf '%s' "$a"; }
 
 while :; do
   all=1
-  for i in "${!ids[@]}"; do
-    [ "${done[$i]}" = 1 ] && continue
-    report_done "${reports[$i]}" && { done[$i]=1; continue; }
+  done_lines=
+  while IFS= read -r job; do
+    [ -n "$job" ] || continue
+    id=$(field "$job" id); events=$(field "$job" events_file); report=$(field "$job" report_path)
+    worktree=$(field "$job" worktree); job_dir=$(field "$job" job_dir)
+    [ -n "$job_dir" ] || job_dir=$(dirname "$events" 2>/dev/null)
+    meta="$job_dir/job.meta.json"
+    exit_file=$(field "$job" exit_file); [ -n "$exit_file" ] || exit_file="$job_dir/job.exit.json"
+    heartbeat=$(field "$job" heartbeat_file); [ -n "$heartbeat" ] || heartbeat="$job_dir/job.heartbeat"
+    state_file=$(field "$job" state_file); [ -n "$state_file" ] || state_file="$job_dir/job.state.json"
+    terminal=false; report_done "$report" && terminal=true
+    if [ -z "$job_dir" ] || [ ! -f "$meta" ]; then
+      out_exit 10 "WATCHDOG: LEGACY_UNWRAPPED $id deterministic_exit=false terminal_status=$terminal"
+    fi
+    if [ -n "$events" ] && [ -n "$worktree" ] && [ ! -e "$events" ] && [ ! -e "$worktree" ]; then
+      out_exit 2 "WATCHDOG: INTEGRATED $id"
+    fi
+    ev=$(fsize "$events"); rp=$(fsize "$report"); size=$((ev+rp)); n=$(now); ev_mtime=$(evidence_mtime "$events" "$report")
+    last_size=$(state_field "$state_file" last_size); [ -n "$last_size" ] || last_size=$size
+    last_growth=$(state_field "$state_file" last_growth_epoch); [ -n "$last_growth" ] || last_growth=$ev_mtime; [ "$last_growth" -gt 0 ] || last_growth=$n
+    last_evidence=$(state_field "$state_file" last_evidence_epoch); [ -n "$last_evidence" ] || last_evidence=$ev_mtime
+    report_ready=$(state_field "$state_file" report_ready_epoch); [ -n "$report_ready" ] || report_ready=0
+    grew=false
+    if [ "$size" != "$last_size" ] || [ "$ev_mtime" -gt "$last_evidence" ]; then last_size=$size; last_evidence=$ev_mtime; last_growth=$n; grew=true; fi
+    code=$(exit_code "$exit_file")
+    if [ -n "$code" ]; then
+      if [ "$code" = 0 ] && [ "$terminal" = true ]; then
+        save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"
+        done_lines="${done_lines}DONE_OK $id $report $(fsize "$report") bytes exit_code=0
+"
+        continue
+      fi
+      save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"
+      out_exit 9 "WATCHDOG: DONE_FAILED $id exit_code=$code terminal_status=$terminal report=$report"
+    fi
     all=0
-    if [ ! -e "${events[$i]}" ] && [ ! -e "${trees[$i]}" ]; then
-      printf 'WATCHDOG: INTEGRATED %s\n' "${ids[$i]}"; exit 2
+    if [ "$terminal" = true ]; then
+      if [ "$report_ready" = 0 ]; then report_ready=$n; save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"; continue; fi
+      save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"
+      age=$((n-report_ready))
+      if awk -v a="$age" -v g="$report_ready_grace" 'BEGIN{exit !(a>=g)}'; then
+        out_exit 6 "WATCHDOG: REPORT_READY $id terminal_status=true exit_file=false age_sec=$age"
+      fi
+      continue
     fi
-    ev=$(fsize "${events[$i]}"); rp=$(fsize "${reports[$i]}"); sz=$((ev+rp)); mt=$(activity_mtime "${events[$i]}" "${reports[$i]}" "${trees[$i]}")
-    if [ "$sz" -ne "${sizes[$i]}" ] || [ "$mt" -gt "${mtimes[$i]}" ]; then sizes[$i]=$sz; mtimes[$i]=$mt; growth[$i]=$(now); fi
-    mins=$(awk -v a="$(now)" -v b="${growth[$i]}" 'BEGIN{printf "%.3f",(a-b)/60}')
-    grace=$(awk -v a="$stall" -v b="${hints[$i]:-0}" 'BEGIN{print a+b}')
-    if awk -v m="$mins" -v g="$grace" 'BEGIN{exit !(m>g)}'; then
-      printf 'WATCHDOG: STALL %s minutes_since_activity=%s bytes=%s mtime=%s\n' "${ids[$i]}" "$mins" "$sz" "$mt"
-      tail_text "${events[$i]}" | tail -n 5; exit 3
+    report_ready=0
+    last4=$(tail_text "$events" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | tail -n 4)
+    if [ "$(printf '%s\n' "$last4" | sed '/^$/d' | wc -l | tr -d ' ')" = 4 ] && [ "$(printf '%s\n' "$last4" | sort -u | wc -l | tr -d ' ')" = 1 ]; then
+      save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"
+      out_exit 4 "WATCHDOG: REPEAT $id command=$(printf '%s\n' "$last4" | sed -n '1p') count=4"
     fi
-    last4=$(tail_text "${events[$i]}" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | tail -n 4)
-    if [ "$(printf '%s\n' "$last4" | sed '/^$/d' | wc -l)" -eq 4 ] && [ "$(printf '%s\n' "$last4" | sort -u | wc -l)" -eq 1 ]; then
-      printf 'WATCHDOG: REPEAT %s command=%s count=4\n' "${ids[$i]}" "$(printf '%s\n' "$last4" | sed -n '1p')"; exit 4
+    if [ -f "$heartbeat" ]; then hb_age=$((n-$(mtime "$heartbeat"))); elif [ -f "$meta" ]; then hb_age=$((n-$(mtime "$meta"))); else hb_age=999999; fi
+    growth_age=$((n-last_growth))
+    hint=$(numfield "$job" duration_hint_min); [ -n "$hint" ] || hint=0
+    quiet=$(awk -v a="$stall" -v b="$hint" 'BEGIN{v=(a+b)*60; if(v<0)v=0; printf "%.0f", v}')
+    save_state "$state_file" "$last_size" "$last_growth" "$last_evidence" "$report_ready"
+    if awk -v h="$hb_age" -v s="$heartbeat_stale" 'BEGIN{exit !(h>s)}'; then
+      recent=$(awk -v g="$growth_age" -v s="$sweep" 'BEGIN{exit !(g<=s+1)}'; printf $?)
+      if [ "$grew" = true ] || [ "$recent" = 0 ]; then
+        out_exit 7 "WATCHDOG: ORPHANED $id heartbeat_age_sec=$hb_age last_growth_age_sec=$growth_age"
+      fi
+      out_exit 8 "WATCHDOG: DEAD $id heartbeat_age_sec=$hb_age last_growth_age_sec=$growth_age"
     fi
-  done
+    if awk -v g="$growth_age" -v q="$quiet" 'BEGIN{exit !(g>q)}'; then
+      out_exit 3 "WATCHDOG: STALL $id seconds_since_growth=$growth_age heartbeat_age_sec=$hb_age" "$(tail_text "$events" | tail -n 5)"
+    fi
+  done <<EOF
+$jobs
+EOF
   if [ "$all" -eq 1 ]; then
     printf 'WATCHDOG: ALL_DONE\n'
-    for i in "${!ids[@]}"; do printf '%s %s %s bytes\n' "${ids[$i]}" "${reports[$i]}" "$(fsize "${reports[$i]}")"; done
+    printf '%s' "$done_lines"
     exit 0
   fi
   sleep "$sweep"

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import stat
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -166,6 +167,7 @@ ARCHITECT_HANDOFF_FREE_FILES = [
 ]
 errors: list[str] = []
 BASH_FLAVOR_CACHE: str | None = None
+BASH_INNER_PATH_CACHE: str | None = None
 
 
 def bash_flavor() -> str:
@@ -203,6 +205,40 @@ def bash_path(path: Path | str) -> str:
         if bash_flavor() == "wsl":
             return f"/mnt/{text[0].lower()}/{rest}"
     return text
+
+
+def bash_inner_executable() -> str:
+    global BASH_INNER_PATH_CACHE
+    if BASH_INNER_PATH_CACHE is not None:
+        return BASH_INNER_PATH_CACHE
+    bash = shutil.which("bash")
+    if not bash:
+        BASH_INNER_PATH_CACHE = "bash"
+        return BASH_INNER_PATH_CACHE
+    try:
+        result = subprocess.run(
+            [bash, "-lc", "command -v bash"],
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        BASH_INNER_PATH_CACHE = result.stdout.strip() if result.returncode == 0 else "bash"
+    except Exception:
+        BASH_INNER_PATH_CACHE = "bash"
+    return BASH_INNER_PATH_CACHE
+
+
+def bash_command_exists(command: str) -> bool:
+    bash = shutil.which("bash")
+    if not bash:
+        return False
+    result = subprocess.run(
+        [bash, "-lc", f"command -v {command} >/dev/null 2>&1"],
+        text=True,
+        capture_output=True,
+        timeout=5,
+    )
+    return result.returncode == 0
 
 
 def rmtree_with_writable_retry(path: Path) -> None:
@@ -815,7 +851,15 @@ def watchdog_run(prefix: list[str], config: Path, label: str, expected_exit: int
     return stdout
 
 
-def run_wrapped_fake(kind: str, job_dir: Path, workdir: Path, report: Path, fake: Path, behavior: str) -> subprocess.Popen[str]:
+def run_wrapped_fake(
+    kind: str,
+    job_dir: Path,
+    workdir: Path,
+    report: Path,
+    fake: Path,
+    behavior: str,
+    detached: bool = False,
+) -> subprocess.Popen[str]:
     prefix = run_job_prefix(kind)
     if prefix is None:
         raise RuntimeError(f"missing wrapper executor {kind}")
@@ -840,7 +884,12 @@ def run_wrapped_fake(kind: str, job_dir: Path, workdir: Path, report: Path, fake
         bash = shutil.which("bash")
         if not bash:
             raise RuntimeError("missing bash")
-        child = [bash_path(bash), bash_path(fake), behavior, bash_path(report)]
+        child = [bash_inner_executable(), bash_path(fake), behavior, bash_path(report)]
+        if detached:
+            if bash_command_exists("setsid"):
+                child = ["setsid", *child]
+            elif bash_command_exists("nohup"):
+                child = ["nohup", *child]
         command = [
             *prefix,
             "--job-dir",
@@ -909,6 +958,11 @@ def check_watchdog_determinism_fixture() -> None:
                 "    emit({'command':'ok'})",
                 "    open(report, 'w', encoding='utf-8').write('done\\nSTATUS: COMPLETE\\n')",
                 "    sys.exit(0)",
+                "if behavior == 'orphan-live':",
+                "    for i in range(20):",
+                "        emit({'command':f'still-writing-{i}'})",
+                "        time.sleep(0.5)",
+                "    sys.exit(0)",
                 "sys.exit(64)",
             ]
         )
@@ -951,6 +1005,15 @@ def check_watchdog_determinism_fixture() -> None:
                 "  happy)",
                 "    emit '{\"command\":\"ok\"}'",
                 "    printf 'done\\nSTATUS: COMPLETE\\n' > \"$report\"",
+                "    exit 0",
+                "    ;;",
+                "  orphan-live)",
+                "    i=0",
+                "    while [ \"$i\" -lt 20 ]; do",
+                "      printf '{\"command\":\"still-writing-%s\"}\\n' \"$i\"",
+                "      sleep 0.5",
+                "      i=$((i+1))",
+                "    done",
                 "    exit 0",
                 "    ;;",
                 "esac",
@@ -1048,6 +1111,79 @@ def check_watchdog_determinism_fixture() -> None:
         config = job_dir / "watchdog.json"
         write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
         watchdog_run(watchdog_prefix, config, f"{runner} legacy", 10, "WATCHDOG: LEGACY_UNWRAPPED")
+
+        job_dir = base / f"{runner}-missing-workdir"
+        workdir = job_dir / "missing-work"
+        report = job_dir / "report.md"
+        proc = run_wrapped_fake(kind, job_dir, workdir, report, fake, "happy")
+        finish_wrapped_fake(proc, f"{runner} missing-workdir")
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        output = watchdog_run(watchdog_prefix, config, f"{runner} missing-workdir", 9, "WATCHDOG: DONE_FAILED")
+        if "LEGACY_UNWRAPPED" in output or "INTEGRATED" in output:
+            errors.append(f"watchdog fixture {runner} missing-workdir: wrapper failure lost exit truth\nstdout:\n{output}")
+
+        job_dir = base / f"{runner}-integrated-worktree"
+        workdir = job_dir / "vanished-work"
+        report = job_dir / "report.md"
+        job_dir.mkdir(parents=True)
+        write_fixture_file(job_dir / "job.meta.json", "{}")
+        write_fixture_file(job_dir / "job.heartbeat", "fresh\n")
+        write_fixture_file(job_dir / "events.jsonl", "evidence remains\n")
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} integrated-worktree", 2, "WATCHDOG: INTEGRATED")
+
+        job_dir = base / f"{runner}-integrated-events"
+        workdir = job_dir / "work"
+        report = job_dir / "report.md"
+        workdir.mkdir(parents=True)
+        write_fixture_file(job_dir / "job.meta.json", "{}")
+        write_fixture_file(job_dir / "job.heartbeat", "fresh\n")
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} integrated-events", 2, "WATCHDOG: INTEGRATED")
+
+        if kind == "ps1":
+            job_dir = base / f"{runner}-start-failure"
+            workdir = job_dir / "work"
+            report = job_dir / "report.md"
+            workdir.mkdir(parents=True)
+            prefix = run_job_prefix(kind) or []
+            command = [
+                *prefix,
+                "-JobDir",
+                str(job_dir),
+                "-Workdir",
+                str(workdir),
+                "-Backend",
+                "fake-start-failure",
+                "-ReportPath",
+                str(report),
+                "-ArgvJson",
+                json.dumps(["definitely-not-a-real-executable-architect-loop"]),
+            ]
+            proc = subprocess.Popen(command, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            finish_wrapped_fake(proc, f"{runner} start-failure")
+            config = job_dir / "watchdog.json"
+            write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+            output = watchdog_run(watchdog_prefix, config, f"{runner} start-failure", 9, "WATCHDOG: DONE_FAILED")
+            if "LEGACY_UNWRAPPED" in output:
+                errors.append(f"watchdog fixture {runner} start-failure: missing metadata on Start-Process failure\nstdout:\n{output}")
+
+        if kind == "sh":
+            job_dir = base / f"{runner}-real-orphan"
+            workdir = job_dir / "work"
+            report = job_dir / "report.md"
+            workdir.mkdir(parents=True)
+            proc = run_wrapped_fake(kind, job_dir, workdir, report, fake, "orphan-live", detached=True)
+            time.sleep(1.5)
+            proc.kill()
+            proc.communicate(timeout=5)
+            time.sleep(6)
+            config = job_dir / "watchdog.json"
+            write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+            watchdog_run(watchdog_prefix, config, f"{runner} real-orphan", 7, "WATCHDOG: ORPHANED")
 
 
 def check_status_contract() -> None:

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -43,6 +43,8 @@ REQUIRED_SIBLINGS = {
         "dispatch.md",
         "research.md",
         "loop.md",
+        "run-job.ps1",
+        "run-job.sh",
         "watchdog.ps1",
         "watchdog.sh",
         "status.ps1",
@@ -163,6 +165,44 @@ ARCHITECT_HANDOFF_FREE_FILES = [
     SKILLS / "architect" / "dispatch.md",
 ]
 errors: list[str] = []
+BASH_FLAVOR_CACHE: str | None = None
+
+
+def bash_flavor() -> str:
+    global BASH_FLAVOR_CACHE
+    if BASH_FLAVOR_CACHE is not None:
+        return BASH_FLAVOR_CACHE
+    bash = shutil.which("bash")
+    if not bash:
+        BASH_FLAVOR_CACHE = ""
+        return BASH_FLAVOR_CACHE
+    probe = (
+        "if command -v cygpath >/dev/null 2>&1; then echo msys; "
+        "elif [ -d /mnt/c ]; then echo wsl; "
+        "else echo posix; fi"
+    )
+    try:
+        result = subprocess.run(
+            [bash, "-lc", probe],
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        BASH_FLAVOR_CACHE = result.stdout.strip() if result.returncode == 0 else "posix"
+    except Exception:
+        BASH_FLAVOR_CACHE = "posix"
+    return BASH_FLAVOR_CACHE
+
+
+def bash_path(path: Path | str) -> str:
+    text = str(path)
+    if os.name == "nt" and re.match(r"^[A-Za-z]:\\", text):
+        rest = text[3:].replace(os.sep, "/")
+        if bash_flavor() == "msys":
+            return f"/{text[0].lower()}/{rest}"
+        if bash_flavor() == "wsl":
+            return f"/mnt/{text[0].lower()}/{rest}"
+    return text
 
 
 def rmtree_with_writable_retry(path: Path) -> None:
@@ -618,6 +658,11 @@ def check_watchdog_contract() -> None:
             "WATCHDOG: INTEGRATED",
             "WATCHDOG: STALL",
             "WATCHDOG: REPEAT",
+            "WATCHDOG: DONE_FAILED",
+            "WATCHDOG: LEGACY_UNWRAPPED",
+            "WATCHDOG: REPORT_READY",
+            "WATCHDOG: ORPHANED",
+            "WATCHDOG: DEAD",
         ):
             if marker not in text:
                 errors.append(f"{path.relative_to(ROOT)}: missing {marker}")
@@ -633,7 +678,12 @@ def check_watchdog_contract() -> None:
         errors.append("skills/architect/dispatch.md: watchdog must re-arm on every dispatch event")
     if "Codex backend from a Claude orchestrator" in dispatch:
         errors.append("skills/architect/dispatch.md: CLI dispatch must not be Claude-orchestrator-specific")
-    for marker in ("`codex exec`, `claude -p`, or equivalent", "Claude Code or Codex orchestrator", "long-lived Bash task", "worktree file mtimes"):
+    for marker in (
+        "`codex exec`, `claude -p`, or a",
+        "Claude Code or Codex orchestrator",
+        "long-lived Bash task",
+        "wrapper-owned files",
+    ):
         if marker not in dispatch:
             errors.append(f"skills/architect/dispatch.md: missing CLI watchdog contract marker {marker!r}")
     if not re.search(r"all\s+in-flight CLI-launched jobs at every dispatch event", loop):
@@ -656,10 +706,10 @@ def check_watchdog_contract() -> None:
     if not codex_json_blocks:
         errors.append("skills/architect/dispatch.md: missing Codex --json dispatch examples")
     for i, block in enumerate(codex_json_blocks, start=1):
-        if not re.search(r"(?m)^\s+- < .+ > .+\.events\.jsonl$", block):
+        if "run-job.sh" not in block or "--stdin-file" not in block:
             errors.append(
                 "skills/architect/dispatch.md: Codex --json dispatch example "
-                f"{i} must redirect stdout to an .events.jsonl file"
+                f"{i} must run through the wrapper with --stdin-file"
             )
         for pin in ('-c service_tier="fast"', "-c features.fast_mode=true"):
             if pin not in block:
@@ -669,6 +719,335 @@ def check_watchdog_contract() -> None:
                 )
     if re.search(r"codex exec[\s\S]*?\|\s*tail", dispatch):
         errors.append("skills/architect/dispatch.md: Codex dispatch examples must not pipe through tail")
+    if re.search(r"(?m)^\s+-\s*<\s+.+>\s+.+\.events\.jsonl", dispatch):
+        errors.append("skills/architect/dispatch.md: wrapper, not the child command, must own event redirection")
+
+
+def watchdog_executor_cases() -> list[tuple[str, list[str], str]]:
+    cases: list[tuple[str, list[str], str]] = []
+    powershell = shutil.which("powershell")
+    if powershell:
+        cases.append(
+            (
+                "powershell",
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(SKILLS / "architect" / "watchdog.ps1"),
+                    "-Config",
+                ],
+                "ps1",
+            )
+        )
+    bash = shutil.which("bash")
+    if bash:
+        cases.append(("bash", [bash, bash_path(SKILLS / "architect" / "watchdog.sh"), "-Config"], "sh"))
+    return cases
+
+
+def run_job_prefix(kind: str) -> list[str] | None:
+    if kind == "ps1":
+        powershell = shutil.which("powershell")
+        if not powershell:
+            return None
+        return [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(SKILLS / "architect" / "run-job.ps1"),
+        ]
+    bash = shutil.which("bash")
+    if not bash:
+        return None
+    return [bash, bash_path(SKILLS / "architect" / "run-job.sh")]
+
+
+def write_watchdog_config(
+    config: Path,
+    job_dir: Path,
+    workdir: Path,
+    report: Path,
+    sweep: int = 1,
+    path_for_config=lambda p: str(p),
+) -> None:
+    cfg = {
+        "sweep_sec": sweep,
+        "stall_after_min": 0.01,
+        "heartbeat_stale_sec": 5,
+        "report_ready_grace_sec": 1,
+        "jobs": [
+            {
+                "id": job_dir.name,
+                "job_dir": path_for_config(job_dir),
+                "events_file": path_for_config(job_dir / "events.jsonl"),
+                "report_path": path_for_config(report),
+                "worktree": path_for_config(workdir),
+                "duration_hint_min": 0,
+            }
+        ],
+    }
+    write_fixture_file(config, json.dumps(cfg))
+
+
+def watchdog_run(prefix: list[str], config: Path, label: str, expected_exit: int, needle: str) -> str:
+    config_arg = bash_path(config) if prefix and Path(prefix[0]).name.lower().startswith("bash") else str(config)
+    result = subprocess.run(
+        [*prefix, config_arg],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=12,
+    )
+    stdout = result.stdout.replace("\r\n", "\n")
+    stderr = result.stderr.replace("\r\n", "\n")
+    if result.returncode != expected_exit:
+        errors.append(
+            f"watchdog fixture {label}: expected exit {expected_exit} got {result.returncode}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    if needle not in stdout:
+        errors.append(f"watchdog fixture {label}: missing {needle!r}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    return stdout
+
+
+def run_wrapped_fake(kind: str, job_dir: Path, workdir: Path, report: Path, fake: Path, behavior: str) -> subprocess.Popen[str]:
+    prefix = run_job_prefix(kind)
+    if prefix is None:
+        raise RuntimeError(f"missing wrapper executor {kind}")
+    if kind == "ps1":
+        child = [sys.executable, str(fake), behavior, str(report)]
+        command = [
+            *prefix,
+            "-JobDir",
+            str(job_dir),
+            "-Workdir",
+            str(workdir),
+            "-Backend",
+            f"fake-{kind}",
+            "-ReportPath",
+            str(report),
+            "-HeartbeatSec",
+            "1",
+            "-ArgvJson",
+            json.dumps(child),
+        ]
+    else:
+        bash = shutil.which("bash")
+        if not bash:
+            raise RuntimeError("missing bash")
+        child = [bash_path(bash), bash_path(fake), behavior, bash_path(report)]
+        command = [
+            *prefix,
+            "--job-dir",
+            bash_path(job_dir),
+            "--workdir",
+            bash_path(workdir),
+            "--backend",
+            f"fake-{kind}",
+            "--report-path",
+            bash_path(report),
+            "--heartbeat-sec",
+            "1",
+            "--",
+            *child,
+        ]
+    return subprocess.Popen(command, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def finish_wrapped_fake(proc: subprocess.Popen[str], label: str, timeout: int = 8) -> None:
+    try:
+        proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate(timeout=5)
+        errors.append(f"watchdog fixture {label}: wrapper did not finish")
+
+
+def check_watchdog_determinism_fixture() -> None:
+    cases = watchdog_executor_cases()
+    if not cases:
+        errors.append("watchdog fixture: no runnable executor found")
+        return
+
+    base = ROOT / ".architect" / "tmp" / "watchdog-determinism-fixture"
+    if base.exists():
+        rmtree_with_writable_retry(base)
+    base.mkdir(parents=True)
+    fake_py = base / "fake_cli.py"
+    fake_sh = base / "fake_cli.sh"
+    write_fixture_file(
+        fake_py,
+        "\n".join(
+            [
+                "import json, sys, time",
+                "behavior, report = sys.argv[1], sys.argv[2]",
+                "def emit(obj):",
+                "    print(json.dumps(obj), flush=True)",
+                "if behavior == 'phase0':",
+                "    emit({'phase':'plan'})",
+                "    open(report, 'w', encoding='utf-8').write('PHASE 0 plan only\\n')",
+                "    sys.exit(0)",
+                "if behavior == 'die':",
+                "    emit({'phase':'mid-write'})",
+                "    open(report, 'w', encoding='utf-8').write('partial\\n')",
+                "    sys.exit(9)",
+                "if behavior == 'hang':",
+                "    time.sleep(4)",
+                "    sys.exit(0)",
+                "if behavior == 'loop':",
+                "    for _ in range(6):",
+                "        emit({'command':'same-command'})",
+                "        time.sleep(0.2)",
+                "    time.sleep(3)",
+                "    sys.exit(0)",
+                "if behavior == 'happy':",
+                "    emit({'command':'ok'})",
+                "    open(report, 'w', encoding='utf-8').write('done\\nSTATUS: COMPLETE\\n')",
+                "    sys.exit(0)",
+                "sys.exit(64)",
+            ]
+        )
+        + "\n",
+    )
+    write_fixture_file(
+        fake_sh,
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -u",
+                "behavior=$1",
+                "report=$2",
+                "emit(){ printf '%s\\n' \"$1\"; }",
+                "case \"$behavior\" in",
+                "  phase0)",
+                "    emit '{\"phase\":\"plan\"}'",
+                "    printf 'PHASE 0 plan only\\n' > \"$report\"",
+                "    exit 0",
+                "    ;;",
+                "  die)",
+                "    emit '{\"phase\":\"mid-write\"}'",
+                "    printf 'partial\\n' > \"$report\"",
+                "    exit 9",
+                "    ;;",
+                "  hang)",
+                "    sleep 4",
+                "    exit 0",
+                "    ;;",
+                "  loop)",
+                "    i=0",
+                "    while [ \"$i\" -lt 6 ]; do",
+                "      emit '{\"command\":\"same-command\"}'",
+                "      sleep 0.2",
+                "      i=$((i+1))",
+                "    done",
+                "    sleep 3",
+                "    exit 0",
+                "    ;;",
+                "  happy)",
+                "    emit '{\"command\":\"ok\"}'",
+                "    printf 'done\\nSTATUS: COMPLETE\\n' > \"$report\"",
+                "    exit 0",
+                "    ;;",
+                "esac",
+                "exit 64",
+            ]
+        )
+        + "\n",
+    )
+    try:
+        fake_sh.chmod(fake_sh.stat().st_mode | stat.S_IXUSR)
+    except OSError:
+        pass
+
+    for runner, watchdog_prefix, kind in cases:
+        wrapper_prefix = run_job_prefix(kind)
+        if wrapper_prefix is None:
+            continue
+        fake = fake_py if kind == "ps1" else fake_sh
+        path_for_config = bash_path if kind == "sh" else (lambda p: str(p))
+        for behavior, expected_exit, needle in (
+            ("phase0", 9, "WATCHDOG: DONE_FAILED"),
+            ("die", 9, "WATCHDOG: DONE_FAILED"),
+            ("happy", 0, "WATCHDOG: ALL_DONE"),
+        ):
+            job_dir = base / f"{runner}-{behavior}"
+            workdir = job_dir / "work"
+            report = job_dir / "report.md"
+            workdir.mkdir(parents=True)
+            proc = run_wrapped_fake(kind, job_dir, workdir, report, fake, behavior)
+            finish_wrapped_fake(proc, f"{runner} {behavior}")
+            config = job_dir / "watchdog.json"
+            write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+            output = watchdog_run(watchdog_prefix, config, f"{runner} {behavior}", expected_exit, needle)
+            if behavior == "die" and "exit_code=9" not in output:
+                errors.append(f"watchdog fixture {runner} die: missing exit_code=9\nstdout:\n{output}")
+
+        for behavior, expected_exit, needle in (
+            ("hang", 3, "WATCHDOG: STALL"),
+            ("loop", 4, "WATCHDOG: REPEAT"),
+        ):
+            job_dir = base / f"{runner}-{behavior}"
+            workdir = job_dir / "work"
+            report = job_dir / "report.md"
+            workdir.mkdir(parents=True)
+            proc = run_wrapped_fake(kind, job_dir, workdir, report, fake, behavior)
+            config = job_dir / "watchdog.json"
+            write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+            watchdog_run(watchdog_prefix, config, f"{runner} {behavior}", expected_exit, needle)
+            finish_wrapped_fake(proc, f"{runner} {behavior}")
+
+        job_dir = base / f"{runner}-orphan"
+        workdir = job_dir / "work"
+        report = job_dir / "report.md"
+        workdir.mkdir(parents=True)
+        write_fixture_file(job_dir / "job.meta.json", "{}")
+        write_fixture_file(job_dir / "job.heartbeat", "old\n")
+        os.utime(job_dir / "job.heartbeat", (1, 1))
+        write_fixture_file(job_dir / "events.jsonl", '{"command":"still-growing"}\n')
+        write_fixture_file(job_dir / "job.state.json", '{"last_size":0,"last_growth_epoch":1,"report_ready_epoch":0}\n')
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} orphan", 7, "WATCHDOG: ORPHANED")
+
+        job_dir = base / f"{runner}-report-ready"
+        workdir = job_dir / "work"
+        report = job_dir / "report.md"
+        workdir.mkdir(parents=True)
+        write_fixture_file(job_dir / "job.meta.json", "{}")
+        write_fixture_file(job_dir / "job.heartbeat", "fresh\n")
+        write_fixture_file(job_dir / "events.jsonl", "")
+        write_fixture_file(report, "done\nSTATUS: COMPLETE\n")
+        write_fixture_file(job_dir / "job.state.json", '{"last_size":0,"last_growth_epoch":1,"report_ready_epoch":1}\n')
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} report-ready", 6, "WATCHDOG: REPORT_READY")
+
+        job_dir = base / f"{runner}-dead"
+        workdir = job_dir / "work"
+        report = job_dir / "report.md"
+        workdir.mkdir(parents=True)
+        write_fixture_file(job_dir / "job.meta.json", "{}")
+        write_fixture_file(job_dir / "job.heartbeat", "old\n")
+        write_fixture_file(job_dir / "events.jsonl", "quiet\n")
+        for old_path in (job_dir / "job.meta.json", job_dir / "job.heartbeat", job_dir / "events.jsonl"):
+            os.utime(old_path, (1, 1))
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} dead", 8, "WATCHDOG: DEAD")
+
+        job_dir = base / f"{runner}-legacy"
+        workdir = job_dir / "work"
+        report = job_dir / "report.md"
+        workdir.mkdir(parents=True)
+        write_fixture_file(job_dir / "events.jsonl", "legacy output\n")
+        config = job_dir / "watchdog.json"
+        write_watchdog_config(config, job_dir, workdir, report, path_for_config=path_for_config)
+        watchdog_run(watchdog_prefix, config, f"{runner} legacy", 10, "WATCHDOG: LEGACY_UNWRAPPED")
 
 
 def check_status_contract() -> None:
@@ -778,7 +1157,7 @@ def git_fixture(repo_root: Path, *args: str, check: bool = True) -> subprocess.C
 
 def write_fixture_file(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_text(text, encoding="utf-8", newline="\n")
 
 
 def configure_fixture_repo(repo_root: Path) -> str | None:
@@ -1759,6 +2138,7 @@ def main() -> int:
     check_agent_definitions()
     check_codex_install_step()
     check_watchdog_contract()
+    check_watchdog_determinism_fixture()
     check_status_contract()
     check_status_run_pinning_fixture()
     check_postflight_lane_fixture()


### PR DESCRIPTION
## Summary

- add cross-compatible CLI job wrappers for Codex and Claude child CLIs
- make watchdog liveness depend on wrapper-owned file evidence instead of process enumeration or harness wakeups
- add deterministic watchdog fixtures for failure, stall, repeat, orphan, integrated, legacy, and happy-path states
- record the watchdog determinism rationale in DESIGN.md

## Validation

- git diff --check
- uv run --no-project python tests\validate_skills.py