### PR TITLE
refresh readme for current factory flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,316 +1,191 @@
 # architect-loop
 
-**Set-it-and-forget-it research and software factory loop with best
-practices built in. Cut frontier-model usage while keeping the quality gates.**
+**A spec-approved autonomous software factory for Codex and Claude: one
+orchestrator, fresh-context strategist and builder agents, deterministic gates,
+and a single shipping PR or local finish record.**
 
 ## Usage
 
-```
+```text
 /architect-research <topic>
 /architect <hours+ feature/product request>
 /architect-fast <small change>
 ```
 
-`/architect-research` to explore ideas or features  
-`/architect-fast` to do a quick change  
-`/architect` for long, multi-hour runs. Start it and walk away.
+- `/architect-research` explores a topic and writes an answer-first report.
+- `/architect-fast` ships a small, bounded change through the light lane.
+- `/architect` runs the full multi-hour factory. Approve the spec, then let it work.
 
 ## Installation
 
 ```bash
 git clone https://github.com/DanMcInerney/architect-loop
 cd architect-loop && ./install.sh        # Windows: .\install.ps1
-npm i -g @openai/codex@latest            # optional: Codex CLI (>= 0.133)
+npm i -g @openai/codex@latest            # optional builder backend
 ```
+
+The installer copies the same `skills/` tree to Claude and Codex skill
+locations. Use `./install.sh --project` or `.\install.ps1 -Project` to install
+into the current repo instead of your user profile.
+
+## What Changed Recently
+
+- The loop is now a small stage-skill library: `codebase-design`, `to-spec`,
+  `adversarial-review`, `to-issues`, `frozen-checks`, `tdd`,
+  `final-review`, and `integrate`.
+- Run identity is pinned by `docs/runs/<run>/manifest.md`; status commands
+  take a run slug and no longer discover "the current run" by scanning issues.
+- GitHub and markdown tracker modes share the same state machine. Markdown
+  issues live in `docs/issues/<run>/` and need no GitHub remote.
+- The closing `final-review` is read-only. It returns `REVIEW: GREEN` or a
+  review spec plus fix issues; fix issues build through the same builder wave.
+- CLI jobs now run through `run-job.ps1|.sh`, which owns heartbeat, exit truth,
+  stdout events, stderr logs, sandbox temp/cache redirects, and kill scope.
+- The watchdog is typed evidence only. It detects stalls, repeated commands,
+  blocked tool calls, orphaned wrappers, failed exits, and legacy unwrapped jobs;
+  the orchestrator still decides.
+- `kill-job.ps1|.sh` is the explicit reaping action for stuck wrapped jobs.
+- The check-runner preserves head, tail, and pytest summaries, and can emit
+  progress events for killed or interrupted RUN items.
+- Postflight can defer locked worktree cleanup; `sweep-deferred.ps1|.sh <run>`
+  clears run-scoped debris before final close.
 
 ## Design
 
-The current session is the **orchestrator**: it grounds, dispatches, rules,
-and merges. A configurable **strategist** subagent (default: Fable) handles
-the full-lane design and review work, while **builders** stay Codex GPT-5.5
-xhigh with Fast mode where available. See [Config](#config).
+The current session is the **orchestrator**. It grounds the repo, dispatches
+fresh agents, rules on typed evidence, owns commits, and posts the digest. A
+configurable **strategist** subagent handles full-lane design and review work;
+fresh **builders** implement exactly one issue each in isolated worktrees and
+report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
+[CONTEXT.md](CONTEXT.md) for the vocabulary.
 
 ### /architect
 
 ![architect flow](assets/architect-flow.svg)
 
-- Each stage is its own small skill, invoked in order: `codebase-design`
-  (shared vocabulary), `to-spec`, `adversarial-review`, `to-issues`,
-  `frozen-checks`; builders preload `tdd`; `final-review` audits the run
-  read-only and decomposes findings into fix issues for a fix wave;
-  builder-model `integrate` updates the docs and preps the ship.
-- Orchestrator grounds in the vocabulary, then dispatches a fresh strategist
-  to draft the spec doc and surface at most 5 material questions.
-- A fresh strategist subagent adversarially reviews the spec.
-- A strategist breaks the work into parallelizable, vertical-slice tracker
-  issues and drafts the frozen checks; the orchestrator freezes them in git.
-- A run manifest in `docs/runs/<run>/manifest.md` pins the tracking issue,
-  factory branch, tracker, and spec; status commands take the run slug and
-  read that pin instead of scanning every issue.
-- Orchestrator loops through the issues, assigning builders until every
-  issue is fully complete:
-  - builders work test-first and run their own tests, with progress mirrored
-    to the tracker issue when the backend allows it;
-  - a deterministic check-runner grades each issue's frozen checks;
-  - on failure, the orchestrator diagnoses why, updates the issue and its
-    requirements, and respawns a fresh builder — otherwise it comments,
-    closes, and merges.
-- A closing review — one fresh strategist subagent over the whole
-  run diff — is read-only: it verifies findings and writes a review spec
-  cut into fix issues, never editing the diff itself.
-- Fix issues build through the fix wave, the same parallel builder
-  machinery as any other issue; zero findings short-circuits straight to
-  integrate.
-- An `integrate` subagent updates the product docs first — consuming the
-  run's docs-debt digest — then merges remaining green branches,
-  re-verifies, and preps the ship.
-- The run ends in one PR plus a digest of what shipped.
+- Intake asks at most five materiality-tested questions, records assumptions,
+  drafts a spec, and runs an adversarial review before approval.
+- Spec approval is the one human gate: in-session approval, tracker `APPROVE`,
+  or timed 5-minute auto-approval with a recorded ruling.
+- The strategist decomposes the approved spec into file-disjoint vertical-slice
+  issues and frozen checks. Checks freeze in git before any builder exists.
+- The run manifest pins the tracking issue, tracker mode, factory branch, and
+  spec path; every issue carries a run marker.
+- Builders run in fresh worktrees. They must state disagreements before coding,
+  must not commit, and must end with one raw `STATUS:` line.
+- Wrapped CLI jobs write `job.meta.json`, `job.heartbeat`, `job.exit.json`,
+  `events.jsonl`, and `stderr.log`; exit truth outranks terminal-looking report
+  text.
+- The watchdog reports typed evidence only. It never kills, nudges, or grades.
+  Stuck jobs are reaped with `kill-job.ps1|.sh` and respawned from durable issue
+  context.
+- The check-runner grades frozen RUN items with fixed expectations. Postflight
+  audits touched files, merges green jobs, and records deferred cleanup if a
+  worktree cannot be removed immediately.
+- The final review is one fresh, read-only strategist pass over the whole run.
+  Findings become fix issues and draft checks for a fix wave; zero findings
+  short-circuit to integrate.
+- `integrate` is a builder-model stage whose first step is the docs pass. It
+  consumes the change-context digest, updates product docs, verifies the closing
+  state, sweeps deferred cleanup, and prepares the PR or markdown finish record.
 
 ### /architect-fast
 
 ![architect-fast flow](assets/architect-fast-flow.svg)
 
-- Each stage reuses the same small stage skills as `/architect` —
-  `codebase-design`, `to-spec`, `to-issues`, `integrate` — with named
-  substitutions for the machinery it skips.
-- Orchestrator grounds in the vocabulary, then writes a spec doc and asks
-  you no more than 3 questions.
-- Orchestrator breaks the work into at most 3 parallelizable, file-disjoint
-  vertical-slice issues, each carrying acceptance criteria in place of a
-  frozen-check path; beyond 3 issues or ~400 changed lines, the skill stops
-  and recommends `/architect` instead — the size ceiling.
-- Fresh worktree-isolated builders implement the issues in parallel,
-  running their own tests.
-- Once every issue merges, the orchestrator itself performs one complete
-  review — code, cohesion, and tests — over the whole run diff, and makes
-  the fixes directly: no check-runner, no fresh final-review subagent.
-- Orchestrator dispatches the existing `integrate` stage skill to ship —
-  docs pass first, then one PR plus a digest, the same as `/architect`.
+- Same front door and tracker semantics as `/architect`, but capped at at most
+  three builder issues and roughly 400 changed lines.
+- No strategist subagents, no adversarial review, no frozen checks, no
+  per-issue check-runner, and no watchdog script. Issue-body acceptance
+  criteria, builder-run tests, and the orchestrator review carry the gate.
+- Each job records its dispatch-head SHA; that SHA is the postflight diff base
+  in place of a freeze SHA.
+- One per-wave timed fallback wake replaces watchdog monitoring.
+- After all issues merge, the orchestrator reviews code, cohesion, and tests,
+  makes any fixes directly, records the verdict and diffstat, then dispatches
+  `integrate`.
+- If the work exceeds the size ceiling, the lane stops and recommends
+  `/architect`.
 
 ### /architect-research
 
 ![research flow](assets/research-flow.svg)
 
-- For brainstorm-scale work, orchestrator launches a scout for the overhead
-  view of the topic; quick fact-finds and focused comparisons skip it.
-- Orchestrator designs research lanes along the topic's fault lines.
-- Orchestrator launches researchers per lane, in parallel: up to 10 through
-  CLI-launched workers or the harness cap for built-in subagents.
-- Orchestrator drafts a skeleton report marked SUPPORTED / THIN / EMPTY.
-- THIN / EMPTY sections trigger targeted gap researchers, up to 2 rounds.
-- Orchestrator verifies load-bearing claims against raw sources and writes
-  the final report.
-
-## Details
-
-Every choice below is enforced mechanically — by skill text, script, or
-git — not left as advice. Full evidence and citations: [DESIGN.md](DESIGN.md).
-
-### Both loops
-
-- **One frontier orchestrator, many disposable cheap workers.**
-  Judgment minutes go on the strongest model and typing
-  hours on the cheap one; measured orchestrator/worker splits run 58–74%
-  cheaper than the top model end-to-end, and weak planners hurt results more
-  than weak executors.
-- **Fresh context everywhere it matters.** An agent reviewing
-  its own work in the same session measurably misses more defects, so every
-  builder, researcher, adversarial reviewer, and closing reviewer starts cold.
-- **The tracker is the memory.** Specs and checks live in git;
-  disagreements, verdicts, and digests live on the issues. Not in the
-  tracker = didn't happen, so any later session can recover the run.
-- **The orchestrator sleeps between events.** It reads
-  one-line typed results from scripts and reviewers; builder output streams
-  never enter its context.
-- **Thin, size-guarded skill text.** Skill bodies ride in
-  context all session, so a validator caps their size and a
-  per-model-generation pass deletes instructions newer models do unprompted.
-
-### /architect
-
-- **At most 5 materiality-tested questions, in one batch.** A
-  question is only worth asking if the answer would change the build or how
-  it's validated; everything else becomes a recorded assumption you can veto.
-- **Spec approval is the only human step.** Misdesign is
-  cheapest to fix at the spec, so human attention concentrates there; after
-  approval you hear only the digest or a hard stop.
-- **A fresh adversarial review attacks the plan before anything is built.**
-  It executes draft check commands and hunts contradictions and
-  unfalsifiable criteria; it has caught real defects on every use so far.
-- **Acceptance checks freeze in git before any builder exists.**
-  Criteria written after results exist always pass; a builder touching a
-  check file is an automatic FAIL.
-- **Issues are vertical slices with disjoint file sets, up to 10 in parallel.**
-  CLI-launched builders run 10-wide; built-in harness subagents use their
-  native cap, currently 5. Merge conflicts are the top multi-agent failure
-  mode; a conflict means the plan was wrong, so the job is killed and
-  re-sliced, never hand-merged.
-- **Builders get their own git worktree and no commit rights.**
-  A broken builder can't reach a branch; the orchestrator owns every commit
-  and merge.
-- **Run identity is pinned, not discovered.** Each run has a
-  local `docs/runs/<run>/manifest.md` plus a run marker in every issue
-  body. Status reads `skills/architect/status.ps1 <run>` or
-  `skills/architect/status.sh <run>` from that manifest; foreign issues under
-  the same parent are escalated instead of dispatched.
-- **Builders must argue with the spec before coding.**
-  Builder-class models follow specs literally, so spec errors are only
-  catchable before execution; every disagreement gets an explicit ruling.
-- **Builders report raw evidence only.** Command output and
-  numbers, never verdicts; auditing every status claim against tool output
-  nearly eliminates fabricated reports.
-- **Stall detection is a deterministic watchdog script.**
-  A small script watches output growth, file mtimes, and repeated commands;
-  the LLM monitor it replaced measured 0 true positives and 2 false positives.
-  It never kills — the orchestrator rules on its evidence.
-- **Frozen checks run through a deterministic check-runner.** *token
-  savings* — ~9 mechanical commands per check file were burning
-  frontier-priced judge turns; a script grades expected exits and fixed
-  stdout matches, records the evidence, and can't fabricate an exit code.
-- **Dispatch and merge mechanics are scripted.** Worktree
-  setup, freeze verification, touch-set audit, merge, and cleanup each
-  collapse from 4–5 orchestrator calls into one typed-exit line.
-- **The closing review decomposes findings instead of editing.** One
-  fresh strategist subagent reads the whole run diff read-only
-  before integrate; verified findings become a review spec cut into fix
-  issues for a parallel fix wave; zero findings short-circuits to done.
-- **Reviewed diffs target ≤~400 changed lines per issue.**
-  Review effectiveness collapses past a few hundred lines, so bigger specs
-  split into more issues.
-- **Failures fix inputs, not models.** First FAIL: diagnose from
-  the check-runner's evidence, amend the issue, respawn fresh at the same
-  tier. A failure is a spec or context problem, not a retry knob.
-- **BLOCKED is a completion event.** A stuck builder posts the
-  blocker and stops; the orchestrator answers durably on the issue and
-  respawns fresh, because resuming a polluted context is the documented
-  anti-pattern.
-- **Tiers are fixed when the plan is cut.** A failed job
-  never silently escalates to a stronger model; escalation is an explicit
-  re-plan decision.
-- **Every builder backend passes a canary before the plan is cut.**
-  Each backend proves it has a working shell on a trivial task
-  before tiers are recorded, so a degraded backend is swapped at intake, not
-  discovered mid-run.
-- **High-stakes changes get cross-family review.** Same-family
-  review shares blind spots (measured self-preference bias);
-  Claude-reviews-Codex is the preferred direction.
-- **Closing review and docs debt are batched at the PR boundary.** *token
-  savings* — Product docs are the highest-contention files in a repo; one
-  gated review and integrate's single docs pass consume the accumulated
-  pointers instead of every builder fighting over the README.
-- **Hard stops.** The `docs/STOP` kill-all switch,
-  `docs/runs/<run>/STOP` for one run, irreversible actions, two consecutive
-  killed jobs, or scope growth beyond the approved spec halt the factory and
-  ask you.
-- **`tracker = markdown` runs the same loop without GitHub.**
-  Issues live in git-tracked `docs/issues/<run>/` for GitLab or fully local
-  repos; every rule, check, review, and the status tree work identically.
-
-### /architect-fast
-
-- **Size ceiling: ≤3 issues, ~≤400 changed lines total.** Beyond it the
-  skill stops and recommends `/architect`; small work stays small instead
-  of stretching the light lane past where one reviewer can hold the whole
-  diff in mind.
-- **The orchestrator review replaces the check-runner and the final-review
-  subagent.** After every issue merges, the orchestrator itself reads the
-  whole run diff for code correctness, cross-slice cohesion, and test
-  stewardship, and makes the fixes directly — a recorded relaxation of Hard
-  Rules 3 and 4. The closing PR is the later eyes on that work: the
-  `integrate` subagent verifies mechanically but reviews no code
-  correctness.
-- **A per-wave timed fallback wake replaces the watchdog script.** *token
-  savings* — most waves finish before the timer fires, so no script runs at
-  all; on a fallback wake with jobs still in flight, the orchestrator
-  judges liveness from report growth and file mtimes directly.
-- **The dispatch-head SHA is the postflight base.** Each job's dispatch-head
-  commit is recorded on its issue at dispatch and doubles as its ffcheck
-  target and its postflight merge-guard base, in place of a freeze SHA —
-  there is no separate freeze commit in the fast lane.
-- **Spec approval is unchanged.** The same one human step, the same three
-  recorded forms, the same 5-minute auto-approve on silence as `/architect`.
-
-### /architect-research
-
-- **Research is a separate skill on purpose.** Research
-  fan-out costs ~15× chat-level tokens, so it's a deliberate act, never a
-  side effect of building.
-- **A scout maps the topic before lanes are designed.** Dynamic,
-  topic-shaped decomposition measurably beats any fixed taxonomy; the
-  ~10-search scout is skipped for quick fact-finds.
-- **Researchers run under hard budgets.** 10–25 tool calls
-  and ≤5 subjects each; a researcher that fills its own context window dies
-  without writing output.
-- **Returns are capped near 2,500 tokens against a numbered source list.**
-  Compact findings with `[S#]` tags remove
-  double-citation waste; the cap was calibrated against measured real lanes.
-- **Researchers can't recommend, and NOT FOUND is a first-class answer.**
-  Researchers gather; only the author concludes. Eager agents
-  papering over gaps is how bad claims enter reports.
-- **The draft is the state between waves.** Sections are
-  marked SUPPORTED / THIN / EMPTY, and the gap round (max 2) targets only
-  the gaps — nothing already found gets re-chased.
-- **Verification is a separate pass against raw sources.**
-  ≥2 independent sources per load-bearing claim, adversarial falsification
-  searches, and citations only from URLs actually fetched this session —
-  even search-grounded agents fabricate 3–13% of URLs.
-- **One author writes the report.** Section-parallel writers
-  produce disjoint reports; gathering parallelizes, synthesis never does.
-  The committed report is the handoff into `/architect` specs.
+- A scout maps brainstorm-scale topics before lanes are designed; quick
+  fact-finds skip the scout.
+- The orchestrator designs research lanes along the topic's real fault lines.
+- Researchers gather in parallel under hard budgets and return compact findings
+  tied to numbered sources.
+- The draft is marked SUPPORTED / THIN / EMPTY. Thin or empty sections trigger
+  up to two targeted gap rounds.
+- Verification checks load-bearing claims against raw sources, including
+  falsification searches, before one author writes the report.
 
 ## Config
 
-Optional — with no config file the defaults just work. Settings live in
-`.architect/config` at the repo root or `~/.architect/config` (repo wins;
-unknown keys warn, never fail).
+Optional config lives at `.architect/config` or `~/.architect/config` (repo
+wins; unknown keys warn and do not fail).
 
 ```ini
-strategist = claude/best       # Fable subagents for design/review
-builders = codex/best          # GPT-5.5 at xhigh; Fast pins under ChatGPT auth
-tracker = markdown             # local issue files; omit for the GitHub default
-when broad ambiguous refactor -> codex/best:xhigh  # keep the builder pin, record why
+strategist = claude/best       # Fable-class design/review subagents
+builders = codex/best          # GPT-5.5 xhigh builders; Fast pins when available
+tracker = markdown             # local issue files; omit for GitHub mode
+when broad ambiguous refactor -> codex/best:xhigh  # optional builder route
 ```
 
-### Models
-
 Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` `claude` or
-`codex`. `best` and `tier-down` are per-family aliases (Fable at high /
-GPT-5.5 at xhigh, and Sonnet at high / GPT-5.5 at high); any concrete model
-works too. The orchestrator is always your current session, not a config key.
-Unconfigured, `strategist` subagents are `claude/best` for `/architect`
-design, spec, decomposition, adversarial review, and final review; builders
-are `codex/best` (Fast mode under ChatGPT auth). `claude/tier-down` is the
-builder config-selected alternative and the recorded fallback when the Codex
-CLI is absent. Optional read-only verification subagents follow `builders`;
-`/architect-research` researchers follow `builders`; `/architect-fast` keeps
-its orchestrator-review carve-out and does not invoke the strategist final
-review. `when <task class> -> <model>` lines route classes of builder work.
-A configured CLI missing at dispatch uses the recorded fallback with a note
-on the tracking issue — never a hard fail.
+`codex`. `best` and `tier-down` resolve per family. The orchestrator is always
+the session you opened, never a config key.
 
-### Local issues without GitHub
+Default full-lane routing uses `claude/best` for strategist stages and
+`codex/best` for builders. If a configured CLI is missing, the loop records the
+substitution on the tracker instead of silently changing behavior. Codex
+builders under ChatGPT auth use Fast-mode pins when available; API-key auth
+drops those pins with a recorded substitution.
 
-`tracker = markdown` runs the identical loop with no GitHub dependency —
-for GitLab-hosted or fully local repos. Issues become git-tracked files in
-`docs/issues/<run>/<NNN>-<slug>.md` with per-run numbering, the same states,
-parent/blocker edges, and comment log, so every rule, check, review, and
-the status tree work unchanged. Only a git repo is required; a remote is
-optional and `gh` isn't needed. Two differences: spec approval is
-in-session only, and the run ends with the factory branch ready plus merge
-instructions instead of an auto-merged PR. The default `tracker = github`
-needs a GitHub remote, authenticated `gh` ≥ 2.94.0, and push access.
+### Tracker Modes
 
-### Run artifacts
+`tracker = github` needs a GitHub remote, authenticated `gh >= 2.94.0`, and push
+access. Sub-issues use native parent and blocked-by edges.
 
-A run commits specs to `docs/spec/`, frozen checks to `docs/checks/<run>/`,
-and markdown-mode issues to `docs/issues/<run>/`. Everything else is local,
-gitignored bookkeeping: the manifest at `docs/runs/<run>/manifest.md`, job
-reports and check evidence under `docs/jobs/<run>/` — the tracker is the
-durable record. Each concurrent run uses its own orchestrator checkout on
-`factory/<run>` (local convention: `.architect/runs/<slug>`), while builder
-worktrees live under `.architect/wt/<run>/` and are removed at merge. An
-empty `docs/STOP` file halts every factory at the next dispatch boundary;
-an empty `docs/runs/<run>/STOP` halts only that run.
+`tracker = markdown` needs only a git repo. Issues are git-tracked markdown
+files in `docs/issues/<run>/`, with the same parent/blocker semantics, comments,
+states, and status tree. The run finishes with a ready factory branch and merge
+instructions instead of an auto-opened PR unless the in-session human directs
+otherwise.
+
+### Run Artifacts
+
+Versioned run inputs live under `docs/spec/`, `docs/checks/<run>/`, and, in
+markdown mode, `docs/issues/<run>/`.
+
+Local run bookkeeping is gitignored: manifests under `docs/runs/<run>/`, job
+reports and check evidence under `docs/jobs/<run>/`, wrapper files under
+`.architect/jobs/<run>/`, builder worktrees under `.architect/wt/<run>/`, and
+temporary sandbox/cache paths under `.architect/tmp/`.
+
+Status is scripted:
+
+```bash
+skills/architect/status.sh <run>
+```
+
+```powershell
+skills\architect\status.ps1 <run>
+```
+
+An empty `docs/STOP` file halts every run at the next dispatch boundary. An
+empty `docs/runs/<run>/STOP` halts only that run.
+
+## Validation
+
+```bash
+uv run --no-project python tests/validate_skills.py
+```
+
+The validator checks skill trigger hygiene, sibling-file pointers, README and
+DESIGN links, fenced code blocks, runner contracts, wrapper/watchdog fixtures,
+and the shipped architectural invariants.
 
 ## License
 

--- a/assets/architect-fast-flow.svg
+++ b/assets/architect-fast-flow.svg
@@ -1,94 +1,90 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 880" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 900" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
   <defs>
     <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#334155"/></marker>
   </defs>
-  <rect width="1000" height="880" fill="#ffffff"/>
+  <rect width="1000" height="900" fill="#ffffff"/>
 
-  <text x="45" y="44" font-size="20" font-weight="700" fill="#0f172a">/architect-fast</text>
-  <text x="215" y="44" font-size="12" fill="#64748b">spec → approve → issues (≤3) → builders → orchestrator review + fixes → integrate → PR</text>
+  <text x="45" y="42" font-size="20" font-weight="700" fill="#0f172a">/architect-fast</text>
+  <text x="215" y="42" font-size="12" fill="#64748b">spec -> approve -> &lt;=3 issues -> builders -> timed wake -> orchestrator review -> integrate -> PR</text>
 
-  <!-- spine arrows (single-column section) -->
-  <line x1="380" y1="126" x2="380" y2="168" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="232" x2="380" y2="274" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="338" x2="380" y2="380" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="126" x2="390" y2="160" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="222" x2="390" y2="256" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="318" x2="390" y2="352" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 1 SPEC -->
-  <rect x="230" y="70" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
-  <text x="380" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator writes it, via to-spec · ≤3 questions</text>
-  <text x="560" y="90" font-size="11" fill="#475569">same materiality test as /architect, fewer questions</text>
-  <text x="560" y="104" font-size="11" fill="#475569">expected at small scale — no adversarial review</text>
+  <rect x="230" y="70" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
+  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator writes it; &lt;=3 questions</text>
+  <text x="585" y="90" font-size="11" fill="#475569">Same approval doctrine as /architect, but no</text>
+  <text x="585" y="104" font-size="11" fill="#475569">strategist or adversarial review in this lane.</text>
 
-  <!-- 2 APPROVE -->
-  <rect x="230" y="176" width="300" height="56" rx="10" fill="#d97706"/>
-  <text x="380" y="199" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">APPROVE</text>
-  <text x="380" y="217" font-size="10.5" fill="#fef3c7" text-anchor="middle">the one human step · 5-min auto-approve on silence</text>
-  <text x="560" y="196" font-size="11" fill="#475569">identical to /architect: in-session or an APPROVE</text>
-  <text x="560" y="210" font-size="11" fill="#475569">comment; irreversible silence still defaults safe</text>
+  <rect x="230" y="166" width="320" height="56" rx="8" fill="#d97706"/>
+  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">APPROVE</text>
+  <text x="390" y="207" font-size="10.5" fill="#fef3c7" text-anchor="middle">one human step; timed auto-ruling on silence</text>
+  <text x="585" y="186" font-size="11" fill="#475569">Approval creates the run manifest and cuts the</text>
+  <text x="585" y="200" font-size="11" fill="#475569">factory branch, just like the full lane.</text>
 
-  <!-- 3 ISSUES (<=3) -->
-  <rect x="230" y="282" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="305" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ISSUES (≤3)</text>
-  <text x="380" y="323" font-size="10.5" fill="#ede9fe" text-anchor="middle">file-disjoint slices · acceptance criteria, not a check path</text>
-  <text x="560" y="302" font-size="11" fill="#475569">no change-skeleton required, no check-runner path —</text>
-  <text x="560" y="316" font-size="11" fill="#475569">over the size ceiling, the skill stops and recommends /architect</text>
+  <rect x="230" y="262" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="285" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ISSUES (&lt;=3)</text>
+  <text x="390" y="303" font-size="10.5" fill="#ede9fe" text-anchor="middle">acceptance criteria; no frozen-check path</text>
+  <text x="585" y="282" font-size="11" fill="#475569">Above the size ceiling, stop and recommend</text>
+  <text x="585" y="296" font-size="11" fill="#475569">/architect instead of stretching the lane.</text>
 
-  <!-- 4 BUILDERS (3 in parallel) -->
-  <rect x="182" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="321" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="459" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <text x="241" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="380" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="518" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="241" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="380" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="518" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="740" y="404" font-size="11" fill="#475569">fresh, worktree-isolated, same agent def</text>
-  <text x="740" y="418" font-size="11" fill="#475569">as /architect — own tests only, no</text>
-  <text x="740" y="432" font-size="11" fill="#475569">per-issue check-runner grading</text>
+  <rect x="230" y="358" width="320" height="56" rx="8" fill="#64748b"/>
+  <text x="390" y="381" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DISPATCH-HEAD SHA</text>
+  <text x="390" y="399" font-size="10.5" fill="#e2e8f0" text-anchor="middle">job diff base and postflight merge guard</text>
+  <text x="585" y="378" font-size="11" fill="#475569">There is no freeze SHA here. The recorded</text>
+  <text x="585" y="392" font-size="11" fill="#475569">dispatch head is the audit base.</text>
 
-  <!-- builder → converge -->
-  <line x1="241" y1="444" x2="241" y2="468" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="444" x2="380" y2="468" stroke="#334155" stroke-width="2"/>
-  <line x1="518" y1="444" x2="518" y2="468" stroke="#334155" stroke-width="2"/>
-  <line x1="241" y1="468" x2="518" y2="468" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="468" x2="380" y2="510" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <text x="392" y="494" font-size="11" font-weight="700" fill="#16a34a">ALL ISSUES MERGED</text>
+  <line x1="390" y1="414" x2="390" y2="454" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 5 ORCHESTRATOR REVIEW + FIXES -->
-  <rect x="230" y="518" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="541" font-size="14.5" font-weight="700" fill="#ffffff" text-anchor="middle">ORCHESTRATOR REVIEW + FIXES</text>
-  <text x="380" y="559" font-size="10.5" fill="#ede9fe" text-anchor="middle">code · cohesion · tests — same session, fixes made directly</text>
-  <text x="560" y="538" font-size="11" fill="#475569">no fresh subagent: the fast lane's only review, a recorded</text>
-  <text x="560" y="552" font-size="11" fill="#475569">relaxation of Hard Rules 3 and 4 — the PR is the later eyes on it</text>
+  <rect x="182" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="321" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="459" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <text x="241" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="380" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="518" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="241" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="380" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="518" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="740" y="478" font-size="11" fill="#475569">Fresh builders run acceptance</text>
+  <text x="740" y="492" font-size="11" fill="#475569">criteria and their own tests.</text>
+  <text x="740" y="506" font-size="11" fill="#475569">No per-issue check-runner.</text>
 
-  <!-- arrow to integrate -->
-  <line x1="380" y1="574" x2="380" y2="616" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="241" y1="518" x2="241" y2="542" stroke="#334155" stroke-width="2"/>
+  <line x1="380" y1="518" x2="380" y2="542" stroke="#334155" stroke-width="2"/>
+  <line x1="518" y1="518" x2="518" y2="542" stroke="#334155" stroke-width="2"/>
+  <line x1="241" y1="542" x2="518" y2="542" stroke="#334155" stroke-width="2"/>
+  <line x1="390" y1="542" x2="390" y2="582" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 6 INTEGRATE -->
-  <rect x="230" y="624" width="300" height="56" rx="10" fill="#0d9488"/>
-  <text x="380" y="647" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
-  <text x="380" y="665" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder subagent · docs pass · PR handoff</text>
-  <text x="560" y="644" font-size="11" fill="#475569">the review verdict stands in for final-review by recorded ruling;</text>
-  <text x="560" y="658" font-size="11" fill="#475569">a builder-model integrate subagent runs docs, validation, and PR prep</text>
+  <rect x="230" y="590" width="320" height="56" rx="8" fill="#64748b"/>
+  <text x="390" y="613" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">TIMED FALLBACK WAKE</text>
+  <text x="390" y="631" font-size="10.5" fill="#e2e8f0" text-anchor="middle">per wave; no watchdog script</text>
+  <text x="585" y="610" font-size="11" fill="#475569">If jobs are still running when the timer fires,</text>
+  <text x="585" y="624" font-size="11" fill="#475569">liveness is judged from reports and mtimes.</text>
 
-  <!-- arrow to PR -->
-  <line x1="380" y1="680" x2="380" y2="722" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="646" x2="390" y2="680" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="688" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="711" font-size="14.5" font-weight="700" fill="#ffffff" text-anchor="middle">ORCHESTRATOR REVIEW</text>
+  <text x="390" y="729" font-size="10.5" fill="#ede9fe" text-anchor="middle">code, cohesion, tests; fixes made directly</text>
+  <text x="585" y="708" font-size="11" fill="#475569">The review verdict and diffstat are recorded</text>
+  <text x="585" y="722" font-size="11" fill="#475569">on the tracking issue before integrate.</text>
 
-  <!-- 7 PR -->
-  <rect x="230" y="730" width="300" height="56" rx="10" fill="#16a34a"/>
-  <text x="380" y="753" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PR</text>
-  <text x="380" y="771" font-size="10.5" fill="#dcfce7" text-anchor="middle">opened by integrate with the run digest</text>
-  <text x="560" y="750" font-size="11" fill="#475569">the tracking issue gets the review verdict and</text>
-  <text x="560" y="764" font-size="11" fill="#475569">diffstat before the PR — docs shipped by integrate</text>
+  <line x1="390" y1="744" x2="390" y2="778" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="786" width="320" height="56" rx="8" fill="#0d9488"/>
+  <text x="390" y="809" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
+  <text x="390" y="827" font-size="10.5" fill="#ccfbf1" text-anchor="middle">docs pass, validation, PR or markdown finish</text>
+  <text x="585" y="806" font-size="11" fill="#475569">The orchestrator-review verdict stands in for</text>
+  <text x="585" y="820" font-size="11" fill="#475569">the full-lane final-review gate.</text>
 
-  <!-- legend -->
-  <rect x="45" y="830" width="12" height="12" rx="3" fill="#7c3aed"/>
-  <text x="63" y="840" font-size="11" fill="#475569">orchestrator work (running session)</text>
-  <rect x="360" y="830" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="378" y="840" font-size="11" fill="#475569">builders + integrate (Codex xhigh fast)</text>
-  <rect x="650" y="830" width="12" height="12" rx="3" fill="#d97706"/>
-  <text x="668" y="840" font-size="11" fill="#475569">human</text>
-  <rect x="750" y="830" width="12" height="12" rx="3" fill="#16a34a"/>
-  <text x="768" y="840" font-size="11" fill="#475569">the shipped PR</text>
+  <line x1="390" y1="842" x2="390" y2="868" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="874" width="320" height="16" rx="8" fill="#16a34a"/>
+
+  <rect x="45" y="850" width="12" height="12" rx="3" fill="#7c3aed"/>
+  <text x="63" y="860" font-size="11" fill="#475569">orchestrator</text>
+  <rect x="175" y="850" width="12" height="12" rx="3" fill="#0d9488"/>
+  <text x="193" y="860" font-size="11" fill="#475569">builders + integrate</text>
+  <rect x="355" y="850" width="12" height="12" rx="3" fill="#64748b"/>
+  <text x="373" y="860" font-size="11" fill="#475569">light-lane mechanics</text>
+  <rect x="555" y="850" width="12" height="12" rx="3" fill="#d97706"/>
+  <text x="573" y="860" font-size="11" fill="#475569">human approval</text>
 </svg>

--- a/assets/architect-flow.svg
+++ b/assets/architect-flow.svg
@@ -1,140 +1,115 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 990" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1080" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
   <defs>
     <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#334155"/></marker>
     <marker id="arrRed" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#dc2626"/></marker>
     <marker id="arrPurple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#7c3aed"/></marker>
   </defs>
-  <rect width="1000" height="990" fill="#ffffff"/>
+  <rect width="1000" height="1080" fill="#ffffff"/>
 
-  <text x="45" y="44" font-size="20" font-weight="700" fill="#0f172a">/architect</text>
-  <text x="165" y="44" font-size="12" fill="#64748b">spec → adversarial review → plan + frozen checks → builders → run checks → final review → fix wave → integrate → PR — run at max parallelization</text>
+  <text x="45" y="42" font-size="20" font-weight="700" fill="#0f172a">/architect</text>
+  <text x="165" y="42" font-size="12" fill="#64748b">spec -> adversarial review -> frozen checks -> wrapped builders -> typed gates -> final review -> fix wave -> integrate -> PR</text>
 
-  <!-- spine arrows (single-column section) -->
-  <line x1="380" y1="126" x2="380" y2="168" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="232" x2="380" y2="274" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="338" x2="380" y2="380" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="126" x2="390" y2="160" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="222" x2="390" y2="256" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="318" x2="390" y2="352" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 1 SPEC -->
-  <rect x="230" y="70" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
-  <text x="380" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">strategist drafts it · ≤5 questions · you approve</text>
-  <text x="560" y="90" font-size="11" fill="#475569">every question must pass a materiality test — would the answer</text>
-  <text x="560" y="104" font-size="11" fill="#475569">change the build? all else is a recorded assumption you can veto</text>
+  <rect x="230" y="70" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
+  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">strategist draft; &lt;=5 questions; human approval</text>
+  <text x="585" y="90" font-size="11" fill="#475569">Only material questions are asked. Assumptions and</text>
+  <text x="585" y="104" font-size="11" fill="#475569">timed rulings are recorded on the tracker.</text>
 
-  <!-- 2 ADVERSARIAL REVIEW -->
-  <rect x="230" y="176" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="199" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ADVERSARIAL REVIEW</text>
-  <text x="380" y="217" font-size="10.5" fill="#ede9fe" text-anchor="middle">a fresh strategist attacks spec + plan</text>
-  <text x="560" y="196" font-size="11" fill="#475569">fresh context, zero sunk cost: runs draft check commands, attacks</text>
-  <text x="560" y="210" font-size="11" fill="#475569">criteria for contradictions — bad plans die before they cost a build</text>
+  <rect x="230" y="166" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ADVERSARIAL REVIEW</text>
+  <text x="390" y="207" font-size="10.5" fill="#ede9fe" text-anchor="middle">fresh strategist attacks the spec</text>
+  <text x="585" y="186" font-size="11" fill="#475569">Bad plans die before dispatch. Surviving findings</text>
+  <text x="585" y="200" font-size="11" fill="#475569">are folded into the spec before approval.</text>
 
-  <!-- 3 PLAN + FROZEN CHECKS -->
-  <rect x="230" y="282" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="305" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PLAN + FROZEN CHECKS</text>
-  <text x="380" y="323" font-size="10.5" fill="#ede9fe" text-anchor="middle">parallel GitHub issues · checks frozen in git</text>
-  <text x="560" y="302" font-size="11" fill="#475569">parallel issues share no files, so merges can't conflict; checks</text>
-  <text x="560" y="316" font-size="11" fill="#475569">freeze in git before any code exists, so goalposts can't move</text>
+  <rect x="230" y="262" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="285" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ISSUES + FROZEN CHECKS</text>
+  <text x="390" y="303" font-size="10.5" fill="#ede9fe" text-anchor="middle">file-disjoint slices; checks frozen in git</text>
+  <text x="585" y="282" font-size="11" fill="#475569">Manifest pins run identity. Run markers protect</text>
+  <text x="585" y="296" font-size="11" fill="#475569">against foreign sub-issues and sibling runs.</text>
 
-  <!-- 4 BUILDERS (5 in parallel) -->
-  <rect x="45" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="182" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="321" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="459" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="597" y="388" width="118" height="56" rx="10" fill="#0d9488"/>
-  <text x="104" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="241" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="380" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="518" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="656" y="411" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
-  <text x="104" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="241" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="380" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="518" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="656" y="429" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
-  <text x="740" y="404" font-size="11" fill="#475569">fresh builder per ready issue,</text>
-  <text x="740" y="418" font-size="11" fill="#475569">10 via CLI; harness cap 5</text>
-  <text x="740" y="432" font-size="11" fill="#475569">dispatches the next instantly</text>
+  <rect x="230" y="358" width="320" height="56" rx="8" fill="#64748b"/>
+  <text x="390" y="381" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PREFLIGHT + WRAPPER</text>
+  <text x="390" y="399" font-size="10.5" fill="#e2e8f0" text-anchor="middle">run-job owns heartbeat, exit truth, stderr, sandbox env</text>
+  <text x="585" y="378" font-size="11" fill="#475569">CLI jobs write meta, events, stderr, heartbeat, and</text>
+  <text x="585" y="392" font-size="11" fill="#475569">exit JSON. Exit truth outranks report text.</text>
 
-  <!-- builder → checks arrows -->
-  <line x1="104" y1="444" x2="104" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="241" y1="444" x2="241" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="444" x2="380" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="518" y1="444" x2="518" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="656" y1="444" x2="656" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="414" x2="390" y2="454" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 5 RUN CHECKS (5 in parallel, deterministic) -->
-  <rect x="45" y="494" width="118" height="56" rx="10" fill="#64748b"/>
-  <rect x="182" y="494" width="118" height="56" rx="10" fill="#64748b"/>
-  <rect x="321" y="494" width="118" height="56" rx="10" fill="#64748b"/>
-  <rect x="459" y="494" width="118" height="56" rx="10" fill="#64748b"/>
-  <rect x="597" y="494" width="118" height="56" rx="10" fill="#64748b"/>
-  <text x="104" y="517" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RUN CHECKS</text>
-  <text x="241" y="517" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RUN CHECKS</text>
-  <text x="380" y="517" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RUN CHECKS</text>
-  <text x="518" y="517" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RUN CHECKS</text>
-  <text x="656" y="517" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RUN CHECKS</text>
-  <text x="104" y="535" font-size="9.5" fill="#e2e8f0" text-anchor="middle">frozen · scripted</text>
-  <text x="241" y="535" font-size="9.5" fill="#e2e8f0" text-anchor="middle">frozen · scripted</text>
-  <text x="380" y="535" font-size="9.5" fill="#e2e8f0" text-anchor="middle">frozen · scripted</text>
-  <text x="518" y="535" font-size="9.5" fill="#e2e8f0" text-anchor="middle">frozen · scripted</text>
-  <text x="656" y="535" font-size="9.5" fill="#e2e8f0" text-anchor="middle">frozen · scripted</text>
-  <text x="740" y="510" font-size="11" fill="#475569">a script, not a model — it</text>
-  <text x="740" y="524" font-size="11" fill="#475569">can't fabricate an exit code;</text>
-  <text x="740" y="538" font-size="11" fill="#475569">green merges, red respawns</text>
+  <rect x="45" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="182" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="321" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="459" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="597" y="462" width="118" height="56" rx="8" fill="#0d9488"/>
+  <text x="104" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="241" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="380" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="518" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="656" y="485" font-size="12.5" font-weight="700" fill="#ffffff" text-anchor="middle">BUILDER</text>
+  <text x="104" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="241" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="380" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="518" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="656" y="503" font-size="9.5" fill="#ccfbf1" text-anchor="middle">own worktree</text>
+  <text x="740" y="478" font-size="11" fill="#475569">Fresh builder per ready issue.</text>
+  <text x="740" y="492" font-size="11" fill="#475569">10 CLI jobs or harness cap 5.</text>
+  <text x="740" y="506" font-size="11" fill="#475569">Builders report raw evidence only.</text>
 
-  <!-- FAIL loop: checks back to a fresh builder -->
-  <path d="M 45 522 H 20 V 416 H 42" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrRed)"/>
-  <text x="20" y="464" font-size="10" font-weight="700" fill="#dc2626">FAIL</text>
-  <text x="20" y="477" font-size="8.5" fill="#64748b">amend issue,</text>
-  <text x="20" y="488" font-size="8.5" fill="#64748b">fresh builder</text>
+  <rect x="45" y="548" width="670" height="54" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="380" y="570" font-size="13" font-weight="700" fill="#0f172a" text-anchor="middle">WATCHDOG EVIDENCE</text>
+  <text x="380" y="588" font-size="10.5" fill="#475569" text-anchor="middle">ALL_DONE, STALL, REPEAT, BLOCKED_ON_TOOL, ORPHANED, DEAD, DONE_FAILED, LEGACY_UNWRAPPED</text>
+  <text x="740" y="568" font-size="11" fill="#475569">Detection only. It never kills,</text>
+  <text x="740" y="582" font-size="11" fill="#475569">nudges, grades, or decides.</text>
 
-  <!-- converge: checks → final review -->
-  <line x1="104" y1="550" x2="104" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="241" y1="550" x2="241" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="550" x2="380" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="518" y1="550" x2="518" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="656" y1="550" x2="656" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="104" y1="574" x2="656" y2="574" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="574" x2="380" y2="614" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <text x="392" y="600" font-size="11" font-weight="700" fill="#16a34a">ALL ISSUES CLOSED</text>
+  <line x1="380" y1="518" x2="380" y2="540" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="380" y1="602" x2="380" y2="636" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 6 FINAL REVIEW -->
-  <rect x="230" y="622" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="645" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">FINAL REVIEW</text>
-  <text x="380" y="663" font-size="10.5" fill="#ede9fe" text-anchor="middle">strategist review · whole run diff · findings become a review spec</text>
-  <text x="560" y="648" font-size="11" fill="#475569">never the author, always fresh: verifies findings, never edits —</text>
-  <text x="560" y="662" font-size="11" fill="#475569">the review spec is cut into fix issues, built like any other issue</text>
+  <rect x="230" y="644" width="320" height="56" rx="8" fill="#64748b"/>
+  <text x="390" y="667" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">CHECK-RUNNER</text>
+  <text x="390" y="685" font-size="10.5" fill="#e2e8f0" text-anchor="middle">graded RUN items; head/tail/pytest evidence</text>
+  <text x="585" y="664" font-size="11" fill="#475569">Fixed exit and match expectations. Progress sidecar</text>
+  <text x="585" y="678" font-size="11" fill="#475569">names the active RUN item if a runner is killed.</text>
 
-  <!-- FINDINGS loop: final review → review spec → fix issues → parallel fix builders -->
-  <path d="M 530 634 H 950 V 372 H 656 V 380" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrPurple)"/>
-  <text x="690" y="364" font-size="10" font-weight="700" fill="#7c3aed">FINDINGS → fix issues → parallel fix builders (one cycle)</text>
+  <path d="M 230 672 H 24 V 490 H 43" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrRed)"/>
+  <text x="28" y="604" font-size="10" font-weight="700" fill="#dc2626">FAIL OR WEDGE</text>
+  <text x="28" y="617" font-size="8.5" fill="#64748b">kill-job; amend issue;</text>
+  <text x="28" y="628" font-size="8.5" fill="#64748b">fresh builder</text>
 
-  <!-- spine: final review → integrate -->
-  <line x1="380" y1="678" x2="380" y2="720" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <text x="392" y="702" font-size="11" font-weight="700" fill="#16a34a">GREEN — or fix wave merged</text>
+  <line x1="390" y1="700" x2="390" y2="734" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="742" width="320" height="56" rx="8" fill="#64748b"/>
+  <text x="390" y="765" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">POSTFLIGHT + MERGE</text>
+  <text x="390" y="783" font-size="10.5" fill="#e2e8f0" text-anchor="middle">touch-set audit; merge; cleanup or deferred cleanup</text>
+  <text x="585" y="762" font-size="11" fill="#475569">Conflicts are decomposition failures. Deferred</text>
+  <text x="585" y="776" font-size="11" fill="#475569">cleanup becomes sweepable run-scoped state.</text>
 
-  <!-- 7 INTEGRATE -->
-  <rect x="230" y="728" width="300" height="56" rx="10" fill="#0d9488"/>
-  <text x="380" y="751" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
-  <text x="380" y="769" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder subagent · docs pass · PR handoff</text>
-  <text x="560" y="748" font-size="11" fill="#475569">one fresh builder-model subagent consumes the docs-debt digest,</text>
-  <text x="560" y="762" font-size="11" fill="#475569">then merges, re-verifies, and opens the PR + digest</text>
+  <line x1="390" y1="798" x2="390" y2="832" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="840" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="863" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">FINAL REVIEW</text>
+  <text x="390" y="881" font-size="10.5" fill="#ede9fe" text-anchor="middle">read-only strategist; GREEN or FINDINGS</text>
+  <text x="585" y="860" font-size="11" fill="#475569">Findings become a review spec, fix issues, and</text>
+  <text x="585" y="874" font-size="11" fill="#475569">draft checks. The reviewer never edits code.</text>
 
-  <!-- 8 PR -->
-  <line x1="380" y1="784" x2="380" y2="826" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <rect x="230" y="834" width="300" height="56" rx="10" fill="#16a34a"/>
-  <text x="380" y="857" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PR</text>
-  <text x="380" y="875" font-size="10.5" fill="#dcfce7" text-anchor="middle">opened by integrate with the run digest</text>
-  <text x="560" y="854" font-size="11" fill="#475569">the PR digest lists shipped, skipped, residual risks, and evidence;</text>
-  <text x="560" y="868" font-size="11" fill="#475569">the issue trail is the durable memory of the whole run</text>
+  <path d="M 550 858 H 955 V 450 H 656 V 454" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrPurple)"/>
+  <text x="678" y="442" font-size="10" font-weight="700" fill="#7c3aed">FINDINGS -> fix issues -> one fix wave</text>
 
-  <!-- legend -->
-  <rect x="45" y="940" width="12" height="12" rx="3" fill="#7c3aed"/>
-  <text x="63" y="950" font-size="11" fill="#475569">strategists (Fable default)</text>
-  <rect x="360" y="940" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="378" y="950" font-size="11" fill="#475569">builders + integrate (Codex xhigh fast)</text>
-  <rect x="620" y="940" width="12" height="12" rx="3" fill="#64748b"/>
-  <text x="638" y="950" font-size="11" fill="#475569">deterministic script</text>
-  <rect x="800" y="940" width="12" height="12" rx="3" fill="#16a34a"/>
-  <text x="818" y="950" font-size="11" fill="#475569">the shipped PR</text>
+  <line x1="390" y1="896" x2="390" y2="930" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="938" width="320" height="56" rx="8" fill="#0d9488"/>
+  <text x="390" y="961" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
+  <text x="390" y="979" font-size="10.5" fill="#ccfbf1" text-anchor="middle">docs pass first; verify; sweep; PR handoff</text>
+  <text x="585" y="958" font-size="11" fill="#475569">Consumes the digest, retires docs debt, runs</text>
+  <text x="585" y="972" font-size="11" fill="#475569">closing validation, and prepares the ship.</text>
+
+  <line x1="390" y1="994" x2="390" y2="1018" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <rect x="230" y="1026" width="320" height="34" rx="8" fill="#16a34a"/>
+  <text x="390" y="1048" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PR OR MARKDOWN FINISH RECORD</text>
+
+  <rect x="45" y="1040" width="12" height="12" rx="3" fill="#7c3aed"/>
+  <text x="63" y="1050" font-size="11" fill="#475569">strategist</text>
+  <rect x="140" y="1040" width="12" height="12" rx="3" fill="#0d9488"/>
+  <text x="158" y="1050" font-size="11" fill="#475569">builder/integrate</text>
+  <rect x="275" y="1040" width="12" height="12" rx="3" fill="#64748b"/>
+  <text x="293" y="1050" font-size="11" fill="#475569">scripted gates</text>
 </svg>

--- a/assets/research-flow.svg
+++ b/assets/research-flow.svg
@@ -1,99 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 810" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 820" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
   <defs>
     <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#334155"/></marker>
     <marker id="arrPurple" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#7c3aed"/></marker>
   </defs>
-  <rect width="1000" height="810" fill="#ffffff"/>
+  <rect width="1000" height="820" fill="#ffffff"/>
 
-  <text x="45" y="44" font-size="20" font-weight="700" fill="#0f172a">/architect-research</text>
-  <text x="260" y="44" font-size="12" fill="#64748b">scout → lane design → parallel researchers → draft/gap round → verify → report</text>
+  <text x="45" y="42" font-size="20" font-weight="700" fill="#0f172a">/architect-research</text>
+  <text x="260" y="42" font-size="12" fill="#64748b">scout -> lane design -> parallel researchers -> draft gaps -> verify -> report</text>
 
-  <!-- spine arrows (single-column section) -->
-  <line x1="380" y1="126" x2="380" y2="168" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <line x1="380" y1="232" x2="380" y2="274" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="126" x2="390" y2="160" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="222" x2="390" y2="256" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 1 SCOUT -->
-  <rect x="230" y="70" width="300" height="56" rx="10" fill="#0d9488"/>
-  <text x="380" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SCOUT</text>
-  <text x="380" y="111" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder-model agent maps the topic before lanes exist</text>
-  <text x="560" y="90" font-size="11" fill="#475569">~10 searches find the topic vocabulary, load-bearing systems,</text>
-  <text x="560" y="104" font-size="11" fill="#475569">and expert fault lines; skipped entirely for quick fact-finds</text>
+  <rect x="230" y="70" width="320" height="56" rx="8" fill="#0d9488"/>
+  <text x="390" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SCOUT</text>
+  <text x="390" y="111" font-size="10.5" fill="#ccfbf1" text-anchor="middle">builder-model agent maps the topic</text>
+  <text x="585" y="90" font-size="11" fill="#475569">Used for brainstorm-scale topics. Quick fact-finds</text>
+  <text x="585" y="104" font-size="11" fill="#475569">skip it and go straight to lane design.</text>
 
-  <!-- 2 DESIGN LANES -->
-  <rect x="230" y="176" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="199" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DESIGN LANES</text>
-  <text x="380" y="217" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator cuts topic-shaped research lanes</text>
-  <text x="560" y="196" font-size="11" fill="#475569">lanes follow the topic's own fault lines, never a fixed taxonomy;</text>
-  <text x="560" y="210" font-size="11" fill="#475569">overlap is checked before any researcher launches</text>
+  <rect x="230" y="166" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DESIGN LANES</text>
+  <text x="390" y="207" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator cuts topic-shaped lanes</text>
+  <text x="585" y="186" font-size="11" fill="#475569">Lanes follow the subject's fault lines instead of</text>
+  <text x="585" y="200" font-size="11" fill="#475569">a fixed taxonomy. Overlap is checked first.</text>
 
-  <!-- 3 RESEARCHERS (parallel gather) -->
-  <rect x="45" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="182" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="321" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="459" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
-  <rect x="597" y="282" width="118" height="56" rx="10" fill="#0d9488"/>
-  <text x="104" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
-  <text x="241" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
-  <text x="380" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
-  <text x="518" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
-  <text x="656" y="305" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
-  <text x="104" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 1</text>
-  <text x="241" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 2</text>
-  <text x="380" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 3</text>
-  <text x="518" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 4</text>
-  <text x="656" y="323" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 5</text>
-  <text x="740" y="298" font-size="11" fill="#475569">up to 10 researchers run side by side</text>
-  <text x="740" y="312" font-size="11" fill="#475569">under hard budgets: 10–25 tool calls,</text>
-  <text x="740" y="326" font-size="11" fill="#475569">≤5 subjects, NOT FOUND allowed</text>
+  <rect x="45" y="262" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="182" y="262" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="321" y="262" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="459" y="262" width="118" height="56" rx="8" fill="#0d9488"/>
+  <rect x="597" y="262" width="118" height="56" rx="8" fill="#0d9488"/>
+  <text x="104" y="285" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="241" y="285" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="380" y="285" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="518" y="285" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="656" y="285" font-size="11.5" font-weight="700" fill="#ffffff" text-anchor="middle">RESEARCHER</text>
+  <text x="104" y="303" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 1</text>
+  <text x="241" y="303" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 2</text>
+  <text x="380" y="303" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 3</text>
+  <text x="518" y="303" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 4</text>
+  <text x="656" y="303" font-size="9.5" fill="#ccfbf1" text-anchor="middle">lane 5</text>
+  <text x="740" y="278" font-size="11" fill="#475569">Up to 10 researchers gather in parallel.</text>
+  <text x="740" y="292" font-size="11" fill="#475569">Each has hard tool and subject budgets.</text>
+  <text x="740" y="306" font-size="11" fill="#475569">NOT FOUND is an allowed answer.</text>
 
-  <!-- researcher findings converge to the draft -->
-  <line x1="104" y1="338" x2="104" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="241" y1="338" x2="241" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="338" x2="380" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="518" y1="338" x2="518" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="656" y1="338" x2="656" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="104" y1="362" x2="656" y2="362" stroke="#334155" stroke-width="2"/>
-  <line x1="380" y1="362" x2="380" y2="404" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <text x="392" y="388" font-size="11" font-weight="700" fill="#16a34a">FINDINGS RETURN</text>
+  <line x1="104" y1="318" x2="104" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="241" y1="318" x2="241" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="380" y1="318" x2="380" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="518" y1="318" x2="518" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="656" y1="318" x2="656" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="104" y1="342" x2="656" y2="342" stroke="#334155" stroke-width="2"/>
+  <line x1="390" y1="342" x2="390" y2="382" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <text x="404" y="368" font-size="11" font-weight="700" fill="#16a34a">FINDINGS RETURN</text>
 
-  <!-- 4 DRAFT -->
-  <rect x="230" y="412" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="435" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DRAFT</text>
-  <text x="380" y="453" font-size="10.5" fill="#ede9fe" text-anchor="middle">one author marks SUPPORTED / THIN / EMPTY</text>
-  <text x="560" y="432" font-size="11" fill="#475569">the draft is the state between waves; gaps are visible,</text>
-  <text x="560" y="446" font-size="11" fill="#475569">and evidence already found is not re-chased</text>
+  <rect x="230" y="390" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="413" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">DRAFT</text>
+  <text x="390" y="431" font-size="10.5" fill="#ede9fe" text-anchor="middle">one author marks SUPPORTED / THIN / EMPTY</text>
+  <text x="585" y="410" font-size="11" fill="#475569">The draft is the state between waves, so gap</text>
+  <text x="585" y="424" font-size="11" fill="#475569">rounds target missing evidence only.</text>
 
-  <!-- gap loop: draft back to targeted researchers -->
-  <path d="M 230 440 H 20 V 310 H 42" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrPurple)"/>
-  <text x="82" y="390" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">THIN / EMPTY</text>
-  <text x="82" y="404" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">gap researchers</text>
-  <text x="82" y="418" font-size="8.5" fill="#64748b" text-anchor="middle">max 2 rounds</text>
+  <path d="M 230 418 H 24 V 290 H 43" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrPurple)"/>
+  <text x="82" y="372" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">THIN / EMPTY</text>
+  <text x="82" y="386" font-size="10" font-weight="700" fill="#7c3aed" text-anchor="middle">gap round</text>
+  <text x="82" y="400" font-size="8.5" fill="#64748b" text-anchor="middle">max 2 rounds</text>
 
-  <!-- arrow to verify -->
-  <line x1="380" y1="468" x2="380" y2="510" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="446" x2="390" y2="486" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 5 VERIFY -->
-  <rect x="230" y="518" width="300" height="56" rx="10" fill="#7c3aed"/>
-  <text x="380" y="541" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">VERIFY</text>
-  <text x="380" y="559" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator re-checks load-bearing claims</text>
-  <text x="560" y="538" font-size="11" fill="#475569">claims need independent support plus falsification searches;</text>
-  <text x="560" y="552" font-size="11" fill="#475569">citations only come from URLs fetched in this session</text>
+  <rect x="230" y="494" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="517" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">VERIFY</text>
+  <text x="390" y="535" font-size="10.5" fill="#ede9fe" text-anchor="middle">load-bearing claims checked against raw sources</text>
+  <text x="585" y="514" font-size="11" fill="#475569">Independent support and falsification searches</text>
+  <text x="585" y="528" font-size="11" fill="#475569">happen before the final report is written.</text>
 
-  <!-- arrow to report -->
-  <line x1="380" y1="574" x2="380" y2="616" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
+  <line x1="390" y1="550" x2="390" y2="590" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
 
-  <!-- 6 REPORT -->
-  <rect x="230" y="624" width="300" height="56" rx="10" fill="#16a34a"/>
-  <text x="380" y="647" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">REPORT</text>
-  <text x="380" y="665" font-size="10.5" fill="#dcfce7" text-anchor="middle">committed answer-first report</text>
-  <text x="560" y="644" font-size="11" fill="#475569">gathering parallelizes, synthesis does not: one author writes,</text>
-  <text x="560" y="658" font-size="11" fill="#475569">and the report becomes the handoff into /architect specs</text>
+  <rect x="230" y="598" width="320" height="56" rx="8" fill="#16a34a"/>
+  <text x="390" y="621" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">REPORT</text>
+  <text x="390" y="639" font-size="10.5" fill="#dcfce7" text-anchor="middle">answer-first synthesis; handoff into /architect</text>
+  <text x="585" y="618" font-size="11" fill="#475569">Gathering parallelizes. Synthesis stays with one</text>
+  <text x="585" y="632" font-size="11" fill="#475569">author so the final answer is coherent.</text>
 
-  <!-- legend -->
   <rect x="45" y="760" width="12" height="12" rx="3" fill="#7c3aed"/>
-  <text x="63" y="770" font-size="11" fill="#475569">orchestrator + verification (running session)</text>
-  <rect x="360" y="760" width="12" height="12" rx="3" fill="#0d9488"/>
-  <text x="378" y="770" font-size="11" fill="#475569">scout + researchers (builder model)</text>
-  <rect x="590" y="760" width="12" height="12" rx="3" fill="#16a34a"/>
-  <text x="608" y="770" font-size="11" fill="#475569">committed report</text>
+  <text x="63" y="770" font-size="11" fill="#475569">orchestrator and verification</text>
+  <rect x="300" y="760" width="12" height="12" rx="3" fill="#0d9488"/>
+  <text x="318" y="770" font-size="11" fill="#475569">scout and researchers</text>
+  <rect x="520" y="760" width="12" height="12" rx="3" fill="#16a34a"/>
+  <text x="538" y="770" font-size="11" fill="#475569">committed report</text>
 </svg>


### PR DESCRIPTION
## Summary
- refresh README for the current stage-skill factory flow
- update /architect, /architect-fast, and /architect-research SVG diagrams
- document recent wrapper, watchdog, check-runner, final-review, tracker, and deferred-cleanup changes

## Validation
- SVG XML parse passed for all README diagrams
- README local links resolve
- README fenced code blocks are balanced
- git diff --check passed
- Full validator was attempted earlier and hit existing Windows bash-path fixture failures resolving scripts as C:Users... paths