### PR TITLE
Respec both lanes: no approval gates, harden dispatch, closing test pass

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,12 +9,13 @@ Glossary only. No implementation details, no spec content.
   freezes, arbitrates, diagnoses, integrates. It is whatever model the loop
   started in, never a config role. Never writes implementation code, never
   reads large diffs, never judges checks. In the fast lane (`/architect-fast`)
-  it additionally performs the closing review and its fixes - the recorded
-  Hard-Rule 3/4 relaxation.
+  it additionally writes the spec and issues itself and runs the closing
+  test pass that feeds the builder review - the recorded Hard-Rule 3/4
+  relaxation.
 - **Strategist** - a fresh high-judgment subagent, defaulting to Fable
   (`claude/best`), that handles `/architect` design work: spec drafting,
-  issue decomposition, frozen-check drafting, adversarial review, and the
-  closing final review. Not used for `/architect-fast`'s closing review.
+  the harden dispatch (adversarial attack, revised spec, issue and check
+  drafting), and the closing final review. Not used in `/architect-fast`.
 - **Builder** - a fresh-context worker agent that implements exactly one issue
   in an isolated worktree. Cannot commit. The builder tier is typically
   cheaper than the strategist tier and never changes because a job failed.
@@ -33,10 +34,11 @@ Glossary only. No implementation details, no spec content.
 - **Monitor** - informal name for the watchdog. Historically an LLM subagent;
   now only a fallback template for harnesses without background-exit
   notifications.
-- **Stress-test** - Target 2 of `/adversarial-review`: a fresh reviewer
-  attacks the frozen-but-not-yet-dispatched decomposition (check commands,
-  issue bodies, repo reality) before the freeze is authorized. Target 1 of
-  the same skill is the pre-decomposition spec review.
+- **Stress-test** - stage 3 of `/adversarial-review`: the harden strategist
+  executes its own not-yet-frozen decomposition against repo reality (check
+  commands, issue bodies, pointers) before returning drafts. Stage 1 is the
+  spec attack; stage 2 folds surviving findings into the revised spec and
+  decomposes it.
 
 ## Units of work
 
@@ -59,9 +61,9 @@ Glossary only. No implementation details, no spec content.
 - **Fix wave** - the parallel builder dispatch that implements a review spec;
   the run's final wave, graded by the check-runner like any other.
 - **Review cycle** - one final review plus its fix wave; exactly one per run.
-- **Factory run** - everything between spec approval and the closing PR; runs
-  unattended on the factory branch (`factory/<run>`), with an optional
-  human-gated closing review before integrate.
+- **Factory run** - everything between intake and the closing PR; runs
+  unattended on the factory branch (`factory/<run>`), closing with an
+  unconditional final review before integrate.
 - **Fast lane** - the `/architect-fast` loop as a whole; `/architect` is the
   full factory. Both are loop skills over the same stage-skill library.
 
@@ -74,13 +76,13 @@ Glossary only. No implementation details, no spec content.
   mutations are orchestrator-executed. "Not in the tracker = didn't happen."
 - **Status tree** - a read-only render over run artifacts and the tracker;
   never a new state store.
-- **Spec approval** - the one human step: review one spec document, edit or
-  veto its recorded assumptions, approve in-session or by commenting
-  `APPROVE` on the tracking issue. Verbatim pre-approval can authorize a run
-  at invocation; otherwise the factory waits about 5 minutes, rules with the
-  orchestrator's best judgment, records the ruling for after-the-fact veto,
-  and continues. Irreversible or destructive silence takes the non-destructive
-  path; `docs/STOP` remains absolute.
+- **Timed ruling** - how every human question resolves; there is no approval
+  gate anywhere. The factory prints the question and its recommended
+  default, mirrors it on the tracker, waits about 5 minutes, applies the
+  default on silence, and records the ruling for after-the-fact veto.
+  Irreversible or destructive silence takes the non-destructive path;
+  `docs/STOP` remains absolute. The human steers by editing the spec,
+  commenting rulings, or vetoing digests.
 - **Check** - a frozen, committed, exact acceptance check
   (`docs/checks/<run>/<slice>.md`). Read-only for everyone once frozen. RUN
   items are graded by machine-readable expectations.
@@ -110,13 +112,12 @@ Glossary only. No implementation details, no spec content.
   task in the same turn its result or typed exit was consumed.
 - **Review spec** - the reviewer-authored spec at the finish boundary:
   verified findings as requirements, each carrying severity and its
-  verification. Input to fix-issue decomposition; a run artifact, not
-  human-approved.
-- **Closing review** - the human-gated review-and-decompose pass after build
-  issues close and before integrate. It uses the strategist role, is
-  read-only over product code and tests, and on findings writes a review spec
-  cut into fix issues for the fix wave; zero findings short-circuits to a
-  GREEN verdict.
+  verification. Input to fix-issue decomposition; a run artifact.
+- **Closing review** - the unconditional review-and-decompose pass after
+  build issues close and before integrate, fed the orchestrator's closing
+  test-pass output. It uses the strategist role, is read-only over product
+  code and tests, and on findings writes a review spec cut into fix issues
+  for the fix wave; zero findings short-circuits to a GREEN verdict.
 - **Canary** - the preflight spawn that proves a builder backend actually has
   working tools before the decomposition records it.
 - **Change-context digest** - the shipped-issues, diffstat, rulings,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,8 @@ tests, answers blockers, grades every issue's frozen checks through a
 deterministic check-runner, closes with one fresh, read-only strategist review
 over the whole run diff that decomposes any findings into fix issues built by
 a parallel fix wave before the integrate subagent (docs pass first) preps the
-PR, and merges — with exactly one human step, spec approval. This document is the
+PR, and merges — with no approval gate anywhere: every human question resolves
+through the timed-ruling protocol. This document is the
 "why", with citations; the skill files in `skills/architect/` are the "how";
 [CONTEXT.md](CONTEXT.md) is the vocabulary.
 
@@ -75,9 +76,9 @@ wiring them into two installable skills with the failure modes closed.
 | **Builder** | fresh worker agent, one per issue, own worktree | implementation and raw-evidence reporting only |
 | **Judge** *(retired — see note)* | fresh builders-model agent, read-only | checks-integrity review, diff-vs-intent, one graded-check spot-check |
 | **Watchdog** | deterministic script per wave; "monitor" informally | mechanical stall evidence only — never kills, never decides |
-| **Adversarial reviewer** | fresh strategist reviewer, pre-freeze | the stress-test pass (called the *grill* in earlier runs) falsifies the decomposition before it's authorized |
+| **Harden strategist** | fresh strategist, one dispatch pre-freeze | the adversarial attack (called the *grill* in earlier runs), the revised spec, issue decomposition, check drafting, and the self-run decomposition stress test |
 | **Cohesion reviewer** | fresh strategist subagent, once per run | read-only closing review over the whole run diff; verified findings become a review spec cut into fix issues for the fix wave, never a direct edit |
-| **Human** | you | spec approval, hard stops, taste |
+| **Human** | you | hard stops, ruling vetoes, taste |
 
 Note (human-directed, 2026-07): the per-issue Judge role was retired in
 favor of the closing cohesion review alone; the skill-library run removed it
@@ -176,38 +177,30 @@ advice. Tags like D4/P2 refer to the numbered decisions in
 architect-v5 and architect-v5.1 specs, and loop-improvements research
 (evidence: git history before the 2026-07-04 cleanup).
 
-### Intake and spec approval
+### Intake and spec hardening
 
-- **At most ~5 materiality-tested questions, in one batch (D3).** GitHub Spec
-  Kit's `/clarify` is the template: each question must pass "would the answer
-  materially change implementation or validation strategy?"; everything else
-  becomes a recorded `## Assumptions` section the human can veto. This is the
-  established middle path between maximal stress-testing and zero questions
-  ([Spec Kit](https://github.com/github/spec-kit);
-  evidence: autonomous-software-factory research, in git history before the
-  2026-07-04 cleanup).
-- **Spec approval is the one human step (D4).** The human reviews one
-  `docs/spec/<project>.md`, edits or vetoes assumptions, and approves.
-  Approval authorizes the entire plan — after it, the human hears from
-  the factory only through the tracking issue digest or a hard stop. Concentrating
-  human attention at the spec is where misdesign is cheapest to fix
-  ([PEAR](https://arxiv.org/abs/2510.07505): planner errors dominate).
-- **Approval is explicit, durable, and fail-safe.** The two approval forms
-  are in-session approval or an `APPROVE` comment on the tracking issue;
-  an invocation can also pre-authorize a run only when the exact
-  pre-authorization text is recorded verbatim. The evidence is the same shape
-  across deployment systems and agent products: GitHub environments auto-fail
-  unapproved runs after 30 days, Azure timeout-rejects approvals, OWASP
-  fail-safe defaults ban inferred allow, and Copilot treats assignment itself
-  as authorization. The 2026-07-03 human directive in the loop-tuning spec
-  (evidence: git history before the 2026-07-04 cleanup) overrides the earlier
-  park-and-poll product behavior: absent a human answer, wait about 5 minutes,
-  rule with the orchestrator's best judgment, record the ruling for
-  after-the-fact veto, and continue. Carve-out: irreversible or destructive
-  choices resolve to the non-destructive path on silence; `docs/STOP` remains
-  absolute
+- **No question batch and no spec approval (owner directive, 2026-07-07).**
+  Supersedes D3 (the ~5-question intake batch) and D4 (spec approval as the
+  one human step): the goal feeds a fresh strategist's spec draft directly,
+  every open question resolves through the timed-ruling protocol (~5-minute
+  auto-default, recorded, veto-able after the fact), and no approval gate
+  exists in either lane. The human steers by editing the spec, commenting
+  rulings, vetoing digests, or `docs/STOP`. D3/D4's rationale and citations
+  (Spec Kit, PEAR, GitHub environments, Azure, OWASP fail-safe defaults)
+  remain in git history; the timed-ruling carve-out is unchanged —
+  irreversible or destructive choices resolve to the non-destructive path on
+  silence, and `docs/STOP` remains absolute
   (evidence: factory-hardening research, in git history before the
-  2026-07-04 cleanup).
+  2026-07-04 cleanup; owner directive, flow respec, 2026-07-07).
+- **One harden dispatch replaces review–approve–decompose (owner directive,
+  2026-07-07).** A single fresh strategist runs the adversarial attack on
+  the draft, folds the surviving findings into a revised spec, decomposes it
+  with `to-issues`, drafts frozen checks, and stress-tests its own
+  decomposition before returning all drafts; the orchestrator rules,
+  publishes, and freezes. This collapses the former separate adversarial
+  spec review, human approval, strategist decomposition dispatch, and
+  pre-freeze stress pass into one fresh-context dispatch with the
+  orchestrator as the only gate.
 - **Preflight has no fallback.** A GitHub remote, passing `gh auth status`,
   and `gh` ≥ 2.94.0 are hard preconditions; failing any of them fails
   loudly rather than degrading to a local tracker (no silent fallback, P1).
@@ -308,15 +301,16 @@ architect-v5 and architect-v5.1 specs, and loop-improvements research
   [ImpossibleBench](https://arxiv.org/abs/2510.20270)), so builders get no
   iterate-against-the-judge feedback channel.
 - **Freeze → push → dispatch, then verify (v5.1 D2).** The factory branch
-  `factory/<run>` is cut at spec approval; the freeze commit is pushed
+  `factory/<run>` is cut at intake, when the spec draft returns; the freeze commit is pushed
   before any dispatch; after each spawn the orchestrator verifies the
   worktree HEAD equals the freeze commit and spot-checks one frozen file on
   disk. Motivated by a live finding: the first harness-created worktree had
   a fast-forwarded ref but stale files on disk (evidence:
   worktree-stale-snapshot solution, in git history before the 2026-07-04
   cleanup).
-- **One fresh independent adversarial pass attacks the whole decomposition (P2, widened by
-  v5.1 D3).** Before the freeze, a read-only adversarial agent executes
+- **The decomposition stress test executes before the freeze (P2, widened by
+  v5.1 D3; folded into the harden dispatch by the 2026-07-07 owner
+  directive).** The harden strategist executes
   draft check commands against the current tree, attacks acceptance criteria
   for non-falsifiability and repo-name grep collisions, sweeps references to
   files the plan deletes or renames, and checks new artifact paths against
@@ -508,12 +502,14 @@ runner's first live use finished 7/7.
   while the reverse hurt; the skill prefers Claude-reviews-Codex and records
   the direction in the verdict comment
   ([cross-provider review](https://www.mindstudio.ai/blog/openai-codex-plugin-claude-code-cross-provider-review)).
-- **Closing review is human-gated and read-only (review-fanout, 2026-07-06,
-  issue #137).** After the last build issue closes and before integrate, the
-  orchestrator asks through the timed-ruling protocol whether to run
-  a comprehensive review. The default is yes; if it runs, the reviewer is at
-  the resolved strategist model, reads spec -> diff, and edits
-  no product code and no tests. Zero verified findings return a GREEN verdict
+- **Closing review is unconditional and read-only (review-fanout,
+  2026-07-06, issue #137; the entry ruling was removed by the 2026-07-07
+  owner directive).** After the last build issue closes and before
+  integrate, the orchestrator runs the closing test pass — builder-built
+  suites plus every frozen RUN item at the factory branch head — and always
+  dispatches the reviewer with that raw output in its dispatch block. The
+  reviewer is at the resolved strategist model, reads spec -> diff ->
+  test-pass output, and edits no product code and no tests. Zero verified findings return a GREEN verdict
   and the run proceeds straight to integrate. One or more findings become a
   review spec — the findings as requirements — cut into fix issues with draft
   graded checks; the orchestrator freezes the checks, files the issues, and
@@ -571,8 +567,8 @@ runner's first live use finished 7/7.
   at most.
 - **Hard stops (D11).** the `docs/STOP` kill-all switch before any wave;
   `docs/runs/<run>/STOP` for one run; irreversible actions; two consecutive
-  KILLs; a blocker colliding with a recorded assumption (a spec-approval
-  decision surfacing late); scope growth beyond the approved spec;
+  KILLs; a blocker colliding with a recorded assumption (a spec-level
+  decision surfacing late); scope growth beyond the hardened spec;
   unsatisfiable preflight. All of them stop the factory and ask the human.
 
 ### Model routing
@@ -773,21 +769,24 @@ What it drops, and why the drops are safe at the size ceiling (≤3 issues,
 ~≤400 changed lines total):
 
 - **No frozen checks, no check-runner.** Issue-body acceptance criteria
-  plus builder-run tests plus the orchestrator's own review are the gates.
-  At ≤400 lines the orchestrator can hold the whole diff in mind for one
+  plus builder-run tests plus the closing builder review are the gates.
+  At ≤400 lines one reviewer can hold the whole diff in mind for one
   pass — the same line count already gates per-issue review effectiveness
   in `/architect` (§4, Decomposition, "Judged diffs target ≤~400 changed
   lines").
-- **No adversarial spec review.** At small scale the
-  orchestrator's own ≤3 materiality-tested questions plus recorded,
-  vetoable assumptions substitute; the size ceiling is the safety valve —
+- **No adversarial spec review.** At small scale the orchestrator's own
+  spec plus recorded, vetoable timed-ruling assumptions substitute; the
+  size ceiling is the safety valve —
   an honest decomposition needing more than 3 issues stops and recommends
   `/architect` instead of stretching the light lane past where it's safe.
 - **The review doctrine is relaxed, not the docs doctrine.** A deliberate,
-  recorded relaxation of Hard Rules 3 and 4: the orchestrator both reviews
-  its own run's diff (no fresh subagent) and writes the fixes directly (no
-  third-strike gate). The closing PR is the later eyes on that work — the
-  `integrate` subagent verifies mechanically but reviews no code
+  recorded relaxation of Hard Rules 3 and 4, reshaped by the 2026-07-07
+  owner directive: after the orchestrator's closing test pass, one fresh
+  builder subagent reviews the whole run diff with the test output in its
+  dispatch block, records its findings as one fix issue, and fixes them in
+  its own worktree with no check-runner over that work; the orchestrator
+  merges through postflight. The closing PR is the later eyes on that work
+  — the `integrate` subagent verifies mechanically but reviews no code
   correctness. Product docs still land in integrate's docs pass, the same
   never-the-orchestrator path as `/architect` (§4, Run mechanics and
   memory).
@@ -845,9 +844,10 @@ Full flow, the substitution table, and the recorded assumptions:
 - **Not just Goal Mode.** Codex's Goal Mode loops plan→act→test→review
   internally; this design adds what it lacks — frozen external checks, fresh
   cross-model judgment, issue-plan coordination, and repo-resident evidence.
-- **Not human-free.** Autonomy is bounded by spec approval at the front and
-  hard stops throughout; kill/continue authority inside the run belongs to
-  judges and hard-stop rules, and taste stays with the human.
+- **Not human-free.** Autonomy is bounded by timed rulings with recorded,
+  veto-able defaults and hard stops throughout; kill/continue authority
+  inside the run belongs to typed gates and hard-stop rules, and taste
+  stays with the human.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # architect-loop
 
-**A spec-approved autonomous software factory for Codex and Claude: one
-orchestrator, fresh-context strategist and builder agents, deterministic gates,
-and a single shipping PR or local finish record.**
+**An autonomous software factory for Codex and Claude: one orchestrator,
+fresh-context strategist and builder agents, deterministic gates,
+and a single shipping PR or local finish record — no approval gates,
+timed rulings all the way down.**
 
 ## Usage
 
@@ -14,7 +15,7 @@ and a single shipping PR or local finish record.**
 
 - `/architect-research` explores a topic and writes an answer-first report.
 - `/architect-fast` ships a small, bounded change through the light lane.
-- `/architect` runs the full multi-hour factory. Approve the spec, then let it work.
+- `/architect` runs the full multi-hour factory. State the goal, then let it work.
 
 ## Installation
 
@@ -63,12 +64,15 @@ report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
 
 ![architect flow](assets/architect-flow.svg)
 
-- Intake asks at most five materiality-tested questions, records assumptions,
-  drafts a spec, and runs an adversarial review before approval.
-- Spec approval is the one human gate: in-session approval, tracker `APPROVE`,
-  or timed 5-minute auto-approval with a recorded ruling.
-- The strategist decomposes the approved spec into file-disjoint vertical-slice
-  issues and frozen checks. Checks freeze in git before any builder exists.
+- Intake feeds the goal straight to a fresh strategist that drafts the spec;
+  open questions become timed rulings that auto-default into recorded
+  assumptions. There is no human approval gate anywhere — the human steers
+  by editing the spec, commenting rulings, or `docs/STOP`.
+- One fresh harden strategist attacks the draft, folds surviving findings
+  into a revised spec, decomposes it into file-disjoint vertical-slice
+  issues, drafts frozen checks, and stress-tests its own decomposition.
+- The orchestrator publishes the spec and issues to the tracker and owns the
+  freeze commit. Checks freeze in git before any builder exists.
 - The run manifest pins the tracking issue, tracker mode, factory branch, and
   spec path; every issue carries a run marker.
 - Builders run in fresh worktrees. They must state disagreements before coding,
@@ -82,7 +86,9 @@ report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
 - The check-runner grades frozen RUN items with fixed expectations. Postflight
   audits touched files, merges green jobs, and records deferred cleanup if a
   worktree cannot be removed immediately.
-- The final review is one fresh, read-only strategist pass over the whole run.
+- At finish the orchestrator runs the closing test pass — builder-built
+  suites plus every frozen RUN item — and feeds the raw output into the
+  final review: one fresh, read-only strategist pass over the whole run.
   Findings become fix issues and draft checks for a fix wave; zero findings
   short-circuit to integrate.
 - `integrate` is a builder-model stage whose first step is the docs pass. It
@@ -97,13 +103,15 @@ report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
   three builder issues and roughly 400 changed lines.
 - No strategist subagents, no adversarial review, no frozen checks, no
   per-issue check-runner, and no watchdog script. Issue-body acceptance
-  criteria, builder-run tests, and the orchestrator review carry the gate.
+  criteria, builder-run tests, and the closing builder review carry the gate.
 - Each job records its dispatch-head SHA; that SHA is the postflight diff base
   in place of a freeze SHA.
 - One per-wave timed fallback wake replaces watchdog monitoring.
-- After all issues merge, the orchestrator reviews code, cohesion, and tests,
-  makes any fixes directly, records the verdict and diffstat, then dispatches
-  `integrate`.
+- After all issues merge, the orchestrator runs the full test suite and hands
+  the output to one fresh builder subagent that reviews code, cohesion, and
+  tests, records its findings as one fix issue, and fixes them in its
+  worktree; the orchestrator merges, records the verdict and diffstat, then
+  dispatches `integrate`.
 - If the work exceeds the size ceiling, the lane stops and recommends
   `/architect`.
 

--- a/assets/architect-fast-flow.svg
+++ b/assets/architect-fast-flow.svg
@@ -5,7 +5,7 @@
   <rect width="1000" height="900" fill="#ffffff"/>
 
   <text x="45" y="42" font-size="20" font-weight="700" fill="#0f172a">/architect-fast</text>
-  <text x="215" y="42" font-size="12" fill="#64748b">spec -> approve -> &lt;=3 issues -> builders -> timed wake -> orchestrator review -> integrate -> PR</text>
+  <text x="215" y="42" font-size="12" fill="#64748b">spec -> publish -> &lt;=3 issues -> builders -> timed wake -> test pass -> builder review -> integrate -> PR</text>
 
   <line x1="390" y1="126" x2="390" y2="160" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <line x1="390" y1="222" x2="390" y2="256" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
@@ -13,14 +13,14 @@
 
   <rect x="230" y="70" width="320" height="56" rx="8" fill="#7c3aed"/>
   <text x="390" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
-  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator writes it; &lt;=3 questions</text>
-  <text x="585" y="90" font-size="11" fill="#475569">Same approval doctrine as /architect, but no</text>
-  <text x="585" y="104" font-size="11" fill="#475569">strategist or adversarial review in this lane.</text>
+  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator writes it; no question batch</text>
+  <text x="585" y="90" font-size="11" fill="#475569">No approval gate, and no strategist or</text>
+  <text x="585" y="104" font-size="11" fill="#475569">adversarial review in this lane.</text>
 
-  <rect x="230" y="166" width="320" height="56" rx="8" fill="#d97706"/>
-  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">APPROVE</text>
-  <text x="390" y="207" font-size="10.5" fill="#fef3c7" text-anchor="middle">one human step; timed auto-ruling on silence</text>
-  <text x="585" y="186" font-size="11" fill="#475569">Approval creates the run manifest and cuts the</text>
+  <rect x="230" y="166" width="320" height="56" rx="8" fill="#7c3aed"/>
+  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">PUBLISH</text>
+  <text x="390" y="207" font-size="10.5" fill="#ede9fe" text-anchor="middle">tracking issue + manifest; no approval gate</text>
+  <text x="585" y="186" font-size="11" fill="#475569">Publishing creates the run manifest and cuts the</text>
   <text x="585" y="200" font-size="11" fill="#475569">factory branch, just like the full lane.</text>
 
   <rect x="230" y="262" width="320" height="56" rx="8" fill="#7c3aed"/>
@@ -63,18 +63,18 @@
   <text x="585" y="624" font-size="11" fill="#475569">liveness is judged from reports and mtimes.</text>
 
   <line x1="390" y1="646" x2="390" y2="680" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
-  <rect x="230" y="688" width="320" height="56" rx="8" fill="#7c3aed"/>
-  <text x="390" y="711" font-size="14.5" font-weight="700" fill="#ffffff" text-anchor="middle">ORCHESTRATOR REVIEW</text>
-  <text x="390" y="729" font-size="10.5" fill="#ede9fe" text-anchor="middle">code, cohesion, tests; fixes made directly</text>
-  <text x="585" y="708" font-size="11" fill="#475569">The review verdict and diffstat are recorded</text>
-  <text x="585" y="722" font-size="11" fill="#475569">on the tracking issue before integrate.</text>
+  <rect x="230" y="688" width="320" height="56" rx="8" fill="#0d9488"/>
+  <text x="390" y="711" font-size="14.5" font-weight="700" fill="#ffffff" text-anchor="middle">TEST PASS + BUILDER REVIEW</text>
+  <text x="390" y="729" font-size="10.5" fill="#ccfbf1" text-anchor="middle">orchestrator runs the suite; fresh builder reviews + fixes</text>
+  <text x="585" y="708" font-size="11" fill="#475569">The builder files one fix issue, fixes it in its</text>
+  <text x="585" y="722" font-size="11" fill="#475569">worktree; verdict + diffstat land on the tracker.</text>
 
   <line x1="390" y1="744" x2="390" y2="778" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <rect x="230" y="786" width="320" height="56" rx="8" fill="#0d9488"/>
   <text x="390" y="809" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">INTEGRATE</text>
   <text x="390" y="827" font-size="10.5" fill="#ccfbf1" text-anchor="middle">docs pass, validation, PR or markdown finish</text>
-  <text x="585" y="806" font-size="11" fill="#475569">The orchestrator-review verdict stands in for</text>
-  <text x="585" y="820" font-size="11" fill="#475569">the full-lane final-review gate.</text>
+  <text x="585" y="806" font-size="11" fill="#475569">The builder-review verdict stands in for</text>
+  <text x="585" y="820" font-size="11" fill="#475569">the full-lane final review.</text>
 
   <line x1="390" y1="842" x2="390" y2="868" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <rect x="230" y="874" width="320" height="16" rx="8" fill="#16a34a"/>
@@ -85,6 +85,4 @@
   <text x="193" y="860" font-size="11" fill="#475569">builders + integrate</text>
   <rect x="355" y="850" width="12" height="12" rx="3" fill="#64748b"/>
   <text x="373" y="860" font-size="11" fill="#475569">light-lane mechanics</text>
-  <rect x="555" y="850" width="12" height="12" rx="3" fill="#d97706"/>
-  <text x="573" y="860" font-size="11" fill="#475569">human approval</text>
 </svg>

--- a/assets/architect-flow.svg
+++ b/assets/architect-flow.svg
@@ -7,7 +7,7 @@
   <rect width="1000" height="1080" fill="#ffffff"/>
 
   <text x="45" y="42" font-size="20" font-weight="700" fill="#0f172a">/architect</text>
-  <text x="165" y="42" font-size="12" fill="#64748b">spec -> adversarial review -> frozen checks -> wrapped builders -> typed gates -> final review -> fix wave -> integrate -> PR</text>
+  <text x="165" y="42" font-size="12" fill="#64748b">spec -> harden -> frozen checks -> wrapped builders -> typed gates -> test pass -> final review -> fix wave -> integrate -> PR</text>
 
   <line x1="390" y1="126" x2="390" y2="160" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <line x1="390" y1="222" x2="390" y2="256" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
@@ -15,19 +15,19 @@
 
   <rect x="230" y="70" width="320" height="56" rx="8" fill="#7c3aed"/>
   <text x="390" y="93" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">SPEC</text>
-  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">strategist draft; &lt;=5 questions; human approval</text>
-  <text x="585" y="90" font-size="11" fill="#475569">Only material questions are asked. Assumptions and</text>
-  <text x="585" y="104" font-size="11" fill="#475569">timed rulings are recorded on the tracker.</text>
+  <text x="390" y="111" font-size="10.5" fill="#ede9fe" text-anchor="middle">strategist draft; no question batch, no approval gate</text>
+  <text x="585" y="90" font-size="11" fill="#475569">Open questions become timed rulings that</text>
+  <text x="585" y="104" font-size="11" fill="#475569">auto-default; assumptions land on the tracker.</text>
 
   <rect x="230" y="166" width="320" height="56" rx="8" fill="#7c3aed"/>
-  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ADVERSARIAL REVIEW</text>
-  <text x="390" y="207" font-size="10.5" fill="#ede9fe" text-anchor="middle">fresh strategist attacks the spec</text>
-  <text x="585" y="186" font-size="11" fill="#475569">Bad plans die before dispatch. Surviving findings</text>
-  <text x="585" y="200" font-size="11" fill="#475569">are folded into the spec before approval.</text>
+  <text x="390" y="189" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">HARDEN</text>
+  <text x="390" y="207" font-size="10.5" fill="#ede9fe" text-anchor="middle">fresh strategist attacks, revises, decomposes</text>
+  <text x="585" y="186" font-size="11" fill="#475569">Bad plans die before dispatch. One dispatch returns</text>
+  <text x="585" y="200" font-size="11" fill="#475569">the revised spec, issue drafts, and check drafts.</text>
 
   <rect x="230" y="262" width="320" height="56" rx="8" fill="#7c3aed"/>
   <text x="390" y="285" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">ISSUES + FROZEN CHECKS</text>
-  <text x="390" y="303" font-size="10.5" fill="#ede9fe" text-anchor="middle">file-disjoint slices; checks frozen in git</text>
+  <text x="390" y="303" font-size="10.5" fill="#ede9fe" text-anchor="middle">orchestrator publishes; checks frozen in git</text>
   <text x="585" y="282" font-size="11" fill="#475569">Manifest pins run identity. Run markers protect</text>
   <text x="585" y="296" font-size="11" fill="#475569">against foreign sub-issues and sibling runs.</text>
 
@@ -88,7 +88,7 @@
   <line x1="390" y1="798" x2="390" y2="832" stroke="#334155" stroke-width="2.5" marker-end="url(#arr)"/>
   <rect x="230" y="840" width="320" height="56" rx="8" fill="#7c3aed"/>
   <text x="390" y="863" font-size="15" font-weight="700" fill="#ffffff" text-anchor="middle">FINAL REVIEW</text>
-  <text x="390" y="881" font-size="10.5" fill="#ede9fe" text-anchor="middle">read-only strategist; GREEN or FINDINGS</text>
+  <text x="390" y="881" font-size="10.5" fill="#ede9fe" text-anchor="middle">read-only strategist fed the closing test pass; GREEN or FINDINGS</text>
   <text x="585" y="860" font-size="11" fill="#475569">Findings become a review spec, fix issues, and</text>
   <text x="585" y="874" font-size="11" fill="#475569">draft checks. The reviewer never edits code.</text>
 

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -2,19 +2,20 @@
 name: adversarial-review
 description: >
   Use when the architect factory orchestrator dispatches a fresh strategist
-  subagent to falsify a draft spec before decomposition, or a frozen decomposition
-  (issues plus checks) before dispatch. Attacks the plan with file:line
-  evidence; never edits the spec, an issue, or a check.
+  subagent to harden a draft spec: falsify it with file:line evidence, fold
+  the surviving findings into a revised spec, decompose it (issues plus
+  checks), and stress-test its own decomposition before returning all
+  drafts. Never commits, touches the tracker, or edits product code.
 effort: high
 ---
 
 # Adversarial Review
 
-You are a fresh reviewer with no stake in this plan surviving. Break it,
-don't improve it. Every finding is a verdict — `<item>: FALSIFIED | HOLDS`
-with evidence — returned to the orchestrator, which alone decides what to
-apply. You read and you write findings; you never touch the artifacts.
-Findings use the codebase-design vocabulary
+You are a fresh strategist with no stake in this plan surviving. Break it
+first; rebuild only from what the attack proves. Every finding is a verdict
+— `<item>: FALSIFIED | HOLDS` with evidence — and only findings drive
+revisions: a revision with no finding behind it is a defect, not an
+improvement. Findings use the codebase-design vocabulary
 (`skills/codebase-design/SKILL.md`) — a plan that drifts from it is itself
 a finding.
 
@@ -22,7 +23,7 @@ a finding.
 
 Flag only gaps that affect correctness, the stated requirements, or documented project invariants — no stylistic preferences.
 
-## Target 1: spec review (post-/to-spec)
+## Stage 1: spec attack (post-/to-spec)
 
 Attack the draft spec on its own terms:
 
@@ -38,9 +39,18 @@ Attack the draft spec on its own terms:
 
 Every finding quotes the claim or cites the spec file:line.
 
-## Target 2: decomposition stress test (post-/to-issues + /frozen-checks, pre-freeze)
+## Stage 2: revise and decompose
 
-Execute reality against the frozen plan; reading it is not enough:
+Only after the attack is exhausted: fold each FALSIFIED finding's fix into
+a revised spec on `to-spec`'s exact template — evidence-backed revisions
+only — and record what survived unevidenced under `## Assumptions`. Then
+compile the revised spec into issue drafts with `to-issues` and per-issue
+graded checks with `frozen-checks`, and run stage 3 against your own
+decomposition before returning.
+
+## Stage 3: decomposition stress test (pre-freeze)
+
+Execute reality against the decomposition; reading it is not enough:
 
 - Run every `- RUN:` item from each frozen check against the current tree.
   A mechanical check with no `->` expectation is itself a check defect.
@@ -58,18 +68,20 @@ Execute reality against the frozen plan; reading it is not enough:
 
 ## Reporting
 
-Return a flat findings list to the orchestrator, one line per item:
+Return to the orchestrator: the revised spec path, the issue-draft and
+check-draft paths, and a flat findings ledger, one line per item:
 `<check id, clause, or claim>: FALSIFIED | HOLDS` plus the command output
-or quoted evidence behind it. Close with any assumptions that survived
-review unevidenced. Do not summarize, encourage, or soften a finding — the
-orchestrator applies or discards each one; you decide nothing.
+or quoted evidence behind it, so every revision traces to its finding.
+Close with any assumptions that survived review unevidenced. Do not
+summarize, encourage, or soften a finding.
 
 ## Boundary
 
-You never edit the spec, an issue, or a check — not even a one-word fix,
-not even a finding you're certain about. Findings only. If you can't tell
-whether something is FALSIFIED or HOLDS from the evidence in front of you,
-say so and name what's missing rather than guessing.
+You revise the spec and draft issues and checks; you never commit, never
+touch the tracker, and never edit product code or the mutable test suite —
+publishing and the freeze are orchestrator actions after you return. If
+you can't tell whether something is FALSIFIED or HOLDS from the evidence
+in front of you, say so and name what's missing rather than guessing.
 
 ## Vocabulary
 

--- a/skills/architect-fast/SKILL.md
+++ b/skills/architect-fast/SKILL.md
@@ -18,137 +18,120 @@ PR — with the per-issue grading machinery removed. Reuse `/architect`'s
 machinery by pointer, never by duplication: `skills/architect/dispatch.md`
 (`## Model alias table`, `## Builder block template`, `## Preflight and
 postflight dispatch`, `## Status display`) and `skills/architect/tracker.md`
-(`## Config`) govern models, dispatch, merges, status, and tracker modes
-exactly as in `/architect`, except where a substitution below names a
-deviation.
+(`## Config`) govern models, dispatch, merges, status, and tracker modes,
+except where a substitution below names a deviation.
 
-## Size ceiling
-
-The size ceiling: at most 3 builder issues and ~400 changed lines expected.
-If the honest decomposition needs more, stop and recommend `/architect`
-instead — a hard stop, human ruling, never silently absorbed into a bigger
-run.
+Size ceiling: at most 3 builder issues and ~400 changed lines expected. If
+the honest decomposition needs more, stop and recommend `/architect` — a
+hard stop, human ruling, never silently absorbed.
 
 ## Rules kept
 
 Unchanged from `/architect`: the tracking issue is the coordination log;
 builders are fresh, worktree-isolated, and never commit; the orchestrator
-owns commits, merges, and closure; tier is set at decomposition, never moved
-by a failure; the timed-ruling protocol times every human question and no
-approval gate exists anywhere; disagreement is mandatory at PHASE 0; no
-silent fallback — every precondition, blocker, and substitution is recorded.
+owns commits, merges, and closure; tier is set at decomposition, never
+moved by a failure; the timed-ruling protocol times every human question
+and no approval gate exists anywhere; disagreement is mandatory at PHASE 0;
+no silent fallback — every precondition, blocker, and substitution is
+recorded.
 
 ## Relaxed by design
 
 - No strategist subagents — no adversarial spec, decomposition, or final
   review. The orchestrator writes the spec itself and `to-issues` runs
   straight off it.
-- The fast lane's gates: no frozen check files, no check-runner —
-  issue-body acceptance criteria, builder-run tests, and the orchestrator
-  review carry the weight instead.
+- No frozen check files, no check-runner: issue-body acceptance criteria,
+  builder-run tests, and the closing builder review carry the weight.
 - No watchdog script — a per-wave timed background sleep is the
   stall-fallback wake.
-- The review doctrine ("nobody grades their own work") is deliberately
-  relaxed alongside Hard Rules 3 and 4: the closing review is one fresh
-  builder subagent that both reviews and fixes, with no check-runner over
-  its work — the orchestrator's merge through postflight and the closing
-  PR are the later eyes. Product docs land in integrate's docs pass, same
-  as `/architect`.
+- "Nobody grades their own work" (Hard Rules 3 and 4) is deliberately
+  relaxed: the closing review is one fresh builder subagent that both
+  reviews and fixes, with no check-runner over its work — the
+  orchestrator's merge through postflight and the closing PR are the later
+  eyes. Product docs land in integrate's docs pass, same as `/architect`.
 
 ## Procedure
 
 1. **Ground.** Load `codebase-design` first and use its glossary exactly.
-   Read authority docs in `/architect`'s order. Tracker preflight per mode
-   and the backend canary are unchanged from `/architect`
-   (`skills/architect/tracker.md` `## Preflight per mode`). No ground
-   script mid-run: `ground.ps1|.sh`'s reconcile assumes frozen-check and
-   checkrun evidence this lane never produces and would exit DRIFT on every
-   wake; read the (≤3-issue) frontier directly from tracker state instead.
-   `skills/architect/status.ps1|.sh` works unchanged for status requests.
+   Read authority docs in `/architect`'s order. Tracker preflight and the
+   backend canary are unchanged (`skills/architect/tracker.md`
+   `## Preflight per mode`). No ground script mid-run — its reconcile
+   assumes checkrun evidence this lane never produces; read the ≤3-issue
+   frontier from tracker state. `skills/architect/status.ps1|.sh` works
+   unchanged.
 
 2. **Intake.** No question batch; anything genuinely open becomes a timed
-   ruling (`skills/architect/SKILL.md` `## Timed-ruling protocol`) that
-   auto-defaults into a recorded assumption. No adversarial spec review.
-   Write the spec with `to-spec` on its exact template, one named
-   substitution: the `## Validation strategy` section names the fast
-   lane's actual gates — builder-run tests plus the closing builder
-   review-and-fix — instead of the check-runner and closing review.
+   ruling (`skills/architect/SKILL.md` `## Timed-ruling protocol`) recorded
+   as an assumption. No adversarial spec review. Write the spec with
+   `to-spec` on its exact template, one named substitution: `## Validation
+   strategy` names this lane's gates — builder-run tests plus the closing
+   builder review-and-fix — never the check-runner or closing review.
    Create the tracking issue and manifest; cut the factory branch.
 
 3. **Decompose.** `to-issues` cuts at most 3 tracer-bullet vertical-slice
-   issues with a file-disjoint parallel frontier and producer interface
-   contracts, two named substitutions: each issue body carries an
-   acceptance-criteria section in place of a check path, and the
-   change-skeleton is optional. Above the size ceiling, stop and recommend
-   `/architect` instead of absorbing the extra issues.
+   issues with a file-disjoint frontier and producer interface contracts,
+   two named substitutions: an acceptance-criteria section replaces the
+   check path, and the change-skeleton is optional. Above the ceiling,
+   stop and recommend `/architect`.
 
-4. **Factory loop.** Dispatch every ready issue as a fresh worktree-isolated
-   builder — same agent def, preloads, model resolution, never-commit rule,
-   PHASE-0 disagreements, raw-evidence reports
-   (`skills/architect/dispatch.md` `## Builder block template`), one named
-   substitution: its frozen-checks section becomes acceptance criteria
+4. **Factory loop.** Dispatch every ready issue as a fresh
+   worktree-isolated builder — same agent def, preloads, model resolution,
+   never-commit rule, PHASE-0 disagreements, raw-evidence reports
+   (`skills/architect/dispatch.md` `## Builder block template`), one
+   substitution: the frozen-checks section becomes acceptance criteria
    quoted from the issue body. At dispatch, record each job's
-   dispatch-head SHA on its issue — that SHA is the job's ffcheck target
-   and the postflight base (`freeze_sha` field, same touch-set-diff-base
-   and merge-guard semantics). No watchdog script: each wave arms one
-   timed background sleep as the stall-fallback wake; on a fallback wake
-   with jobs still in flight, judge liveness from report growth and
-   process activity directly. On DONE, merge through postflight
-   (`skills/architect/dispatch.md` `## Preflight and postflight dispatch`).
-   The size ceiling, not backend capacity, is the active cap here; the shared
-   dispatch cap remains 10 CLI-launched jobs or 5 harness-native subagents.
-   On BLOCKED, answer durably and respawn fresh, unchanged.
+   dispatch-head SHA on its issue — the job's ffcheck target and
+   postflight base (`freeze_sha` field, same semantics). Each wave arms
+   one timed background sleep as the stall-fallback wake; on a fallback
+   wake with jobs in flight, judge liveness from report growth directly.
+   On DONE, merge through postflight (`skills/architect/dispatch.md`
+   `## Preflight and postflight dispatch`). On BLOCKED, answer durably and
+   respawn fresh.
 
-5. **Closing test pass.** After all issues merge, the orchestrator runs the
-   full test suite over the merged factory branch and captures the raw
-   output for the reviewer.
+5. **Closing test pass.** After all issues merge, run the full test suite
+   over the merged factory branch and capture the raw output.
 
-6. **Builder review.** Dispatch one fresh worktree-isolated builder
-   subagent with the run diff scope, the test-pass output, and the same
-   calibration wording as `/architect`: "Flag only gaps that affect
-   correctness, the stated requirements, or documented project invariants
-   -- cite file:line evidence for every finding. Do not report stylistic
-   preferences." It does the complete review — code correctness,
-   cross-slice cohesion, test stewardship — records its findings as one
-   fix issue (orchestrator-filed where the job sandbox has no tracker
-   access), then fixes them in its worktree. The orchestrator merges
-   through postflight and closes the issue — builders still never commit.
-   This is the fast lane's only review — fast-lane-only vocabulary, never
-   part of `/architect`'s flow. The verdict plus diffstat is posted on the
-   tracking issue.
+6. **Builder review.** Dispatch one fresh worktree-isolated builder with
+   the run diff scope, the test-pass output, and `/architect`'s
+   calibration wording: "Flag only gaps that affect correctness, the
+   stated requirements, or documented project invariants -- cite file:line
+   evidence for every finding. Do not report stylistic preferences." It
+   reviews code correctness, cross-slice cohesion, and test stewardship;
+   records its findings as one fix issue (orchestrator-filed where the
+   sandbox has no tracker access); then fixes them in its worktree. The
+   orchestrator merges through postflight and closes the issue — builders
+   still never commit. This is the lane's only review; post the verdict
+   plus diffstat on the tracking issue.
 
-7. **Integrate.** Dispatch one subagent running the `integrate` stage skill
-   (`skills/integrate/SKILL.md`) with the change-context digest in its
-   dispatch block; its first step is the docs pass, same as `/architect`.
-   Standing fast-lane ruling: the builder-review verdict is the
-   recorded final-review substitute — the "skipped by a recorded ruling"
-   arm of integrate's precondition — and integrate's graded-RUN
-   verification set is empty by design; its validator-suite verification
-   still runs. The orchestrator rules on the result and posts the digest.
+7. **Integrate.** Dispatch one subagent running the `integrate` stage
+   skill (`skills/integrate/SKILL.md`) with the change-context digest; its
+   first step is the docs pass. Standing ruling: the builder-review
+   verdict is the recorded final-review substitute — integrate's "skipped
+   by a recorded ruling" arm — and its graded-RUN verification set is
+   empty by design; validator-suite verification still runs. The
+   orchestrator rules on the result and posts the digest.
 
-Stage skills invoked explicitly: `codebase-design`, `to-spec`
-(`skills/to-spec/SKILL.md`), `to-issues` (`skills/to-issues/SKILL.md`), and
-`integrate` (`skills/integrate/SKILL.md`). `frozen-checks`,
-`adversarial-review`, and `final-review` are intentionally not invoked in
-this lane, to prevent description-trigger drift.
+Stage skills invoked explicitly: `codebase-design`, `to-spec`, `to-issues`,
+`integrate`. `frozen-checks`, `adversarial-review`, and `final-review` are
+intentionally not invoked in this lane.
 
 ## Substitutions
 
 | Reused contract | Fast-lane substitution |
 |---|---|
-| `to-spec`'s validation-strategy naming instruction | Names builder-run tests + the closing builder review-and-fix, never the check-runner or `/architect`'s closing review |
-| `to-issues`' per-issue check path | An acceptance-criteria section quoted in the issue body |
-| `to-issues`' mandatory change-skeleton | Optional (the size-ceiling carve-out) |
-| The builder dispatch template's frozen-checks section | Acceptance criteria quoted from the issue body |
+| `to-spec`'s validation-strategy naming | Builder-run tests + the closing builder review-and-fix |
+| `to-issues`' per-issue check path | Acceptance-criteria section in the issue body |
+| `to-issues`' mandatory change-skeleton | Optional |
+| Builder template's frozen-checks section | Acceptance criteria quoted from the issue body |
 | Postflight's `freeze_sha` diff base | The job's recorded dispatch-head SHA |
-| The ground script's frontier line | Read directly from tracker state; no ground script mid-run |
-| The watchdog's typed stall detection | One per-wave timed background sleep as the stall-fallback wake |
-| Final review | One fresh builder review-and-fix subagent fed the closing test-pass output — code, cohesion, and test axes; fixes merge through postflight |
-| Integrate's graded-RUN verification set | Empty by design; its validator-suite verification still runs |
+| Ground script's frontier line | Read from tracker state; no ground script mid-run |
+| Watchdog | One per-wave timed background sleep |
+| Final review | One fresh builder review-and-fix subagent fed the test-pass output; fixes merge through postflight |
+| Integrate's graded-RUN verification set | Empty by design; validator-suite verification still runs |
 
 ## Maintenance
 
-Re-read against each new model generation; delete what models now do
-unprompted — the size ceiling and Rules kept are invariants, everything
-else is prunable. Re-run `docs/evals/trigger-prompts.md` per generation. No
-feature ships without evidence in `DESIGN.md`.
+Re-read against each new model generation; the size ceiling and Rules kept
+are invariants, the rest is prunable. Re-run
+`docs/evals/trigger-prompts.md`. No feature ships without evidence in
+`DESIGN.md`.

--- a/skills/architect-fast/SKILL.md
+++ b/skills/architect-fast/SKILL.md
@@ -3,9 +3,9 @@ name: architect-fast
 description: >
   Use when the user asks to architect-fast a change, run the light factory
   lane, or factory-build a small goal — a few files, roughly one sitting, at
-  most ~3 parallel issues — into a spec-approved plan with parallel
-  builders, one orchestrator-performed closing review, and a single PR. Same
-  loop shape as /architect with the per-issue grading machinery removed; for
+  most ~3 parallel issues — into a specced plan with parallel builders, one
+  builder-performed closing review-and-fix, and a single PR. Same loop
+  shape as /architect with the per-issue grading machinery removed; for
   larger, riskier, or many-issue work use /architect instead.
 effort: high
 ---
@@ -34,25 +34,26 @@ run.
 Unchanged from `/architect`: the tracking issue is the coordination log;
 builders are fresh, worktree-isolated, and never commit; the orchestrator
 owns commits, merges, and closure; tier is set at decomposition, never moved
-by a failure; the timed-ruling protocol times every human question; the one
-human step is spec approval; disagreement is mandatory at PHASE 0; no
+by a failure; the timed-ruling protocol times every human question and no
+approval gate exists anywhere; disagreement is mandatory at PHASE 0; no
 silent fallback — every precondition, blocker, and substitution is recorded.
 
 ## Relaxed by design
 
 - No strategist subagents — no adversarial spec, decomposition, or final
-  review. Intake is at most ~3 questions and `to-issues` runs straight off
-  the approved spec.
+  review. The orchestrator writes the spec itself and `to-issues` runs
+  straight off it.
 - The fast lane's gates: no frozen check files, no check-runner —
   issue-body acceptance criteria, builder-run tests, and the orchestrator
   review carry the weight instead.
 - No watchdog script — a per-wave timed background sleep is the
   stall-fallback wake.
 - The review doctrine ("nobody grades their own work") is deliberately
-  relaxed alongside Hard Rules 3 and 4: the orchestrator itself reads the
-  whole run diff, does the code, cohesion, and test review, and writes the
-  fixes directly. The closing PR is the later eyes on that work. Product
-  docs land in integrate's docs pass, same as `/architect`.
+  relaxed alongside Hard Rules 3 and 4: the closing review is one fresh
+  builder subagent that both reviews and fixes, with no check-runner over
+  its work — the orchestrator's merge through postflight and the closing
+  PR are the later eyes. Product docs land in integrate's docs pass, same
+  as `/architect`.
 
 ## Procedure
 
@@ -65,27 +66,23 @@ silent fallback — every precondition, blocker, and substitution is recorded.
    wake; read the (≤3-issue) frontier directly from tracker state instead.
    `skills/architect/status.ps1|.sh` works unchanged for status requests.
 
-2. **Intake.** At most ~3 materiality-tested questions via the timed-ruling
-   protocol (`skills/architect/SKILL.md` `### 2. Spec Approval`). No
-   adversarial spec review. Write the spec with `to-spec` on its exact
-   template, one named substitution: the `## Validation strategy` section
-   names the fast lane's actual gates — builder-run tests plus the
-   orchestrator review — instead of the check-runner and closing review.
-   Create the tracking issue and manifest; cut the factory branch on
-   approval.
+2. **Intake.** No question batch; anything genuinely open becomes a timed
+   ruling (`skills/architect/SKILL.md` `## Timed-ruling protocol`) that
+   auto-defaults into a recorded assumption. No adversarial spec review.
+   Write the spec with `to-spec` on its exact template, one named
+   substitution: the `## Validation strategy` section names the fast
+   lane's actual gates — builder-run tests plus the closing builder
+   review-and-fix — instead of the check-runner and closing review.
+   Create the tracking issue and manifest; cut the factory branch.
 
-3. **Spec approval.** Identical to `/architect`: the one human step, three
-   recorded forms — in-session, tracking-issue comment, or the timed
-   5-minute auto-APPROVE on silence.
-
-4. **Decompose.** `to-issues` cuts at most 3 tracer-bullet vertical-slice
+3. **Decompose.** `to-issues` cuts at most 3 tracer-bullet vertical-slice
    issues with a file-disjoint parallel frontier and producer interface
    contracts, two named substitutions: each issue body carries an
    acceptance-criteria section in place of a check path, and the
    change-skeleton is optional. Above the size ceiling, stop and recommend
    `/architect` instead of absorbing the extra issues.
 
-5. **Factory loop.** Dispatch every ready issue as a fresh worktree-isolated
+4. **Factory loop.** Dispatch every ready issue as a fresh worktree-isolated
    builder — same agent def, preloads, model resolution, never-commit rule,
    PHASE-0 disagreements, raw-evidence reports
    (`skills/architect/dispatch.md` `## Builder block template`), one named
@@ -102,21 +99,28 @@ silent fallback — every precondition, blocker, and substitution is recorded.
    dispatch cap remains 10 CLI-launched jobs or 5 harness-native subagents.
    On BLOCKED, answer durably and respawn fresh, unchanged.
 
-6. **Orchestrator review.** After all issues merge, the orchestrator itself
-   reviews the entire run diff — code correctness, cross-slice cohesion,
-   and test stewardship — using the same calibration wording as
-   `/architect`: "Flag only gaps that affect correctness, the stated
-   requirements, or documented project invariants -- cite file:line
-   evidence for every finding. Do not report stylistic preferences." It
-   makes the fixes directly, runs the named test suites, and commits its
-   own work. This is the fast lane's only review — fast-lane-only
-   vocabulary, never part of `/architect`'s flow. The verdict plus
-   diffstat is posted on the tracking issue.
+5. **Closing test pass.** After all issues merge, the orchestrator runs the
+   full test suite over the merged factory branch and captures the raw
+   output for the reviewer.
+
+6. **Builder review.** Dispatch one fresh worktree-isolated builder
+   subagent with the run diff scope, the test-pass output, and the same
+   calibration wording as `/architect`: "Flag only gaps that affect
+   correctness, the stated requirements, or documented project invariants
+   -- cite file:line evidence for every finding. Do not report stylistic
+   preferences." It does the complete review — code correctness,
+   cross-slice cohesion, test stewardship — records its findings as one
+   fix issue (orchestrator-filed where the job sandbox has no tracker
+   access), then fixes them in its worktree. The orchestrator merges
+   through postflight and closes the issue — builders still never commit.
+   This is the fast lane's only review — fast-lane-only vocabulary, never
+   part of `/architect`'s flow. The verdict plus diffstat is posted on the
+   tracking issue.
 
 7. **Integrate.** Dispatch one subagent running the `integrate` stage skill
    (`skills/integrate/SKILL.md`) with the change-context digest in its
    dispatch block; its first step is the docs pass, same as `/architect`.
-   Standing fast-lane ruling: the orchestrator-review verdict is the
+   Standing fast-lane ruling: the builder-review verdict is the
    recorded final-review substitute — the "skipped by a recorded ruling"
    arm of integrate's precondition — and integrate's graded-RUN
    verification set is empty by design; its validator-suite verification
@@ -132,14 +136,14 @@ this lane, to prevent description-trigger drift.
 
 | Reused contract | Fast-lane substitution |
 |---|---|
-| `to-spec`'s validation-strategy naming instruction | Names builder-run tests + the orchestrator review, never the check-runner or closing review |
+| `to-spec`'s validation-strategy naming instruction | Names builder-run tests + the closing builder review-and-fix, never the check-runner or `/architect`'s closing review |
 | `to-issues`' per-issue check path | An acceptance-criteria section quoted in the issue body |
 | `to-issues`' mandatory change-skeleton | Optional (the size-ceiling carve-out) |
 | The builder dispatch template's frozen-checks section | Acceptance criteria quoted from the issue body |
 | Postflight's `freeze_sha` diff base | The job's recorded dispatch-head SHA |
 | The ground script's frontier line | Read directly from tracker state; no ground script mid-run |
 | The watchdog's typed stall detection | One per-wave timed background sleep as the stall-fallback wake |
-| Final review | The orchestrator review — code, cohesion, and test axes, fixes made directly |
+| Final review | One fresh builder review-and-fix subagent fed the closing test-pass output — code, cohesion, and test axes; fixes merge through postflight |
 | Integrate's graded-RUN verification set | Empty by design; its validator-suite verification still runs |
 
 ## Maintenance

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -2,7 +2,7 @@
 name: architect
 description: >
   Use when the user asks to architect, run or continue the autonomous software
-  factory, turn a goal into a spec-approved tracker issue plan, dispatch builder
+  factory, turn a goal into a hardened tracker issue plan, dispatch builder
   jobs, grade finished work, diagnose blockers, or finish a factory run.
 effort: high
 ---
@@ -50,6 +50,23 @@ preload) — a stage skill returns here and never invokes a peer. Mechanics:
 9. **No silent fallback.** Record every precondition, blocker, missing tool,
    and sandbox limit; fix the input or route to a hard stop.
 
+## Timed-ruling protocol
+
+There is no approval gate anywhere in the loop; the human steers by editing
+the spec, commenting rulings, vetoing digests, or `docs/STOP`. Every human
+question routes through this protocol, human present or not. Never a
+blocking question UI (nothing times it out; an absent human hangs the
+factory):
+
+1. Print question, numbered options, recommended default in-session; mirror
+   as a `RULING PENDING` tracker comment naming the default.
+2. Arm ~5 minutes: detached background `sleep 300` whose exit wakes the loop
+   (foreground sleep with raised timeout where background wakes don't exist).
+3. Answer first: apply and kill the timer. Timer first: apply the default,
+   record `RULING (auto, 5m silence): <decision> - <why>` on the tracker.
+   Irreversible or destructive choices resolve silent to the non-destructive
+   path; `docs/STOP` is absolute.
+
 ## Procedure
 
 ### 0. Ground
@@ -73,10 +90,9 @@ glossary exactly — substitution is a defect.
 
 ### 1. Intake
 
-Explore, then ask at most ~5 questions in one batch — only where the answer
-changes implementation or validation. Ask via the timed-ruling protocol;
-timer-expired questions become recorded `## Assumptions` on the recommended
-option.
+Feed the user's goal straight into the pipeline — no intake question batch;
+anything genuinely open becomes a timed ruling that auto-defaults and lands
+as a recorded `## Assumptions` entry.
 
 Preflight per tracker mode (`tracker.md` `## Preflight per mode`). Canary
 each candidate backend once — list tools, `git log -1 --oneline`, reply
@@ -85,68 +101,46 @@ record the substitution with evidence. Never switch backend mid-wave.
 
 Dispatch a fresh strategist subagent to write the spec with `to-spec`; it
 returns the spec draft (`SPEC DRAFT: <path>`) and any `RULING NEEDED:`
-questions. Rule them via the timed-ruling protocol, fold the outcomes into
-the draft as `## Assumptions`, and commit the spec — the strategist never
-commits or touches the tracker. Then one fresh strategist subagent runs
-`adversarial-review` against the draft; apply surviving findings before
-approval. Create the tracking issue — spec pointer, assumptions digest,
-approve-by-comment instructions (`APPROVE`, `APPROVE with edits: <text>`,
-`REJECT <reason>`), run marker, manifest path — then write the manifest, a
-local gitignored run artifact like all of `docs/runs/` and `docs/jobs/`.
+questions. Rule them via the timed-ruling protocol and fold the outcomes
+into the draft as `## Assumptions` — the strategist never commits or
+touches the tracker. Cut `factory/<run>` and commit the spec there; every
+run commit lands on that branch and main stays untouched until the closing
+PR. One run per checkout — concurrent runs each get their own worktree
+(`.architect/runs/<slug>`, machine-local). Create the tracking issue — spec
+pointer, assumptions digest, run marker, manifest path — then write the
+manifest, a local gitignored run artifact like all of `docs/runs/` and
+`docs/jobs/`.
 
-### 2. Spec Approval
+### 2. Harden
 
-The one human step: the human edits or vetoes assumptions and approves or
-rejects. Approval authorizes the whole issue plan; afterward, contact the
-human only through tracking-issue digests or hard stops. Exactly three
-forms, recorded verbatim in the spec, never inferred:
-
-- In-session: explicit authorization, quoted.
-- Tracking-issue: repo-owner comment `APPROVE` / `APPROVE with edits:` /
-  `REJECT`.
-- Timer: timed-ruling protocol expired silent → `APPROVE (auto, 5m silence)`
-  plus reasoning, veto-able after the fact.
-
-Timed-ruling protocol — every human question in the loop, present or not.
-Never a blocking question UI (nothing times it out; an absent human hangs
-the factory):
-
-1. Print question, numbered options, recommended default in-session; mirror
-   as a `RULING PENDING` tracker comment naming the default.
-2. Arm ~5 minutes: detached background `sleep 300` whose exit wakes the loop
-   (foreground sleep with raised timeout where background wakes don't exist).
-3. Answer first: apply and kill the timer. Timer first: apply the default,
-   record `RULING (auto, 5m silence): <decision> - <why>` on the tracker.
-   Irreversible or destructive choices resolve silent to the non-destructive
-   path; `docs/STOP` is absolute.
-
-On approval, cut `factory/<run>`; every run commit lands there and main
-stays untouched until the closing PR. One run per checkout — concurrent runs
-each get their own worktree (`.architect/runs/<slug>`, machine-local).
-
-### 3. Decompose
-
-Dispatch a fresh strategist subagent to compile the spec into dispatch-ready
-issue drafts with `to-issues` (publish-ordered files under
+Dispatch one fresh strategist subagent over the committed draft; this one
+dispatch replaces the old review-approve-decompose chain. It runs
+`adversarial-review` against the spec and folds the surviving findings into
+a revised spec itself, then compiles that spec into dispatch-ready issue
+drafts with `to-issues` (publish-ordered files under
 `docs/runs/<run>/issues/`): structural before behavioral with blocking
 edges, tracer-bullet vertical slices, a file-disjoint parallel frontier,
 interface contracts from producers, one compact change-skeleton per issue
-(a contract, not a line mandate — PHASE 0 is the disagreement channel).
+(a contract, not a line mandate — PHASE 0 is the disagreement channel). It
+drafts per-issue graded checks with `frozen-checks` under
+`docs/checks/<run>/` — each issue links its check — and closes by
+stress-testing its own decomposition with `adversarial-review`'s
+decomposition discipline, executing every draft RUN item and resolving
+every pointer before returning. It returns the revised spec, issue drafts,
+check drafts, and its findings ledger; it never commits or touches the
+tracker.
 
-The strategist drafts per-issue graded checks with `frozen-checks` under
-`docs/checks/<run>/`;
-each issue links its check. The orchestrator publishes the sub-issues from
-the drafts with native edges (`dispatch.md` `## Issue conventions`) and owns
-the freeze commit. Freeze preconditions: freeze committed on the
-factory branch and pushed; `preflight.ps1`/`.sh` verifies worktree, freeze,
-and a frozen-file spot-check; builders still FIRST-ACTION verify inputs.
+### 3. Publish and freeze
 
-Before the freeze commit, one fresh strategist `adversarial-review` stress pass attacks
-the whole decomposition — issues plus draft checks — and its surviving
-findings land. Record freeze SHA, stress result, and plan on the tracking
-issue. Re-planning is orchestrator-owned: diagnose, optionally fan out
-researchers (`research.md`), amend spec/issue/checks in git and tracker,
-respawn fresh. Builders never re-plan.
+The orchestrator rules on the returned drafts, commits the revised spec,
+publishes the sub-issues from the drafts with native edges (`dispatch.md`
+`## Issue conventions`), and owns the freeze commit. Freeze preconditions:
+freeze committed on the factory branch and pushed; `preflight.ps1`/`.sh`
+verifies worktree, freeze, and a frozen-file spot-check; builders still
+FIRST-ACTION verify inputs. Record the freeze SHA, stress result, and plan
+on the tracking issue. Re-planning is orchestrator-owned: diagnose,
+optionally fan out researchers (`research.md`), amend spec/issue/checks in
+git and tracker, respawn fresh. Builders never re-plan.
 
 ### 4. Factory Loop
 
@@ -186,11 +180,14 @@ Event loop: loop.md `## Factory block procedure`.
 
 ### 5. Finish
 
-Open with a timed-ruling question: run the final review? Default YES. On
-YES, one fresh strategist subagent (MEDIUM effort, worktree from the
-factory branch head) runs the `final-review` stage skill, dispatched by
-citing the installed user-level skill text by explicit path. It reports and
-decomposes, never edits, and returns one verdict. `REVIEW: GREEN` is a
+When every build issue has closed, run the closing test pass: execute the
+run's builder-built test suites plus every frozen RUN item at the factory
+branch head and capture the raw output. Then one fresh strategist subagent
+(MEDIUM effort, worktree from the factory branch head) runs the
+`final-review` stage skill — always, never gated on a ruling to enter it —
+dispatched by citing the installed user-level skill text by explicit path,
+with the test-pass output and every rulings file in its dispatch block. It
+reports and decomposes, never edits, and returns one verdict. `REVIEW: GREEN` is a
 short-circuit: post the GREEN verdict on the tracking issue and go straight
 to integrate. `REVIEW: FINDINGS n=<count>` names a review spec, fix-issue
 drafts, and check drafts; the orchestrator harvests those three draft sets,
@@ -227,7 +224,7 @@ Stop and ask the human when:
 - An irreversible or destructive action is needed.
 - Two consecutive KILL decisions occur.
 - A blocker collides with a recorded assumption.
-- Scope grows beyond the approved spec.
+- Scope grows beyond the hardened spec.
 - Required tracker preflight cannot be satisfied.
 
 ## Maintenance

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -15,10 +15,9 @@ You ground, dispatch strategist work, freeze, dispatch builders, rule, merge,
 and digest. Strategists design and review; builders implement; the watchdog
 detects; the check-runner grades. Never collapse these roles.
 
-Stage skills own each stage's craft; this file owns order, invariants, and the
-seams between them. Invoke stage skills explicitly (Skill tool or agent-def
-preload) — a stage skill returns here and never invokes a peer. Mechanics:
-`dispatch.md` (templates, model routing, `## Issue conventions`), `loop.md`
+Stage skills own each stage's craft; this file owns order, invariants, and
+seams. Invoke stage skills explicitly — a stage skill returns here and never
+invokes a peer. Mechanics: `dispatch.md` (templates, routing), `loop.md`
 (event loop), `tracker.md` (modes), `research.md` (fan-out). Rationale:
 `DESIGN.md`.
 
@@ -29,20 +28,19 @@ preload) — a stage skill returns here and never invokes a peer. Mechanics:
 2. **Checks freeze in git before dispatch.** Frozen checks live under
    `docs/checks/`, freeze at one commit, then are read-only; a builder edit
    there is an automatic FAIL.
-3. **Nobody grades their own work.** Builders report raw evidence. The
-   check-runner grades every frozen RUN item; one fresh strategist subagent
-   runs the final review — the loop's only model review. It
-   reports and decomposes, never edits. Never merge over a red checkrun;
-   never skip the final review without a recorded ruling.
+3. **Nobody grades their own work.** Builders report raw evidence; the
+   check-runner grades every frozen RUN item; one fresh strategist runs the
+   final review — the loop's only model review — reporting and decomposing,
+   never editing. Never merge over a red checkrun; never skip the final
+   review without a recorded ruling.
 4. **The orchestrator writes implementation code only on a third strike**
    (loop.md `## Failure ladder`), graded like any builder's work. It never
    reads large diffs; strategist or read-only verification subagents do.
 5. **Fresh builder per issue,** worktree-isolated. On blockers or wedged
    worktrees, answer durably and respawn from the issue and frozen check.
-6. **Roles are set before decomposition.** The orchestrator is this running
-   session; strategist and builder models come from config and dispatch
-   rules. Failure never moves builder tier — failures are spec, context, or
-   architecture problems.
+6. **Roles are set before decomposition.** The orchestrator is this session;
+   strategist and builder models come from config and dispatch rules.
+   Failure never moves builder tier.
 7. **Builders never commit.** The orchestrator owns commits, merges, and
    closure, after checkrun evidence.
 8. **Disagreement is mandatory.** PHASE 0 states the plan and every
@@ -52,14 +50,13 @@ preload) — a stage skill returns here and never invokes a peer. Mechanics:
 
 ## Timed-ruling protocol
 
-There is no approval gate anywhere in the loop; the human steers by editing
-the spec, commenting rulings, vetoing digests, or `docs/STOP`. Every human
-question routes through this protocol, human present or not. Never a
-blocking question UI (nothing times it out; an absent human hangs the
-factory):
+No approval gate exists anywhere; the human steers by editing the spec,
+commenting rulings, vetoing digests, or `docs/STOP`. Every human question
+routes through this protocol, human present or not — never a blocking
+question UI:
 
-1. Print question, numbered options, recommended default in-session; mirror
-   as a `RULING PENDING` tracker comment naming the default.
+1. Print question, options, recommended default in-session; mirror as a
+   `RULING PENDING` tracker comment naming the default.
 2. Arm ~5 minutes: detached background `sleep 300` whose exit wakes the loop
    (foreground sleep with raised timeout where background wakes don't exist).
 3. Answer first: apply and kill the timer. Timer first: apply the default,
@@ -72,164 +69,113 @@ factory):
 ### 0. Ground
 
 At every factory block boundary. Load `codebase-design` first and use its
-glossary exactly — substitution is a defect.
+glossary exactly.
 
 - Read in authority order: `CLAUDE.md`/`AGENTS.md`, `README.md`, architecture
   docs, active spec, open issues, reports, checks, branches.
-- Run `skills/architect/ground.ps1|.sh <run>` and rule on its typed exit: 0
-  `GROUND: OK` proceeds — read its `FRONTIER:` line for the ready issues; 2
-  `GROUND: STOP <which>` halts before dispatch; 3 `GROUND: DRIFT <fact>` is a
-  tracker/git disagreement to rule on before continuing; 5 `GROUND: ERROR
-  <why>` is a script/input error to fix. Detection only — it never posts,
-  edits, or decides.
-- Resolve roles: orchestrator is this running session; `strategist` and
-  `builders` from `.architect/config`, then `~/.architect/config`, then
-  dispatch.md `## Model alias table`. Verification subagents run at the
-  builders model; high-judgment subagents run at the strategist model; the
-  monitor is a script.
+- Run `skills/architect/ground.ps1|.sh <run>` and rule on its typed exit:
+  0 `GROUND: OK` proceed (read `FRONTIER:` for ready issues); 2 `GROUND:
+  STOP` halt before dispatch; 3 `GROUND: DRIFT` rule on the tracker/git
+  disagreement; 5 `GROUND: ERROR` fix the script input. Detection only.
+- Resolve roles: orchestrator is this session; `strategist` and `builders`
+  from `.architect/config`, then `~/.architect/config`, then dispatch.md
+  `## Model alias table`. Verification subagents run at the builders model.
 
 ### 1. Intake
 
-Feed the user's goal straight into the pipeline — no intake question batch;
-anything genuinely open becomes a timed ruling that auto-defaults and lands
-as a recorded `## Assumptions` entry.
+Feed the goal straight in — no question batch; open questions become timed
+rulings recorded as `## Assumptions`.
 
 Preflight per tracker mode (`tracker.md` `## Preflight per mode`). Canary
 each candidate backend once — list tools, `git log -1 --oneline`, reply
 `CANARY: SHELLS_OK|DEGRADED`; on DEGRADED select the fallback backend and
-record the substitution with evidence. Never switch backend mid-wave.
+record the substitution. Never switch backend mid-wave.
 
-Dispatch a fresh strategist subagent to write the spec with `to-spec`; it
-returns the spec draft (`SPEC DRAFT: <path>`) and any `RULING NEEDED:`
-questions. Rule them via the timed-ruling protocol and fold the outcomes
-into the draft as `## Assumptions` — the strategist never commits or
-touches the tracker. Cut `factory/<run>` and commit the spec there; every
-run commit lands on that branch and main stays untouched until the closing
-PR. One run per checkout — concurrent runs each get their own worktree
-(`.architect/runs/<slug>`, machine-local). Create the tracking issue — spec
-pointer, assumptions digest, run marker, manifest path — then write the
-manifest, a local gitignored run artifact like all of `docs/runs/` and
+Dispatch a fresh strategist to write the spec with `to-spec`; it returns
+`SPEC DRAFT: <path>` plus `RULING NEEDED:` questions. Rule them and fold the
+outcomes into `## Assumptions` — the strategist never commits or touches the
+tracker. Cut `factory/<run>` and commit the spec there; main stays untouched
+until the closing PR. One run per checkout; concurrent runs get their own
+worktrees (`.architect/runs/<slug>`). Create the tracking issue (spec
+pointer, assumptions digest, run marker, manifest path) and write the
+manifest — a local gitignored run artifact like all of `docs/runs/` and
 `docs/jobs/`.
 
 ### 2. Harden
 
-Dispatch one fresh strategist subagent over the committed draft; this one
-dispatch replaces the old review-approve-decompose chain. It runs
-`adversarial-review` against the spec and folds the surviving findings into
-a revised spec itself, then compiles that spec into dispatch-ready issue
-drafts with `to-issues` (publish-ordered files under
-`docs/runs/<run>/issues/`): structural before behavioral with blocking
-edges, tracer-bullet vertical slices, a file-disjoint parallel frontier,
-interface contracts from producers, one compact change-skeleton per issue
-(a contract, not a line mandate — PHASE 0 is the disagreement channel). It
-drafts per-issue graded checks with `frozen-checks` under
-`docs/checks/<run>/` — each issue links its check — and closes by
-stress-testing its own decomposition with `adversarial-review`'s
-decomposition discipline, executing every draft RUN item and resolving
-every pointer before returning. It returns the revised spec, issue drafts,
-check drafts, and its findings ledger; it never commits or touches the
-tracker.
+Dispatch one fresh strategist over the committed draft. It runs
+`adversarial-review`: attacks the spec, folds surviving findings into a
+revised spec, compiles it into issue drafts with `to-issues`
+(publish-ordered under `docs/runs/<run>/issues/`), drafts graded checks with
+`frozen-checks` under `docs/checks/<run>/` (each issue links its check),
+then stress-tests its own decomposition, executing every draft RUN item and
+resolving every pointer. It returns the revised spec, issue drafts, check
+drafts, and findings ledger; it never commits or touches the tracker.
 
 ### 3. Publish and freeze
 
-The orchestrator rules on the returned drafts, commits the revised spec,
-publishes the sub-issues from the drafts with native edges (`dispatch.md`
-`## Issue conventions`), and owns the freeze commit. Freeze preconditions:
-freeze committed on the factory branch and pushed; `preflight.ps1`/`.sh`
+Rule on the drafts, commit the revised spec, publish the sub-issues with
+native edges (`dispatch.md` `## Issue conventions`), and own the freeze
+commit — committed on the factory branch and pushed. `preflight.ps1|.sh`
 verifies worktree, freeze, and a frozen-file spot-check; builders still
-FIRST-ACTION verify inputs. Record the freeze SHA, stress result, and plan
-on the tracking issue. Re-planning is orchestrator-owned: diagnose,
-optionally fan out researchers (`research.md`), amend spec/issue/checks in
-git and tracker, respawn fresh. Builders never re-plan.
+FIRST-ACTION verify. Record freeze SHA, stress result, and plan on the
+tracking issue. Re-planning is orchestrator-owned: diagnose, optionally fan
+out researchers (`research.md`), amend spec/issues/checks in git and
+tracker, respawn fresh. Builders never re-plan.
 
-### 4. Factory Loop
+### 4. Factory loop
 
-Event loop: loop.md `## Factory block procedure`.
-
-- Dispatch the ready issues to the backend cap: up to 10 CLI-launched build
-  jobs, or the built-in harness subagent cap (currently 5). Builders default
-  to codex-CLI jobs (`codex/best`); Claude-native Agent-tool jobs
-  (`architect-builder` def preloads `tdd` + `codebase-design`; model per
-  alias table) are the config alternative and codex-absent fallback. Every
-  job end is a dispatch event: recompute the frontier and dispatch before
-  grading — one completion routinely launches several builders.
-- Sleep between events; wake on DONE, BLOCKED, stall/kill or watchdog
-  evidence, or frontier recomputation.
-- Status requests: run `skills/architect/status.ps1|.sh <run>`, print
-  verbatim in a fenced block, never hand-compose the tree.
-- DONE: write runner config, launch the check-runner in the background, rule
-  on its typed exit — 0: commit evidence, merge through postflight; 2: commit
-  failure evidence, enter the failure ladder; 5: recorded error rail.
-  `POSTFLIGHT: OK` is the clean touch-set evidence.
-- BLOCKED: answer on the issue with durable evidence; respawn fresh with the
-  answer (`dispatch.md` `## Respawn-with-answer template`).
-- Failure ladder (loop.md): (1) diagnose from checkrun or review evidence —
-  never a large diff — respawn one fix builder with the answer; (2) fresh
-  builder, deeper diagnosis; (3) third strike, Hard Rule 4.
-- Post-freeze rulings are append-only in
-  `docs/jobs/<run>/<issue-slug>-rulings.md` — PHASE-0 rulings, touch-set
-  amendments, respawn answers. Orchestrator-owned, local, mirrored to the
-  issue; each rulings file travels verbatim in the reviewer dispatch block.
-- Merge conflict = decomposition failure: kill the job, re-spec the graph.
-- Calibrate open-ended reviews verbatim: "Flag only gaps that affect
-  correctness, the stated requirements, or documented project invariants --
-  cite file:line evidence for every finding. Do not report stylistic
-  preferences."
-- Record docs debt as it accrues; nontrivial diagnoses codify into DESIGN
-  and CONTEXT through the integrate subagent's docs pass, never mid-run.
+Run loop.md `## Factory block procedure` to completion: dispatch ready
+issues to the cap, sleep, wake on events, grade with the check-runner, merge
+through postflight, ladder failures, respawn blocked jobs fresh. Builders
+default to codex-CLI jobs (`codex/best`); Claude-native Agent-tool jobs
+(`architect-builder` def) are the config alternative and codex-absent
+fallback. Status requests: run `skills/architect/status.ps1|.sh <run>` and
+print verbatim. Post-freeze rulings are append-only in
+`docs/jobs/<run>/<issue-slug>-rulings.md`, mirrored to the issue. Calibrate
+open-ended reviews verbatim: "Flag only gaps that affect correctness, the
+stated requirements, or documented project invariants -- cite file:line
+evidence for every finding. Do not report stylistic preferences." Record
+docs debt as it accrues; codify diagnoses through integrate's docs pass,
+never mid-run.
 
 ### 5. Finish
 
-When every build issue has closed, run the closing test pass: execute the
-run's builder-built test suites plus every frozen RUN item at the factory
-branch head and capture the raw output. Then one fresh strategist subagent
-(MEDIUM effort, worktree from the factory branch head) runs the
-`final-review` stage skill — always, never gated on a ruling to enter it —
-dispatched by citing the installed user-level skill text by explicit path,
-with the test-pass output and every rulings file in its dispatch block. It
-reports and decomposes, never edits, and returns one verdict. `REVIEW: GREEN` is a
-short-circuit: post the GREEN verdict on the tracking issue and go straight
-to integrate. `REVIEW: FINDINGS n=<count>` names a review spec, fix-issue
-drafts, and check drafts; the orchestrator harvests those three draft sets,
-discards the reviewer worktree, and runs the frozen-checks freeze gate over
-every draft RUN command, amending drafts pre-freeze where the gate demands it
-(rulings record intent-bearing amendments). It commits the review spec and
-issue bodies under the run directory and the checks into the run's checks
-directory as the fix-wave freeze, updates the tracking-issue body's freeze
-record to the latest freeze SHA
-(prior SHAs stay in comments), files the fix issues as sub-issues, and posts
-the verdict plus fix-issue list as the digest — no human gate; the digest is
-the veto surface. It then dispatches the fix wave through the existing wave
-machinery at the builders tier: single review cycle, no re-review; a fix
-issue closes by merge or by recorded ruling, landing ruling-closed findings
-in the digest as residual risks.
+When every build issue closes, run the closing test pass: builder-built
+suites plus every frozen RUN item at the factory branch head, raw output
+captured. Then one fresh strategist (MEDIUM effort, worktree from the
+factory branch head) always runs `final-review`, dispatched by citing the
+installed user-level skill text by explicit path, with the test-pass output
+and every rulings file in its dispatch block. It reports and decomposes,
+never edits. `REVIEW: GREEN`: post the verdict and go to integrate.
+`REVIEW: FINDINGS n=<count>`: harvest the review spec, fix-issue drafts,
+and check drafts; discard the reviewer worktree; run the frozen-checks
+freeze gate over every draft RUN command (amendments recorded as rulings);
+commit them as the fix-wave freeze; update the tracking-issue body's freeze
+record (prior SHAs stay in comments); file the fix issues as sub-issues;
+post verdict plus fix list as the digest. Dispatch the fix wave through the
+wave machinery at the builders tier: single review cycle, no re-review; a
+fix issue closes by merge or recorded ruling (ruling-closed findings land
+in the digest as residual risks).
 
-Then dispatch one integration subagent running the `integrate` stage skill
-— never the orchestrator — after the fix wave has merged, after a GREEN
-verdict, or after a recorded ruling skips the review. Its dispatch block
-carries the change-context digest: shipped issues with one-liners,
-diffstats, rulings pointers, docs debt, domain language changes. Its first
-step is the docs pass — consume the digest, update product docs, retire the
-docs debt — then it owns remaining merges, ship-time conflict resolution,
-PR prep or markdown-mode finish prep, and the digest draft. The
-orchestrator rules on the result and posts the digest, naming shipped,
-skipped, residual risks, and evidence.
+Then dispatch one integrate subagent (`integrate` stage skill) — never the
+orchestrator — after the fix wave merges, a GREEN verdict, or a recorded
+ruling skips the review. Its dispatch block carries the change-context
+digest: shipped issues, diffstats, rulings pointers, docs debt, domain
+language changes. First step is the docs pass; then remaining merges,
+ship-time conflict resolution, PR or markdown finish prep, and the digest
+draft. The orchestrator rules on the result and posts the digest.
 
 ## Hard Stops
 
-Stop and ask the human when:
-
-- `docs/STOP` exists in run or primary checkout, or an uncommitted
-  `docs/runs/<run>/STOP` exists before dispatch.
-- An irreversible or destructive action is needed.
-- Two consecutive KILL decisions occur.
-- A blocker collides with a recorded assumption.
-- Scope grows beyond the hardened spec.
-- Required tracker preflight cannot be satisfied.
+Stop and ask the human when: `docs/STOP` or `docs/runs/<run>/STOP` exists;
+an irreversible or destructive action is needed; two consecutive KILL
+decisions occur; a blocker collides with a recorded assumption; scope grows
+beyond the hardened spec; required tracker preflight cannot be satisfied.
 
 ## Maintenance
 
 Re-read against each new model generation; delete what models now do
-unprompted — the Hard Rules are invariants, everything else is prunable.
-Re-run `docs/evals/trigger-prompts.md` per generation. No feature ships
-without evidence in `DESIGN.md`.
+unprompted — Hard Rules are invariants, the rest is prunable. Re-run
+`docs/evals/trigger-prompts.md`. No feature ships without evidence in
+`DESIGN.md`.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -19,11 +19,12 @@
 - Builder block template
 - Builder-side standing setup
 
-Dispatch turns a frozen slice or high-judgment stage into fresh strategist, builder, or verification work.
-The orchestrator chooses the job shape, model role, worktree, and report path; the subagent receives a self-contained task and returns raw evidence.
+Dispatch turns a frozen slice or high-judgment stage into fresh strategist,
+builder, or verification work: the orchestrator chooses job shape, model
+role, worktree, and report path; the subagent gets a self-contained task and
+returns raw evidence.
 
-Verified local Codex facts from the v3 evidence remain useful for the Codex
-backend path: the model slug is `gpt-5.5`; `--search` and
+Verified Codex facts: the model slug is `gpt-5.5`; `--search` and
 `-a/--ask-for-approval` are top-level `codex --help` flags, not `codex exec`
 flags; `codex exec` is non-interactive; Goal Mode subcommands are bare
 `/goal`, `/goal pause|resume|clear`.
@@ -32,29 +33,26 @@ flags; `codex exec` is non-interactive; Goal Mode subcommands are bare
 
 | Alias | Flags | Notes |
 |---|---|---|
-| `codex/best` | `-m gpt-5.5 -c model_reasoning_effort="xhigh"` | Frontier Codex row. Watch for a possible gpt-5.6 rollout before changing this pin. |
-| `claude/best` | `--model fable --effort high` | Frontier Claude row (Fable 5 at high effort). If Fable is unavailable on the account, pin `--model opus --effort xhigh` (Opus 4.8) and record the substitution on the tracking issue. |
-| `codex/tier-down` | `-m gpt-5.5 -c model_reasoning_effort="high"` | Effort-down on the frontier model; high is the quota-saving tier-down, not a model downgrade. Watch the codex rows per model generation. |
+| `codex/best` | `-m gpt-5.5 -c model_reasoning_effort="xhigh"` | Frontier Codex row; watch for a gpt-5.6 rollout before changing the pin. |
+| `claude/best` | `--model fable --effort high` | Frontier Claude row. If Fable is unavailable, pin `--model opus --effort xhigh` and record the substitution. |
+| `codex/tier-down` | `-m gpt-5.5 -c model_reasoning_effort="high"` | Effort-down on the frontier model, not a model downgrade. |
 | `claude/tier-down` | `--model sonnet --effort high` | Model-down at high effort. |
 
-General tier-down rule: same family, one step down. For Claude, the step is the
-model at high effort (Fable/Opus -> Sonnet; Sonnet -> Haiku only when the
-orchestrator explicitly chooses that risk). For Codex, the step is effort
-(xhigh -> high) on the frontier model. Dispatch blocks print explicit pinned
-flags in every command; this table is the source of those pins.
+Tier-down rule: same family, one step down — Claude steps the model
+(Fable/Opus -> Sonnet; Sonnet -> Haiku only as an explicit orchestrator
+risk), Codex steps effort (xhigh -> high). Dispatch blocks print explicit
+pinned flags in every command; this table is the source of those pins.
 
 ## Model resolution and dispatch rules
 
-Role strings are `<cli>/<model-spec>[:<effort>]`, with `<cli>` in `{claude,codex}`.
-The orchestrator is not a config role: it is the Claude or Codex session already running the loop.
-Configurable roles resolve repo `.architect/config`, then user `~/.architect/config`, then defaults: `strategist = claude/best` (Fable 5 high) for `/architect` high-judgment subagents, and `builders = codex/best` (gpt-5.5 xhigh, Fast pins below) as codex-CLI jobs.
-Claude Code and Codex orchestrators both dispatch builders through the codex command lines in the sections below.
-The Claude-native builder backend (`builders = claude/tier-down`, Sonnet high, Agent-tool jobs; `architect-builder` preloads `tdd` and `codebase-design`) is the config-selected alternative and codex-absent fallback.
-Flat `key = value` lines are the supported role-key format; the legacy orchestrator key is retired, warns, and is ignored. Unknown keys warn and never fail.
-
-A pin is a request, not proof — verify the served model from the spawn transcript's model field; resume drifts a subagent's model back to the parent's, and `CLAUDE_CODE_SUBAGENT_MODEL` outranks per-invocation pins.
-
-Optional dispatch-rules lines route task classes to a builder tier:
+Role strings are `<cli>/<model-spec>[:<effort>]`, `<cli>` in
+`{claude,codex}`. The orchestrator is not a config role — it is the session
+running the loop. Roles resolve repo `.architect/config`, then
+`~/.architect/config`, then defaults `strategist = claude/best` and
+`builders = codex/best`. Flat `key = value` lines only; unknown keys warn
+and never fail. A pin is a request, not proof — verify the served model
+from the spawn transcript; resume drifts a subagent's model back to the
+parent's, and `CLAUDE_CODE_SUBAGENT_MODEL` outranks per-invocation pins.
 
 ```ini
 # .architect/config or ~/.architect/config
@@ -65,68 +63,89 @@ when trivial mechanical edit -> codex/best:xhigh # keep builder pin
 when broad ambiguous refactor -> codex/best:xhigh # same builder pin, record why
 ```
 
-Format: `when <task-class description> -> <cli>/<model-spec>[:<effort>] # why`.
-The trailing reason is optional but preferred. Absent role lines use `strategist = claude/best` and `builders = codex/best`; absent dispatch rules = the builders default.
-A matching rule is still a judgment aid; the orchestrator records which rule was used and may override it with a reason recorded on the issue.
+Dispatch-rules lines (`when <task-class> -> <cli>/<model-spec>[:<effort>] #
+why`) route task classes to a builder tier; a matching rule is a judgment
+aid — record which rule was used, and any override with a reason.
 
-Builder speed default: when the resolved builders backend is Codex under
-ChatGPT auth, every builder `codex exec` appends the Fast-mode pins
-`-c service_tier="fast" -c features.fast_mode=true` — same model, faster
-inference (gpt-5.5 at 2.5x credit burn), never a tier change. Verify at the
-intake canary; API-key auth cannot use Fast mode — drop the two pins and
-record the substitution on the tracking issue (no silent fallback). The
-default is builder-only; strategist subagents, verification subagents, and the
-monitor never carry the Fast pins.
+Builder speed default: Codex builders under ChatGPT auth append the
+Fast-mode pins `-c service_tier="fast" -c features.fast_mode=true` — same
+model, faster inference; verify at the intake canary. API-key auth cannot
+use Fast mode — drop the pins and record the substitution. Builder-only:
+strategist, verification, and monitor never carry Fast pins.
 
-Strategist *model* unavailable on the account -> step down in-family per the alias row (e.g. Fable -> Opus xhigh) and record the substitution.
-Strategist *CLI* absent at preflight -> run the strategist on the orchestrator's own family at the alias table's frontier row, without builder Fast pins, and record the capability caveat; never silently skip a strategist stage.
-Configured builders CLI absent -> fall back to `claude/tier-down` and write one tracking-issue comment naming requested vs substituted.
-Cross-family review backend absent -> run review in a fresh same-CLI context and log the same-family bias caveat. Never hard-fail on model availability alone.
-Builder tier is fixed at decomposition by config plus dispatch rules and never moves because a job failed; failure is the orchestrator's diagnosis job, not a retry-at-a-different-tier job (see `loop.md` "## Failure ladder").
+Fallbacks, each recorded, never silent: strategist model unavailable ->
+step down in-family per the alias row. Strategist CLI absent -> run the
+strategist on the orchestrator's own family at the frontier row; never skip
+a strategist stage. Builders CLI absent -> `claude/tier-down` plus one
+tracking-issue comment naming requested vs substituted. Cross-family review
+backend absent -> fresh same-CLI review with the bias caveat logged. Never
+hard-fail on model availability alone. Builder tier is fixed at
+decomposition and never moves because a job failed (`loop.md`
+"## Failure ladder").
 
 ## Per-harness delegation
 
 | | Claude Code (CLI + Desktop) | Codex (CLI + app) |
 |---|---|---|
-| Strategist | Resolved `strategist = claude/*`: Agent tool at the strategist model, `run_in_background: false` for result-bearing stages, stage skills named in the prompt (`codebase-design` plus `to-spec`, `to-issues`, `frozen-checks`, `adversarial-review`, or `final-review`). Resolved `strategist = codex/*` (cross-family, e.g. gpt-5.5 under a Claude Code orchestrator): background `codex exec -o <file>` job launched through `run-job.ps1|.sh` like any CLI subagent — read-heavy sandbox, never builder Fast pins; drafts and the verdict line return as files (the sandbox has no tracker access). | Resolved `strategist = codex/*`: `spawn_agent` with defensive framing at the strategist model, never builder Fast pins. Resolved `strategist = claude/*` (the default Fable row, cross-family): CLI-launched `claude -p` through `run-job.ps1|.sh` with the dispatch block on stdin and a file-based output contract; claude CLI absent -> record the substitution and run the strategist on Codex per the fallback rule above. |
-| Builder | Agent tool with `.claude/agents/architect-builder.md`; `disallowedTools` denies `Bash(git commit *)` and `Bash(git push *)`; `isolation: worktree`; `background: true`; model may be passed per invocation from the alias table. On the desktop app, the harness auto-creates the agent's isolation worktree (`.claude/worktrees/agent-<id>`) and its branch — integrate from that branch. On the CLI, spawns have been observed to run UNISOLATED in the orchestrator's checkout despite `isolation: worktree` frontmatter (D11) — pass isolation explicitly per invocation if supported, and never run two Claude-backend builder jobs concurrently unless each is verified to have its own worktree (`git worktree list` after spawn). In all cases, never pre-create a job worktree for Claude-backend jobs (a pre-made one is ignored); do not use `.architect/wt/<run>/<slice>-<NN>` (that pattern is Codex-backend only, below). | `spawn_agent` with defensive framing: "Your task is: ..."; worktree created by the orchestrator via git; use `/goal` semantics for persistent job completion. |
-| Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md` (read-only verification def); dispatch synchronously with `run_in_background: false`, but require a report file plus one greppable verdict line and harvest that file; read-only tools plus Bash for check commands; the resolved builders model passed per invocation (the def's `model: inherit` is only the fallback where per-invocation model is unsupported). | Background `codex exec -o <file>` typed-exit path with read-only instructions; the process exit wakes the loop. |
-| Monitor | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) under a long-lived Bash task when the orchestrator can wait on task exit; LLM fallback template only otherwise. | Script watchdog (`watchdog.ps1` on Windows, `watchdog.sh` on POSIX) under a long-lived Bash task when task exits wake the orchestrator; LLM fallback template only otherwise and it consumes one native subagent slot. |
-| Parallelism | CLI-launched builder backends, including Claude Code orchestrating Codex, run up to 10 background jobs. Claude Agent-tool builders are harness-native: use the harness cap (currently 5), verify isolated worktrees before concurrent spawns, and expect permission prompts in the main session. | CLI-launched builder backends run up to 10 background jobs. Native `spawn_agent` builders use the harness cap (currently 5), `max_depth` 1 (root session is depth 0; a spawned child may not spawn further), and `wait_agent` for completion (the live collab event stream names the underlying tool call `wait`, not `wait_agent`). |
-| Review (high-stakes) | `codex review --base` when Codex is installed; otherwise a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
-| Skill packaging | `skills/architect/` plus Claude skill install locations. | `.agents/skills/architect/SKILL.md` (and any other `skills/*/`); same source text copied by installer. |
+| Strategist | `strategist = claude/*`: Agent tool at the strategist model, `run_in_background: false` for result-bearing stages, stage skills named in the prompt. `strategist = codex/*`: background `codex exec -o <file>` job through `run-job.ps1\|.sh` — read-heavy sandbox, no Fast pins; drafts and verdict return as files (no tracker access in sandbox). | `strategist = codex/*`: `spawn_agent` with defensive framing, no Fast pins. `strategist = claude/*`: CLI-launched `claude -p` through `run-job.ps1\|.sh`, dispatch block on stdin, file-based output contract; claude CLI absent -> record and fall back per the rules above. |
+| Builder | Agent tool with `.claude/agents/architect-builder.md`; `isolation: worktree`; `background: true`; model passed per invocation. Desktop auto-creates the isolation worktree (`.claude/worktrees/agent-<id>`) — integrate from its branch. CLI spawns have run UNISOLATED despite frontmatter (D11): pass isolation per invocation if supported and verify each concurrent job's worktree (`git worktree list`) before running two at once. Never pre-create a worktree for Claude-backend jobs; `.architect/wt/<run>/<slice>-<NN>` is Codex-backend only. | `spawn_agent` with defensive framing ("Your task is: ..."); worktree created by the orchestrator via git; `/goal` semantics for persistent completion. |
+| Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md`, `run_in_background: false`, report file plus one greppable verdict line required; builders model per invocation. | Background `codex exec -o <file>` typed-exit path with read-only instructions; process exit wakes the loop. |
+| Monitor | Script watchdog (`watchdog.ps1` / `watchdog.sh`) under a long-lived Bash task; LLM fallback template only where task exits cannot wake the loop. | Same; the LLM fallback consumes one native subagent slot. |
+| Parallelism | CLI-launched builder backends run up to 10 background jobs. Agent-tool builders use the harness cap (5); verify isolated worktrees before concurrent spawns. | CLI jobs cap 10. Native `spawn_agent` uses the harness cap (5), `max_depth` 1, `wait_agent` for completion. |
+| Review (high-stakes) | `codex review --base` when installed; else a fresh same-CLI subagent with bias caveat. | `/review` / `review_model`; Claude reviewer when installed. |
+| Skill packaging | `skills/architect/` plus Claude skill install locations. | `.agents/skills/architect/SKILL.md`; same source copied by installer. |
 
-Any Claude-native Agent-tool dispatch, backgrounded or synchronous, must name a report path and one greppable verdict line; the orchestrator harvests that artifact, while a delivered final message is only an optimization. If the harness goes idle without the file, use `loop.md`'s one-poke-then-respawn ladder.
+Any Claude Agent-tool dispatch must name a report path and one greppable
+verdict line; the orchestrator harvests that artifact — a delivered final
+message is only an optimization. If the harness goes idle without the file,
+use loop.md's one-poke-then-respawn ladder.
 
-D9 note: the desktop harness strips the Bash tool from spawned subagents by
-name; both agent defs now carry `PowerShell` as the desktop-safe executor
-(still padded interior per the position guard above). Job and verification reports
-must name which executor — Bash or PowerShell — ran each check command.
-
-D12 note: CLI subagent tool strips have also been observed intermittent and
-definition-asymmetric — not the desktop's Bash-only D9 pattern. A fresh
-builder spawn once kept both shell tools while two same-session judge spawns
-lost both and correctly returned INVALID. Working mitigation (`DESIGN.md`): a
-cross-family codex judge for shell-dependent checks, plus a fresh headless
-`claude -p` session for any check the codex sandbox cannot run at all. A
-builder in this position records the exact missing tools and its substitute,
-or reports the check BLOCKED — never silently skips a check or invents output.
+D9: the desktop harness strips Bash from spawned subagents by name; both
+agent defs carry `PowerShell` as the desktop-safe executor (padded interior
+per the position guard). Reports must name which executor ran each check.
+D12: CLI tool strips are intermittent and definition-asymmetric; mitigation
+is a cross-family codex judge for shell-dependent checks plus a fresh
+headless `claude -p` session for checks the codex sandbox cannot run. A
+builder in this position records the missing tools and its substitute, or
+reports the check BLOCKED — never silently skips or invents output.
 
 ## Check-runner dispatch
 
-Graded RUN grammar is normative from the shipped s1 runner in `skills/architect/check-runner.ps1`: first backtick span is the command; expectation begins immediately after the closing backtick as ``-> exit:<n>`` with optional `match:"<substring>"`. `match:` is a fixed, case-sensitive stdout substring check, never regex. Text after the expectation is judge-facing prose; non-RUN items are judge-only. A RUN item without an expectation exits 5 with `CHECKRUN: ERROR missing RUN expectation`, and no partial evidence is kept.
-Example line: ``- RUN: `git grep -F -c "needle" -- path/to/file.md` -> exit:0 match:"needle"``
+Graded RUN grammar is normative from `skills/architect/check-runner.ps1`:
+first backtick span is the command; expectation follows immediately as
+``-> exit:<n>`` with optional `match:"<substring>"` — a fixed,
+case-sensitive stdout substring, never regex. Text after the expectation is
+judge-facing prose; non-RUN items are judge-only. A RUN item without an
+expectation exits 5 with `CHECKRUN: ERROR missing RUN expectation`, no
+partial evidence kept.
+Example: ``- RUN: `git grep -F -c "needle" -- path/to/file.md` -> exit:0 match:"needle"``
 
-Evidence contains per-item `expected:`/`verdict:` lines, then `CHECKRUN SUMMARY: run_items=<n> pass=<n> fail=<n>`; typed exits: 0 all pass, 2 any fail, 5 error with no partial evidence.
-Launch pattern: write the runner config JSON — fields `check_file`, `workdir`, `freeze_sha`, `evidence_out`, `executor` (`powershell`|`bash`), `max_output_lines` (default 60) — then run `skills/architect/check-runner.ps1 -Config <path>` or `check-runner.sh <path>` as a foreground child of a long-lived Bash task; on exit 0 commit `docs/jobs/<run>/<issue-slug>-checkrun.md`, then merge through postflight. Exit 2 routes to the failure ladder; `loop.md` owns the full rule.
-
-Long RUN output keeps head, tail, and any pytest short-summary block; optional `progress_out` writes flushed `RUN_START`/`RUN_END`/`RUNNER_ERROR` sidecar events for forensics only.
+Evidence: per-item `expected:`/`verdict:` lines, then `CHECKRUN SUMMARY:
+run_items=<n> pass=<n> fail=<n>`; typed exits 0 all pass, 2 any fail, 5
+error. Launch: write the runner config JSON — `check_file`, `workdir`,
+`freeze_sha`, `evidence_out`, `executor` (`powershell`|`bash`),
+`max_output_lines` (default 60) — then run
+`skills/architect/check-runner.ps1 -Config <path>` or `check-runner.sh
+<path>` as a foreground child of a long-lived Bash task. Exit 0: commit
+`docs/jobs/<run>/<issue-slug>-checkrun.md`, merge through postflight; exit
+2: failure ladder (`loop.md`). Long RUN output keeps head, tail, and any
+pytest short-summary block; optional `progress_out` writes
+`RUN_START`/`RUN_END`/`RUNNER_ERROR` sidecar events for forensics only.
 
 ## CLI-launched subagent dispatch
 
-Worktree pre-creation and `codex exec` are Codex-backend builder jobs even under Claude Code; Claude-backend harness jobs use the Per-harness delegation table.
+Worktree pre-creation and `codex exec` are Codex-backend builder jobs even
+under Claude Code; Claude-backend harness jobs use the Per-harness table.
 
-All long-lived CLI subagents — builders, cross-family strategists, verification jobs — run through `run-job.ps1|.sh`; the wrapper writes `job.meta.json`, `job.heartbeat`, `job.exit.json`, `events.jsonl`, and `stderr.log`, including `pgid` on POSIX or `job_object` on Windows for `kill-job.ps1|.sh`. It accepts an opaque command, so the child can be `codex exec`, `claude -p`, or a long check-runner under a Claude Code or Codex orchestrator. Never pipe live stdout through display filters such as `tail`; the wrapper owns redirection. Every dispatch event re-arms the watchdog over all in-flight CLI jobs.
+All long-lived CLI subagents — builders, cross-family strategists,
+verification jobs — run through `run-job.ps1|.sh`; the wrapper writes
+`job.meta.json`, `job.heartbeat`, `job.exit.json`, `events.jsonl`, and
+`stderr.log`, including `pgid` on POSIX or `job_object` on Windows for
+`kill-job.ps1|.sh`. It accepts an opaque command, so the child can be
+`codex exec`, `claude -p`, or a long check-runner under a
+Claude Code or Codex orchestrator. Never pipe live stdout through filters; the
+wrapper owns redirection. Every dispatch event re-arms the watchdog over
+all in-flight CLI jobs.
 
 Single Codex-backed job:
 
@@ -136,7 +155,7 @@ Single Codex-backed job:
   -
 ```
 
-Claude-CLI-backed jobs use the same wrapper and change only the child:
+Claude-CLI-backed jobs change only the child:
 
 ```bash
 <repo-root>/skills/architect/run-job.sh --job-dir <repo-root>/.architect/jobs/<run>/<slice>-<NN> --workdir <repo-root>/.architect/wt/<run>/<slice>-<NN> --backend claude-cli --report-path <repo-root>/docs/jobs/<run>/<slice>-01.md --stdin-file <repo-root>/.architect/jobs/<run>/<slice>-<NN>/block.md -- \
@@ -150,7 +169,7 @@ $argv = @("claude","-p","--model","fable","--effort","high","--output-format","s
 & <repo-root>\skills\architect\run-job.ps1 -JobDir <repo-root>\.architect\jobs\<run>\<slice>-<NN> -Workdir <repo-root>\.architect\wt\<run>\<slice>-<NN> -Backend claude-cli -ReportPath <repo-root>\docs\jobs\<run>\<slice>-01.md -StdinFile <repo-root>\.architect\jobs\<run>\<slice>-<NN>\block.md -ArgvJson $argv
 ```
 
-For 2-10 CLI-launched jobs, the orchestrator owns worktree creation and parallelism:
+For 2-10 CLI jobs the orchestrator owns worktree creation and parallelism:
 
 ```bash
 git -C <repo-root> worktree add <repo-root>/.architect/wt/<run>/<slice>-<NN> -b job/<run>/<slice>-<NN> <freeze-sha>
@@ -158,17 +177,15 @@ git -C <repo-root> worktree add <repo-root>/.architect/wt/<run>/<slice>-<NN> -b 
 ```
 
 A worktree's `.git` is a pointer file and the resolved git dir is
-sandbox-protected too. Builders cannot commit or touch shared history from any
-job; nothing reaches a branch until orchestrator checks pass.
+sandbox-protected too: builders cannot commit or touch shared history;
+nothing reaches a branch until orchestrator checks pass.
 
 ## Preflight and postflight dispatch
 
-Default dispatch and integration are script-backed. The orchestrator writes one
-config JSON, runs the platform script, and rules on the typed line.
-
-Preflight worktree creation is the Codex-backend path only. Claude-backend jobs
-never pre-create worktrees; use the harness-created worktree and branch from
-the Per-harness delegation table instead.
+Script-backed by default: write one config JSON, run the platform script,
+rule on the typed line. Preflight worktree creation is Codex-backend only —
+Claude-backend jobs use the harness-created worktree from the Per-harness
+table.
 
 preflight config JSON:
 
@@ -199,35 +216,26 @@ postflight config JSON:
 }
 ```
 
-Typed exits:
-
 | Script | Exit | Prefix | Meaning |
 |---|---:|---|---|
-| preflight | 0 | `PREFLIGHT: OK` | worktree exists, HEAD equals `freeze_sha`, and every `require_files` path exists |
-| preflight | 5 | `PREFLIGHT: FAIL` | setup could not complete; record the line and fall back to the recorded manual sequence |
-| postflight | 0 | `POSTFLIGHT: OK` | touch-set audit, merge, optional push, and cleanup completed; may append `cleanup=deferred <path>` |
-| postflight | 2 | `POSTFLIGHT: VIOLATION` | automatic FAIL evidence for the job; do not merge |
-| postflight | 3 | `POSTFLIGHT: CONFLICT` | decomposition failure: kill the conflicting job and re-spec, per the existing rule |
-| postflight | 5 | `POSTFLIGHT: ERROR` | script/config/git error; abort partial merge state, then fall back to the recorded manual sequence |
+| preflight | 0 | `PREFLIGHT: OK` | worktree exists, HEAD equals `freeze_sha`, every `require_files` path exists |
+| preflight | 5 | `PREFLIGHT: FAIL` | record the line; use the manual fallback |
+| postflight | 0 | `POSTFLIGHT: OK` | audit, merge, optional push, cleanup done; may append `cleanup=deferred <path>` |
+| postflight | 2 | `POSTFLIGHT: VIOLATION` | automatic FAIL evidence; do not merge |
+| postflight | 3 | `POSTFLIGHT: CONFLICT` | decomposition failure: kill and re-spec |
+| postflight | 5 | `POSTFLIGHT: ERROR` | abort partial merge state; manual fallback |
 
-The scripts never post to the tracker, never grade, and never resolve
-conflicts. A postflight exit 5 is the only typed path that routes to the
-manual integration fallback below; exit 2 and exit 3 are rulings, not fallback
-requests.
+The scripts never post to the tracker, never grade, never resolve
+conflicts. Only exit 5 routes to the manual fallback; 2 and 3 are rulings.
 
 ## Integration commands
 
-Integration is architect-only, after per-job postflight passes. The default
-path is `postflight.ps1` or `postflight.sh` from `## Preflight and postflight
-dispatch`; it performs the touch-set audit, merge, optional push, and cleanup
-from the config. The manual sequence below is the recorded fallback for exit 5
-or an environment where the script cannot run. The `.architect/wt/<run>/<slice>-<NN>`
-paths below are Codex-backend only. For Claude-backend jobs, skip `worktree
-add`/`worktree remove`; commit inside the harness's auto-created worktree, then
-`git -C <repo-root> merge --no-ff <agent-worktree-branch>` from the agent
-worktree's branch.
-
-Recorded fallback manual sequence:
+Architect-only, after per-job postflight passes; the default path is
+`postflight.ps1|.sh`. The manual sequence below is the recorded fallback
+for exit 5 or an environment where the script cannot run. The
+`.architect/wt/` paths are Codex-backend only; for Claude-backend jobs skip
+`worktree add`/`remove`, commit inside the harness worktree, then
+`git -C <repo-root> merge --no-ff <agent-worktree-branch>`.
 
 ```bash
 git -C <repo-root> checkout -b slice/<name> <freeze-sha>
@@ -239,41 +247,33 @@ git -C <repo-root> worktree remove .architect/wt/<run>/<slice>-<NN>
 git -C <repo-root> branch -d job/<run>/<slice>-<NN>
 ```
 
-A merge conflict means the job plan was not disjoint. Kill the conflicting
-job and re-spec; do not hand-resolve builder conflicts.
+A merge conflict means the plan was not disjoint: kill the conflicting job
+and re-spec; do not hand-resolve.
 
 ## Issue conventions
 
-In markdown mode, every command below maps to an orchestrator file operation; see `tracker.md` `## Command mapping`.
+In markdown mode every command below maps to an orchestrator file operation
+(`tracker.md` `## Command mapping`).
 
 Every run issue body ends with `<!-- architect-run: <run> -->`. A sub-issue
-under the run parent with the wrong author or missing run marker is never
-dispatched; escalate it on the tracking-issue digest.
+under the run parent with the wrong author or missing marker is never
+dispatched; escalate it on the digest.
 
-In github mode, create sub-issues with native edges:
-`gh issue create --title <t> --body-file <f> --parent <tracking-n> --blocked-by <n,n>`.
-Parent and blocker edges recorded only as body or title text are retired for
-github mode; the status emitter reads `--json parent,blockedBy`.
+Github mode creates sub-issues with native edges:
+`gh issue create --title <t> --body-file <f> --parent <tracking-n>
+--blocked-by <n,n>`. Body/title-only edge text is retired; the status
+emitter reads `--json parent,blockedBy`.
 
-Claim is an orchestrator action, never a builder action: the orchestrator is
-the single dispatcher and assigns exactly one issue per job before spawning.
-A builder never self-claims or picks its own next issue.
-
-On current backends, builders usually cannot post to issues: Codex has no
-network, and Claude subagents have a shell-strip watch item. `MIRROR:
-ORCHESTRATOR` is normal; direct builder posting stays permitted where supported.
+Claim is an orchestrator action — one issue per job, assigned before
+spawning; a builder never self-claims:
 
 ```bash
 gh issue edit <n> --add-assignee "@me"   # orchestrator claims, before dispatch
 ```
 
-Builder comments on its own issue are limited to four kinds, never one per
-commit:
-
-- One PHASE-0 disagreements comment, before building.
-- `BLOCKED: <exact blocker> + what I tried` (a blocker is a completion event).
-- One milestone comment, only if the job is long enough to warrant one.
-- The final STATUS mirror (the job report's status line, verbatim).
+Builders usually cannot post (Codex has no network; Claude subagents have a
+shell-strip watch item) — `MIRROR: ORCHESTRATOR` is normal. Builder
+comments on its own issue are exactly four kinds, never one per commit:
 
 ```bash
 gh issue comment <n> --body "PHASE 0: <disagreements, or what I checked>"
@@ -282,17 +282,12 @@ gh issue comment <n> --body "MILESTONE: <what completed so far>"
 gh issue comment <n> --body "STATUS: <the report's exact status line>"
 ```
 
-Orchestrator comments on the sub-issue: rulings, blocker answers, and the
-checkrun result + decisive reason at close. The final review's verdict plus
-fix-issue list and the batched escalation digest go on the tracking issue
-only. The reviewer's dispatch block cites the installed user-level
-`final-review` skill text by explicit path, never the repo or worktree copy.
-When a recorded ruling replaces a checkrun, append `GRADED-BY-RULING:` to `docs/jobs/<run>/<issue-slug>-rulings.md`; `ground.ps1|.sh` treats that report as graded.
-On findings, the orchestrator harvests the review spec, fix-issue drafts, and
-check drafts out of the reviewer worktree before discarding it, commits them
-as the fix-wave freeze, and updates the tracking-issue body's freeze record
-to the latest freeze SHA (prior SHAs stay in comments). Fix-issue dispatch
-reuses the builder block template below — no new machinery.
+Orchestrator comments: rulings, blocker answers, checkrun result + decisive
+reason at close on the sub-issue; the review verdict and batched digest on
+the tracking issue only. The reviewer's dispatch block cites the installed
+user-level `final-review` skill text by explicit path. When a recorded
+ruling replaces a checkrun, append `GRADED-BY-RULING:` to the rulings file.
+Fix-issue dispatch reuses the builder block template — no new machinery.
 
 ```bash
 gh issue comment <n> --body "RULING: <decision> - <one line why>"
@@ -302,22 +297,17 @@ gh issue comment <tracking-issue-n> --body "REVIEW: GREEN" # or "REVIEW: FINDING
 gh issue comment <tracking-issue-n> --body "DIGEST: <batched escalations + run summary>"
 ```
 
-Cadence and size hold regardless of author: comments land at least 1 minute
-apart, each under 65,000 characters, and never one per commit (host-side
-secondary rate limits). A running builder does NOT re-read issue comments
-mid-job — the issue is the durable log, not a channel the builder polls; an
-answer reaches the builder only through a fresh respawn's spawn context (see
-"Respawn-with-answer template").
+Cadence: comments at least 1 minute apart, under 65,000 characters
+(host-side rate limits). A running builder does NOT re-read issue comments
+mid-job; answers arrive only through a fresh respawn's spawn context.
 
 ## Monitor dispatch
 
 Every dispatch event re-arms the watchdog: initial wave, job END
-recompute-and-dispatch, blocker respawn, and fix-wave dispatch. The
-orchestrator writes a fresh config covering every in-flight CLI-launched
-builder/subagent from either a Claude Code or Codex orchestrator, then launches
-the platform script as a foreground child of a long-lived Bash task:
-`watchdog.ps1` on Windows, `watchdog.sh` on POSIX. The config uses the spec's
-Interface contract:
+recompute-and-dispatch, blocker respawn, fix-wave dispatch. Write a fresh
+config covering every in-flight CLI-launched job, then launch the platform
+script (`watchdog.ps1` / `watchdog.sh`) as a foreground child of a
+long-lived Bash task:
 
 ```json
 {
@@ -329,35 +319,28 @@ Interface contract:
   ]
 }
 ```
-Codex jobs may set `rollout_glob` to override the default `~/.codex/sessions/*/*/*/rollout-*<thread_id>*.jsonl` derivation.
 
-The watchdog detects mechanically; the orchestrator supplies the reasoning.
-The watchdog never kills, nudges, or judges. It exits with typed evidence:
+Codex jobs may set `rollout_glob` to override the default
+`~/.codex/sessions/*/*/*/rollout-*<thread_id>*.jsonl` derivation. The
+watchdog detects mechanically — never kills, nudges, or judges — and exits
+typed:
 
 | Exit | Prefix | Meaning |
 |---|---|---|
-| 0 | `WATCHDOG: ALL_DONE` | every job report exists, with path and byte size evidence |
-| 2 | `WATCHDOG: INTEGRATED` | a job worktree or events file vanished because the orchestrator integrated it mid-sweep |
-| 3 | `WATCHDOG: STALL` | wrapper heartbeat is fresh but event/report growth stopped beyond `stall_after_min` plus any duration hint |
-| 4 | `WATCHDOG: REPEAT` | the last four parsed command events were identical and need an intentional-vs-stuck ruling |
-| 5 | `WATCHDOG: ERROR` | watchdog config is missing or unreadable |
-| 6 | `WATCHDOG: REPORT_READY` | terminal `STATUS:` exists, `job.exit.json` is absent, and the wrapper heartbeat is stale |
-| 7 | `WATCHDOG: ORPHANED` | wrapper heartbeat is stale but event/report output still grows |
-| 8 | `WATCHDOG: DEAD` | wrapper heartbeat is stale and no event/report output is growing |
-| 9 | `WATCHDOG: DONE_FAILED` | child exited nonzero, or exited 0 without terminal `STATUS:` |
-| 10 | `WATCHDOG: LEGACY_UNWRAPPED` | job lacks wrapper metadata and cannot provide deterministic exit truth |
-| 11 | `WATCHDOG: BLOCKED_ON_TOOL` | heartbeat is fresh, output is stalled, and the freshest stream ends at a started tool/function call with no result |
+| 0 | `WATCHDOG: ALL_DONE` | every job report exists, with path and byte size |
+| 2 | `WATCHDOG: INTEGRATED` | a worktree/events file vanished via mid-sweep integration |
+| 3 | `WATCHDOG: STALL` | heartbeat fresh but growth stopped past `stall_after_min` + hint |
+| 4 | `WATCHDOG: REPEAT` | last four parsed command events identical |
+| 5 | `WATCHDOG: ERROR` | config missing or unreadable |
+| 6 | `WATCHDOG: REPORT_READY` | terminal `STATUS:` exists, exit truth absent, heartbeat stale |
+| 7 | `WATCHDOG: ORPHANED` | heartbeat stale but output still grows |
+| 8 | `WATCHDOG: DEAD` | heartbeat stale, nothing growing, no terminal report |
+| 9 | `WATCHDOG: DONE_FAILED` | child exited nonzero, or 0 without terminal `STATUS:` |
+| 10 | `WATCHDOG: LEGACY_UNWRAPPED` | no wrapper metadata; no deterministic exit truth |
+| 11 | `WATCHDOG: BLOCKED_ON_TOOL` | heartbeat fresh, output stalled, stream ends at a started tool call |
 
-Use the LLM fallback only for backends where the orchestrator cannot launch or
-wait on a long-lived Bash task whose exit wakes the loop.
-
-## Status display
-
-`skills/architect/status.ps1 [<run-slug>] [-RepoRoot <path>]` (Windows) and
-`skills/architect/status.sh [<run-slug>] [--repo-root <path>]` (POSIX) read
-only run artifacts plus tracker state; the first positional is always a run
-slug.
-Piped output is plain text by design; callers print it verbatim instead of hand-composing status.
+Use the LLM fallback only where the orchestrator cannot wait on a
+long-lived Bash task exit:
 
 <!-- architect-monitor-fallback-template:start -->
 ```text
@@ -385,109 +368,106 @@ Any stall, wedged tool call, or repeat concern exits immediately with the job id
 ```
 <!-- architect-monitor-fallback-template:end -->
 
-Native harness note: built-in subagents cap at 5 concurrent jobs. CLI-launched
-`codex exec`/`claude -p` style jobs cap at 10 and do not consume native
-subagent slots; if an LLM fallback monitor is running in native-harness mode,
-reserve one slot.
+Native harness note: built-in subagents cap at 5; CLI-launched jobs cap at
+10 and consume no native slots. An LLM fallback monitor in native-harness
+mode reserves one slot.
+
+## Status display
+
+`skills/architect/status.ps1 [<run-slug>] [-RepoRoot <path>]` and
+`skills/architect/status.sh [<run-slug>] [--repo-root <path>]` read only
+run artifacts plus tracker state; the first positional is always a run
+slug. Output is plain text by design; print it verbatim, never
+hand-compose status.
 
 ## Duration hints and liveness
 
-There are no per-command kill ceilings. Long test suites are legitimate work,
-not stalls. Issue bodies and check files may carry duration *hints* (e.g.
-"full suite ~ 20m") so the monitor does not flag a job early; a hint is
-informative context for the monitor, never a ceiling anything enforces.
+No per-command kill ceilings: long test suites are legitimate work. Issue
+bodies and check files may carry duration *hints* (e.g. "full suite ~ 20m")
+— informative context for the monitor, never an enforced ceiling.
 
-Builder edits, orchestrator exercises: spawn-heavy checks that cannot run in the sandbox are named as orchestrator-side bounded RUN evidence; the builder performs edits plus static/local verification only.
-
-Sanctioned substitutions:
+Builder edits, orchestrator exercises: spawn-heavy checks that cannot run
+in the sandbox become orchestrator-side bounded RUN evidence; the builder
+does edits plus static/local verification only.
 
 Executor truth for sandboxed jobs: MSYS2/Cygwin-runtime binaries (Git for
-Windows `bash.exe`, `usr/bin/grep.exe`, `sed.exe`) die at startup under the
-Codex Windows sandbox because Cygwin's named shared-memory `CreateFileMapping`
-is denied with Win32 error 5 under the sandbox's dedicated-user restricted
-token. Native `git.exe` and PowerShell are unaffected; POSIX/macOS/Linux
-sandboxes are unaffected. Known upstream: openai/codex#12000 and
-openai/codex#21715. Therefore check files name the platform-native executor
-primary for sandboxed jobs: PowerShell + native git subcommands on Windows,
-bash on POSIX; the recorded same-pattern substitution rule stays for
-everything else.
+Windows `bash.exe`, `grep.exe`, `sed.exe`) die at startup under the Codex
+Windows sandbox (Cygwin shared-memory `CreateFileMapping` denied, Win32
+error 5, under the restricted token; upstream openai/codex#12000, #21715).
+Native `git.exe` and PowerShell are unaffected; POSIX sandboxes are
+unaffected. Check files therefore name the platform-native executor primary
+for sandboxed jobs: PowerShell + native git on Windows, bash on POSIX.
 
-| Condition | Substitution | Provenance |
-|---|---|---|
-| Git Bash CreateFileMapping Win32 error 5 in Codex Windows sandbox | PowerShell + native git same-pattern, recorded per check | evidence: factory-hardening research, git history |
-| `uv` AppData cache denial (os error 5) | `UV_CACHE_DIR=.architect/tmp/uv-cache`, recorded | evidence: uv-cache sandbox redirect, git history |
-| pytest tmpdir `mkdir(mode=0o700)` WinError 5 in Codex Windows sandbox | wrapper `--sandbox-env` TEMP/TMP/TMPDIR redirect | evidence: pair-fairness-webui-2026-07 probes |
-| Tracker posting unavailable in sandbox | `MIRROR: ORCHESTRATOR` in the report | evidence: subagent shell-strip codex fallback, git history |
+Sanctioned substitutions, recorded per use:
+
+| Condition | Substitution |
+|---|---|
+| Git Bash CreateFileMapping error 5 in Codex Windows sandbox | PowerShell + native git, same pattern |
+| `uv` AppData cache denial (os error 5) | `UV_CACHE_DIR=.architect/tmp/uv-cache` |
+| pytest tmpdir `mkdir(mode=0o700)` WinError 5 | wrapper `--sandbox-env` TEMP/TMP/TMPDIR redirect |
+| Tracker posting unavailable in sandbox | `MIRROR: ORCHESTRATOR` in the report |
 
 ## Orchestrator shell hygiene
 
-Use absolute paths in every orchestrator shell command. Write dispatch,
-verification, and config blocks with file tools, never heredocs. Never rely on a
-persisted cwd across commands; run #30 lost three commands to current-directory
-drift before this rule was written down.
+Absolute paths in every orchestrator shell command. Write dispatch,
+verification, and config blocks with file tools, never heredocs. Never rely
+on a persisted cwd across commands.
 
 Liveness is judged from wrapper-owned files, never cross-session process
-enumeration. On Windows under Claude Code, launch long-lived CLI jobs through
-its Bash wrapper when available; the PowerShell wrapper exists for harnesses
-where Bash is stripped.
+enumeration. On Windows under Claude Code, launch long-lived CLI jobs
+through its Bash wrapper when available; the PowerShell wrapper exists for
+harnesses where Bash is stripped.
 
-- `DONE_OK` requires `job.exit.json` exit 0 AND a report whose final nonblank line starts with `STATUS:`; every other child exit is `DONE_FAILED`; terminal-looking report text never outranks a fresh wrapper heartbeat.
+- `DONE_OK` requires `job.exit.json` exit 0 AND a report whose final
+  nonblank line starts with `STATUS:`; every other child exit is
+  `DONE_FAILED`. Terminal-looking report text never outranks a fresh
+  wrapper heartbeat.
 - `job.state.json` persists growth clocks across watchdog re-arms.
-- A job repeatedly issuing the same command or query with identical arguments is stalled even while output grows (the tail repeat-command check).
-- Stale heartbeat plus growing output is `ORPHANED`, not `DEAD`; the
-  orchestrator rules from artifacts.
+- A job repeating the same command with identical arguments is stalled even
+  while output grows.
+- Stale heartbeat plus growing output is `ORPHANED`, not `DEAD`; rule from
+  artifacts.
 - Wrappers write child stdout to `events.jsonl` and stderr to `stderr.log`;
-  watchdog growth includes both, repeat-command checks stay stdout-only, and
-  `DONE_FAILED` diagnosis reads `stderr.log` directly.
+  growth counts both, repeat-command checks stay stdout-only, `DONE_FAILED`
+  diagnosis reads `stderr.log` directly.
 
-On Windows PowerShell 5.1, `>`, `*>`, and `Tee-Object` write UTF-16. Liveness
-and rescue checks over event files must read encoding-aware (`Get-Content`,
-or `iconv` from UTF-16); byte-oriented grep can silently miss growth.
+On Windows PowerShell 5.1, `>`, `*>`, and `Tee-Object` write UTF-16; read
+event files encoding-aware (`Get-Content`, or `iconv`) — byte-oriented grep
+can silently miss growth.
 
-Known sandbox hang sources:
-
-- `asyncio.create_subprocess_exec` and anything built on it: Playwright browser
-  launch, anyio subprocess pools, and similar runtime harnesses. Plain
-  `subprocess.run` works.
-- Out-of-workspace temp paths under workspace-write. Prescribe
-  `.architect/tmp/<purpose>` paths, `--basetemp .architect/tmp/<check-id>`, and
-  in-workspace cache dirs.
+Known sandbox hang sources: `asyncio.create_subprocess_exec` and anything
+built on it (Playwright launch, anyio subprocess pools) — plain
+`subprocess.run` works; out-of-workspace temp paths under workspace-write —
+prescribe `.architect/tmp/<purpose>`, `--basetemp
+.architect/tmp/<check-id>`, and in-workspace caches.
 
 ## Respawn-with-answer template
 
-Respawn-over-resume is the default recovery path (D7): a fresh builder
-spawns into the same issue's job. Same-session resume is only for a harness
-that supports live messaging while the existing session's context is still
-young.
+Respawn-over-resume is the default recovery (D7): a fresh builder spawns
+into the same issue's job. Resume only where the harness supports live
+messaging and the session context is still young. The respawn block has
+four pieces:
 
-The respawn spawn block is built from four pieces:
+1. The original issue body — unchanged.
+2. The orchestrator's answer or ruling, posted as an issue comment first
+   and copied verbatim into the spawn context (the only delivery channel).
+3. What the previous session completed — from its job report and the
+   worktree's actual `git status`/`git diff`, never assumed.
+4. Boundaries exactly as decomposed: MAY TOUCH / MUST NOT TOUCH unchanged.
 
-1. The original issue body (task, boundaries, check pointer) — unchanged.
-2. The orchestrator's answer or ruling — a blocker's answer, a failure
-   diagnosis, or a rescue root cause — posted as an issue comment first (the
-   issue is the durable log) and copied verbatim into the spawn context (the
-   spawn context is the delivery channel; a running builder does not re-read
-   issue comments).
-3. What the previous session completed — read from its job report
-   (`docs/jobs/<run>/<issue-slug>-01.md`) and the worktree's actual `git status` /
-   `git diff`, never assumed from conversation.
-4. Boundaries unchanged from the original issue: MAY TOUCH / MUST NOT TOUCH
-   stay exactly as decomposed.
+Sandbox-hang rescue ladder, before respawn:
 
-For a sandbox hang specifically (a wedged job that never gets to post a
-blocker comment), this rescue ladder finds the root cause before respawn:
-
-1. Kill stuck wrapped jobs first with `kill-job.ps1|.sh <job-dir>`; it reads `job.meta.json`, terminates the recorded `pgid`/`job_object`, and waits for wrapper exit truth.
-2. If a native background subagent repeats the same hang, stop that job and
-   discard the worktree. Re-dispatch only after the issue text forbids the
-   failing path or command.
-3. If using the Codex backend path from Claude, resume only within the same
-   job and same issue. Put global flags before `resume`; `-C` after `resume`
-   is rejected. The thread id is in the first `thread.started` event.
-4. If resume fails or hangs again, discard the job and respawn fresh from
-   the frozen check file with the root cause named as forbidden.
-
-Rescue/respawn block template:
+1. Kill stuck wrapped jobs with `kill-job.ps1|.sh <job-dir>`; it reads
+   `job.meta.json`, terminates the recorded `pgid`/`job_object`, and waits
+   for wrapper exit truth.
+2. A native background subagent repeating the same hang: stop it, discard
+   the worktree, re-dispatch only after the issue text forbids the failing
+   path or command.
+3. Codex-backend resume: only within the same job and issue; global flags
+   before `resume` (`-C` after is rejected); thread id is in the first
+   `thread.started` event.
+4. If resume fails or hangs again, discard and respawn fresh from the
+   frozen check with the root cause named as forbidden.
 
 ```text
 You are resuming issue #<n>. Do not redo completed edits; working-tree edits
@@ -520,15 +500,12 @@ Boundaries remain:
 
 ## Cross-model review
 
-Use cross-model review for high-stakes slices: schema, API, persistence,
-security, data loss, auth, or broad architectural changes. The reviewer's job
-is to break confidence in the change with correctness, requirement, or
-invariant gaps grounded in file:line evidence; no style nits.
-
-Direction matters. In the one available study, Claude reviewing Codex output
-helped, while Codex reviewing Claude output hurt. Prefer Claude-reviews-Codex
-when the direction is choosable, and record the direction in the verdict
-comment.
+For high-stakes slices (schema, API, persistence, security, data loss,
+auth, broad architecture): a reviewer whose job is to break confidence with
+correctness, requirement, or invariant gaps grounded in file:line evidence
+— no style nits. Direction matters: the one available study found
+Claude-reviews-Codex helped and the reverse hurt; prefer that direction and
+record it in the verdict comment.
 
 ## Builder block template
 
@@ -611,10 +588,11 @@ fully handled end-to-end.
 
 ## Builder-side standing setup
 
-- Builders never commit; the orchestrator does. Workspace-write protects `.git`
-  as read-only in Codex on Windows, including worktree pointer resolution.
-- Repo `AGENTS.md`: exact build/test commands and repo gotchas only. The
-  loop's PHASE rules stay in the dispatch block so they version with the skill.
-- Subscription quotas are per-window plus weekly cap. For unattended runs that
-  must not die mid-run, use the harness-native paid or scheduled mechanism
-  rather than repo-owned loop infrastructure.
+- Builders never commit; the orchestrator does. Workspace-write protects
+  `.git` as read-only in Codex on Windows, including worktree pointers.
+- Repo `AGENTS.md` carries exact build/test commands and repo gotchas only;
+  the loop's PHASE rules stay in the dispatch block so they version with
+  the skill.
+- Unattended runs that must not die mid-run use the harness-native paid or
+  scheduled mechanism, not repo-owned loop infrastructure (subscription
+  quotas are per-window plus weekly cap).

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -10,15 +10,15 @@
 - Hard Stops
 - Context discipline
 
-The loop is one orchestrator session that runs the factory to completion after
-the spec approval approves the issue plan. Tracker issues carry coordination
+The loop is one orchestrator session that runs the factory to completion once
+the hardened plan is published and frozen. Tracker issues carry coordination
 state; git carries specs and frozen checks. The orchestrator dispatches the
 ready issues, sleeps, and wakes only on an event.
-Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap at 10 concurrent jobs; harness-native result-bearing subagents (Claude Agent tool, Codex `spawn_agent`) use the harness cap, currently 5, and Claude Agent-tool verification still dispatches synchronously with `run_in_background: false`; a job END (DONE or BLOCKED) is a dispatch event that recomputes the full ready frontier and dispatches every ready issue into a free slot before grading (Factory block procedure step 3); merges recompute the frontier too, since a merge can unblock issues no END could; independent orchestrator bookkeeping batches into parallel calls; merges, synthesis, and the pre-freeze `adversarial-review` stress pass stay serial by design.
+Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap at 10 concurrent jobs; harness-native result-bearing subagents (Claude Agent tool, Codex `spawn_agent`) use the harness cap, currently 5, and Claude Agent-tool verification still dispatches synchronously with `run_in_background: false`; a job END (DONE or BLOCKED) is a dispatch event that recomputes the full ready frontier and dispatches every ready issue into a free slot before grading (Factory block procedure step 3); merges recompute the frontier too, since a merge can unblock issues no END could; independent orchestrator bookkeeping batches into parallel calls; merges and synthesis stay serial by design.
 
 ## Factory block procedure
 
-1. **Dispatch the ready issues.** Compute the ready issues of the approved
+1. **Dispatch the ready issues.** Compute the ready issues of the frozen
    plan: up to 10 CLI-launched builder jobs, or 5 harness-native builder
    subagents (see Monitor protocol, and `dispatch.md` "## Monitor dispatch"). Check `docs/STOP` and
    `docs/runs/<run>/STOP` before every wave. Re-arm one watchdog over all
@@ -38,12 +38,12 @@ Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap
      from the frozen check with a route-around).
    - **Ruling timer expiry.** A pending timed ruling's timer exit is a wake:
      if the ruling is still unanswered in-session and on the tracker, apply
-     the recommended default and record the auto-ruling (timed-ruling
-     protocol, SKILL.md "### 2. Spec Approval"); already resolved is a no-op.
+     the recommended default and record the auto-ruling (SKILL.md
+     "## Timed-ruling protocol"); already resolved is a no-op.
 4. **Recompute the ready issues.** Closing an issue may unblock others; rerun
    `ground.ps1|.sh <run>`, read its `FRONTIER:` line, and dispatch the next
    wave from it.
-5. **Finish boundary.** When build issues close, run the SKILL.md `### 5. Finish` timed-ruling closing review before integrate: default YES, 5-minute silence applies; YES dispatches one fresh resolved-strategist MEDIUM subagent from the factory branch head running the `final-review` stage skill, cited by its installed user-level skill path — review basis spec -> run diff -> published interface contract blocks — read-only over product code, reporting and decomposing rather than editing. A GREEN verdict short-circuits straight to integrate. A `REVIEW: FINDINGS n=<count>` verdict names a review spec, fix-issue drafts, and check drafts; the orchestrator harvests the three draft sets, discards the reviewer worktree, runs the frozen-checks freeze gate over every draft RUN command, commits the fix-wave freeze with the tracking-issue body's freeze record updated to the latest freeze SHA, files the fix issues, posts the verdict plus fix-issue list as the digest, and dispatches the fix wave through the existing wave machinery at the builders tier. Integrate fires after the fix wave has merged, after a GREEN verdict, or after a recorded ruling skips the review; its first step is the docs pass (SKILL.md `### 5. Finish`).
+5. **Finish boundary.** When build issues close, run the SKILL.md `### 5. Finish` closing sequence before integrate: the orchestrator executes the closing test pass (builder-built suites plus every frozen RUN item at the factory branch head, raw output captured), then always dispatches one fresh resolved-strategist MEDIUM subagent from the factory branch head running the `final-review` stage skill, cited by its installed user-level skill path, with the test-pass output in its dispatch block — review basis spec -> run diff -> published interface contract blocks -> test-pass output — read-only over product code, reporting and decomposing rather than editing. A GREEN verdict short-circuits straight to integrate. A `REVIEW: FINDINGS n=<count>` verdict names a review spec, fix-issue drafts, and check drafts; the orchestrator harvests the three draft sets, discards the reviewer worktree, runs the frozen-checks freeze gate over every draft RUN command, commits the fix-wave freeze with the tracking-issue body's freeze record updated to the latest freeze SHA, files the fix issues, posts the verdict plus fix-issue list as the digest, and dispatches the fix wave through the existing wave machinery at the builders tier. Integrate fires after the fix wave has merged, after a GREEN verdict, or after a recorded ruling skips the review; its first step is the docs pass (SKILL.md `### 5. Finish`).
 Run `sweep-deferred.ps1|.sh <run>` before final close to clear deferred worktree cleanup paths.
 6. **Repeat** until no issues remain open, the closing review/integrate finish boundary is handled, then post the escalation digest's end-of-run summary on the tracking issue.
 
@@ -138,7 +138,7 @@ Batched on the tracking issue instead of interleaved per-job noise:
 
 - completed and failed jobs, with checkrun results
 - open blockers and the answers given
-- decisions the approved spec genuinely does not answer
+- decisions the hardened spec genuinely does not answer
 - foreign sub-issues under the run parent with wrong author or missing run marker
 
 Ask-the-human items are batched here unless a hard stop below requires an
@@ -157,9 +157,9 @@ immediate stop.
 | Third strike inside the fix wave | A third strike inside the fix wave is a hard stop — the closing review is already spent. |
 | Two consecutive KILLs | Stop the factory and ask the human. |
 | Monitor reports an anomaly | Orchestrator rules before any further dispatch on that job. |
-| Blocker collides with a recorded assumption | Ask the human; it is a spec approval decision surfacing late. |
+| Blocker collides with a recorded assumption | Ask the human; it is a spec-level decision surfacing late. |
 | Session context degrades | End the session; the next session grounds from the issue tracker and git. |
-| Scope grows beyond the approved spec | Stop the factory. |
+| Scope grows beyond the hardened spec | Stop the factory. |
 | High-stakes issue | Add cross-model review before CONTINUE. |
 
 ## Context discipline

--- a/skills/architect/loop.md
+++ b/skills/architect/loop.md
@@ -8,165 +8,155 @@
 - Failure ladder
 - Escalation digest
 - Hard Stops
-- Context discipline
 
-The loop is one orchestrator session that runs the factory to completion once
-the hardened plan is published and frozen. Tracker issues carry coordination
-state; git carries specs and frozen checks. The orchestrator dispatches the
-ready issues, sleeps, and wakes only on an event.
-Parallel rules: CLI-launched builders (`codex exec -o <file>` or equivalent) cap at 10 concurrent jobs; harness-native result-bearing subagents (Claude Agent tool, Codex `spawn_agent`) use the harness cap, currently 5, and Claude Agent-tool verification still dispatches synchronously with `run_in_background: false`; a job END (DONE or BLOCKED) is a dispatch event that recomputes the full ready frontier and dispatches every ready issue into a free slot before grading (Factory block procedure step 3); merges recompute the frontier too, since a merge can unblock issues no END could; independent orchestrator bookkeeping batches into parallel calls; merges and synthesis stay serial by design.
+One orchestrator session runs the factory to completion once the hardened
+plan is published and frozen. Tracker issues carry coordination state; git
+carries specs and frozen checks. Parallel rules: CLI-launched builders
+(`codex exec -o <file>` or equivalent) cap at 10 concurrent jobs;
+harness-native result-bearing subagents use the harness cap (currently 5),
+and Claude Agent-tool verification dispatches synchronously with
+`run_in_background: false`. A job END (DONE or BLOCKED) is a dispatch event
+that recomputes the full ready frontier and dispatches every ready issue
+into a free slot before grading; merges recompute the frontier too.
+Independent bookkeeping batches into parallel calls; merges and synthesis
+stay serial.
 
 ## Factory block procedure
 
-1. **Dispatch the ready issues.** Compute the ready issues of the frozen
-   plan: up to 10 CLI-launched builder jobs, or 5 harness-native builder
-   subagents (see Monitor protocol, and `dispatch.md` "## Monitor dispatch"). Check `docs/STOP` and
+1. **Dispatch.** Compute the ready issues from `ground.ps1|.sh <run>`'s
+   `FRONTIER:` line, up to the cap. Check `docs/STOP` and
    `docs/runs/<run>/STOP` before every wave. Re-arm one watchdog over all
    in-flight CLI-launched jobs at every dispatch event.
-2. **Sleep.** Zero orchestrator work between dispatch and the next event —
-   no polling.
-3. **Wake on one event**, exactly one of:
-   - **Job DONE.** A job END (DONE or BLOCKED) is a dispatch event: before grading the finished job, recompute the full ready frontier — run `skills/architect/ground.ps1|.sh <run>` and read its `FRONTIER:` line as the source, covering newly unblocked issues AND previously-ready issues queued beyond the concurrency cap — dispatch every ready issue into a free slot, and re-arm the watchdog over all in-flight CLI-launched jobs; one completion may launch multiple builders. Merges still recompute the frontier too, since a merge can unblock issues no END could. Ordering: after that recompute-and-dispatch, write the runner config; launch `check-runner.ps1` or `check-runner.sh` as a foreground child of a long-lived Bash task whose exit is the next wake. Exit 0: post the checkrun result on the issue (the evidence file `docs/jobs/<run>/<issue-slug>-checkrun.md` is a local run artifact; the tracker comment is the durable record), then run `postflight.ps1` or `postflight.sh` — no per-issue model review exists on this path: exit 0 `POSTFLIGHT: OK` means merge completed with clean touch-set evidence; exit 2 `POSTFLIGHT: VIOLATION` is automatic FAIL evidence; exit 3 `POSTFLIGHT: CONFLICT` is the decomposition-failure rail; exit 5 `POSTFLIGHT: ERROR` falls back to the recorded manual integration sequence in `dispatch.md`. Exit 2: post failure evidence and enter the Failure ladder. Exit 5: stay on the recorded error rail.
-   - **Job BLOCKED.** A blocker comment on the issue is a completion event.
-     Read it, rule an answer, and respawn a fresh builder job on the same
-     issue with the answer in its spawn context (see `dispatch.md`
-     "## Respawn-with-answer template"). A running job never re-reads its
-     own comments — the spawn context is the only delivery channel.
-   - **Monitor ANOMALY.** Read the evidence report and rule one of:
-     healthy-long-run (re-arm the watchdog, sleep again), needs a nudge
-     or answer, or wedged (kill the job, discard its worktree, respawn
-     from the frozen check with a route-around).
-   - **Ruling timer expiry.** A pending timed ruling's timer exit is a wake:
-     if the ruling is still unanswered in-session and on the tracker, apply
-     the recommended default and record the auto-ruling (SKILL.md
-     "## Timed-ruling protocol"); already resolved is a no-op.
-4. **Recompute the ready issues.** Closing an issue may unblock others; rerun
-   `ground.ps1|.sh <run>`, read its `FRONTIER:` line, and dispatch the next
-   wave from it.
-5. **Finish boundary.** When build issues close, run the SKILL.md `### 5. Finish` closing sequence before integrate: the orchestrator executes the closing test pass (builder-built suites plus every frozen RUN item at the factory branch head, raw output captured), then always dispatches one fresh resolved-strategist MEDIUM subagent from the factory branch head running the `final-review` stage skill, cited by its installed user-level skill path, with the test-pass output in its dispatch block — review basis spec -> run diff -> published interface contract blocks -> test-pass output — read-only over product code, reporting and decomposing rather than editing. A GREEN verdict short-circuits straight to integrate. A `REVIEW: FINDINGS n=<count>` verdict names a review spec, fix-issue drafts, and check drafts; the orchestrator harvests the three draft sets, discards the reviewer worktree, runs the frozen-checks freeze gate over every draft RUN command, commits the fix-wave freeze with the tracking-issue body's freeze record updated to the latest freeze SHA, files the fix issues, posts the verdict plus fix-issue list as the digest, and dispatches the fix wave through the existing wave machinery at the builders tier. Integrate fires after the fix wave has merged, after a GREEN verdict, or after a recorded ruling skips the review; its first step is the docs pass (SKILL.md `### 5. Finish`).
-Run `sweep-deferred.ps1|.sh <run>` before final close to clear deferred worktree cleanup paths.
-6. **Repeat** until no issues remain open, the closing review/integrate finish boundary is handled, then post the escalation digest's end-of-run summary on the tracking issue.
+2. **Sleep.** No orchestrator work between events; no polling.
+3. **Wake on exactly one event:**
+   - **Job DONE.** Recompute the frontier and dispatch into free slots
+     first — one completion may launch several builders. Then write the
+     runner config and launch `check-runner.ps1|.sh` as a foreground child
+     of a long-lived Bash task whose exit is the next wake. Runner exit 0:
+     post the checkrun result on the issue (the evidence file
+     `docs/jobs/<run>/<issue-slug>-checkrun.md` is local; the comment is the
+     durable record), then run `postflight.ps1|.sh` — exit 0
+     `POSTFLIGHT: OK` merged with clean touch-set evidence; 2 `VIOLATION`
+     automatic FAIL; 3 `CONFLICT` decomposition-failure rail; 5 `ERROR`
+     manual-integration fallback (`dispatch.md`). Runner exit 2: post
+     failure evidence, enter the Failure ladder. Exit 5: recorded error
+     rail.
+   - **Job BLOCKED.** The blocker comment is a completion event: rule an
+     answer, respawn fresh with the answer in spawn context (`dispatch.md`
+     "## Respawn-with-answer template"); a running job never re-reads its
+     own comments.
+   - **Monitor ANOMALY.** Rule one of: healthy-long-run (re-arm, sleep),
+     needs a nudge or answer, or wedged (kill the job, discard its
+     worktree, respawn from the frozen check with a route-around).
+   - **Ruling timer expiry.** If still unanswered in-session and on the
+     tracker, apply the recommended default and record the auto-ruling
+     (SKILL.md "## Timed-ruling protocol").
+4. **Recompute the frontier** after any close; dispatch the next wave.
+5. **Finish boundary.** When build issues close, run SKILL.md
+   `### 5. Finish`: the closing test pass, then the unconditional
+   final-review dispatch with the test-pass output; GREEN short-circuits to
+   integrate, FINDINGS freezes and dispatches the fix wave. Run
+   `sweep-deferred.ps1|.sh <run>` before final close.
+6. **Repeat** until no issues remain and the finish boundary is handled;
+   post the end-of-run summary on the tracking issue.
 
 ## Monitor protocol
 
-Launch the script watchdog at every dispatch event from `dispatch.md` "## Monitor dispatch", with every currently in-flight CLI-launched job in the config. The watchdog runs as a foreground child of a long-lived Bash task and its exit wakes the orchestrator.
-It detects mechanically and never kills, nudges, or judges; the orchestrator rules on the evidence. CLI jobs must be wrapped by `run-job.ps1|.sh`; unwrapped jobs are legacy evidence and cannot be accepted as `DONE_OK`.
+Launch the script watchdog at every dispatch event (`dispatch.md`
+"## Monitor dispatch") over every in-flight CLI-launched job, as a
+foreground child of a long-lived Bash task; its exit wakes the orchestrator.
+It detects mechanically and never kills, nudges, or judges. CLI jobs must be
+wrapped by `run-job.ps1|.sh`; unwrapped jobs cannot be accepted as
+`DONE_OK`. Rulings on its typed exits:
 
-Ruling options:
+- 0 `ALL_DONE` -> grade every report listed by path and byte size.
+- 2 `INTEGRATED` -> benign mid-sweep integration; relaunch if jobs remain.
+- 3 `STALL` -> inspect; healthy-long-run vs route-around respawn.
+- 4 `REPEAT` -> rule intentional-vs-stuck (deliberate polling loops are a
+  known false positive).
+- 5 `ERROR` -> fix the watchdog config; no partial verdict.
+- 6 `REPORT_READY` -> grade only with the missing-exit-truth caveat
+  recorded on the issue.
+- 7 `ORPHANED` -> let it finish only with a recorded ruling.
+- 8 `DEAD` -> discard and respawn with evidence.
+- 9 `DONE_FAILED` -> grade as failed or respawn; never accept as done.
+- 10 `LEGACY_UNWRAPPED` -> respawn under the wrapper unless a ruling
+  accepts legacy evidence for diagnosis only.
+- 11 `BLOCKED_ON_TOOL` -> kill or route around the named command; respawn
+  with that command form recorded as forbidden or bounded.
 
-- Exit 0 `WATCHDOG: ALL_DONE` -> proceed to the grading backlog (check-runner
-  per report) for every report listed by path and byte size.
-- Exit 2 `WATCHDOG: INTEGRATED` -> benign mid-sweep integration; relaunch the
-  watchdog if any jobs remain in flight.
-- Exit 3 `WATCHDOG: STALL` -> inspect the named job and choose healthy-long-run
-  vs route-around respawn.
-- Exit 4 `WATCHDOG: REPEAT` -> rule intentional-vs-stuck before action; the
-  OpenHands false-positive caveat applies to deliberate polling loops.
-- Exit 5 `WATCHDOG: ERROR` -> fix the watchdog config; no partial verdict.
-- Exit 6 `WATCHDOG: REPORT_READY` -> report is terminal, exit truth is missing, and the wrapper heartbeat is stale; proceed to check-runner grading only with the missing-exit-truth caveat recorded on the issue.
-- Exit 7 `WATCHDOG: ORPHANED` -> wrapper died while output still grows; let it
-  finish only with a recorded ruling.
-- Exit 8 `WATCHDOG: DEAD` -> no wrapper heartbeat, no terminal report, no
-  growing output; discard and respawn with evidence.
-- Exit 9 `WATCHDOG: DONE_FAILED` -> grade as failed or respawn under the
-  wrapper; never accept it as done.
-- Exit 10 `WATCHDOG: LEGACY_UNWRAPPED` -> respawn under the wrapper unless a
-  recorded ruling accepts legacy evidence for diagnosis only.
-- Exit 11 `WATCHDOG: BLOCKED_ON_TOOL` -> kill or route around the named command, then respawn with that command form recorded as forbidden or bounded.
+Backends that cannot wake on a background process exit use the LLM fallback
+template (`dispatch.md` "## Monitor dispatch"), same detection-only rules.
 
-Backends without background-exit notifications use the LLM fallback template
-in `dispatch.md` "## Monitor dispatch". The fallback keeps the same
-detection-only boundary and per-job evidence requirements.
+Any backgrounded subagent idle without its deliverable: retrieve output via
+the harness task-output mechanism; nudge once; then discard and respawn
+fresh. The orchestrator never authors a missing result. Sync dispatch
+(`run_in_background: false`) applies to any result-bearing Claude
+Agent-tool subagent; harnesses may run such spawns async regardless — one
+poke requesting the deliverable in its fixed format, then escalate.
+
+Close-out: after consuming a subagent's final result, release or stop its
+session in the same turn, batching independent close-outs into parallel
+calls. Before postflight or discard, run `kill-job.ps1|.sh <job-dir>` for
+any consumed wrapped job with lingering children.
 
 ## Verdict comments
 
-Grading is recorded on the issue, not in a file. At each job close, one comment is posted on the job's issue with: the check-runner typed summary (`CHECKRUN SUMMARY` line plus typed exit), the postflight result, the slice call KILL/CONTINUE, and the decisive reason tied to raw evidence; exact tracker comment format lives in `dispatch.md` "## Issue conventions". The orchestrator posts the final review's verdict — `REVIEW: GREEN` or `REVIEW: FINDINGS n=<count>` plus the fix-issue list — as the run-level digest on the tracking issue; per-fix-issue verdicts follow the normal issue-conventions comment.
-The checkrun artifact `docs/jobs/<run>/<issue-slug>-checkrun.md` and the rulings file `docs/jobs/<run>/<issue-slug>-rulings.md` are local run artifacts (gitignored); the rulings file is orchestrator-owned and append-only, and if it contains `GRADED-BY-RULING:` ground counts the report as graded. The closing review receives every rulings file verbatim in its dispatch block rather than thread prose.
-The issue is closed on merge. No checkrun-result comment on an issue means the
-next factory block must not build on it as accepted; the orchestrator may re-run
-the check-runner if evidence is missing, but may not fill in a result from memory.
-
-For ANY backgrounded subagent that goes idle without its expected deliverable,
-use the recovery ladder in order: retrieve its output via the harness task-output
-mechanism; nudge once asking it to deliver the artifact; discard it and respawn
-fresh. The orchestrator never authors a missing result. The sync-dispatch rule
-(`run_in_background: false`) applies to any result-bearing Claude Agent-tool
-subagent — closing review, adversarial review, optional verification —
-but harnesses have been observed to run such spawns async regardless: an idle
-notification without the deliverable gets exactly one poke requesting delivery
-in the deliverable's fixed format before escalation.
-
-Close-out: after processing a subagent's final result — verdict, report, or
-fix — release or stop its session in the same turn, batching independent
-close-outs into parallel calls; a lingering idle session is bookkeeping debt
-and can shadow names, so never leave one open once its result is consumed. No
-polling and no per-close commentary. Before postflight or discard, run
-`kill-job.ps1|.sh <job-dir>` for any consumed wrapped job with lingering
-children.
+Grading is recorded on the issue, not in a file: one comment per job close
+with the `CHECKRUN SUMMARY` line plus typed exit, the postflight result,
+the KILL/CONTINUE call, and the decisive reason (format: `dispatch.md`
+"## Issue conventions"). The final review's verdict goes on the tracking
+issue. The checkrun artifact and the rulings file are local run artifacts
+(gitignored); `GRADED-BY-RULING:` in a rulings file makes ground count that
+report graded; the closing review receives every rulings file verbatim in
+its dispatch block. Issues close on merge. No checkrun comment means not
+accepted: the orchestrator may re-run the check-runner, never fill in a
+result from memory.
 
 ## Failure ladder
 
-Three rungs on the same issue, ending at a third strike; the tier is set once
-at decomposition (config plus dispatch rules) and never changes because a job
-failed — a failure is a spec, context, or architecture problem the
-orchestrator diagnoses, never a signal to move the tier.
+Three rungs on the same issue; the tier is set at decomposition and never
+changes because a job failed.
 
-1. First failure: on check-runner exit 2, diagnose from the checkrun evidence
-   file's failing items; on a closing-review finding, diagnose from the
-   finding's file:line evidence (never the full diff). The
-   orchestrator may fan out researcher agents to inform the diagnosis, fixes
-   the input — issue text, missing context, or a forbidden-pattern note — and
-   respawns one fresh fix builder at the same tier with the answer in its
-   spawn context.
-2. Second failure: a fresh builder with a deeper orchestrator diagnosis —
-   re-read the spec and change-skeleton, question the decomposition assumption
-   that failed, and rewrite the issue input before respawning.
-3. Third strike: the orchestrator implements the remainder itself — Hard Rule
-   4's only license. Its work is graded like any builder's: the frozen-check
-   runner still passes it; no self-grading in artifacts. A third strike
-   inside the fix wave is a hard stop — the closing review is already spent,
-   so orchestrator-written fix code would otherwise merge without any model
-   review.
+1. Diagnose from the checkrun evidence file or the finding's file:line —
+   never the full diff. Fix the input (issue text, missing context,
+   forbidden-pattern note) and respawn one fresh fix builder with the
+   answer in its spawn context; researchers may inform the diagnosis.
+2. Fresh builder with a deeper diagnosis: re-read the spec and
+   change-skeleton, question the decomposition assumption that failed,
+   rewrite the issue input.
+3. Third strike: the orchestrator implements the remainder itself (Hard
+   Rule 4), still graded by the frozen-check runner. A third strike inside
+   the fix wave is a hard stop — the closing review is already spent.
 
-A merge conflict, including postflight exit 3, is a decomposition failure, not
-a build failure: kill the conflicting job and re-spec; never hand-resolve
-builder conflicts.
+A merge conflict, including postflight exit 3, is a decomposition failure:
+kill the conflicting job and re-spec; never hand-resolve builder conflicts.
 
 ## Escalation digest
 
-Batched on the tracking issue instead of interleaved per-job noise:
-
-- completed and failed jobs, with checkrun results
-- open blockers and the answers given
-- decisions the hardened spec genuinely does not answer
-- foreign sub-issues under the run parent with wrong author or missing run marker
-
-Ask-the-human items are batched here unless a hard stop below requires an
-immediate stop.
+Batched on the tracking issue: completed and failed jobs with checkrun
+results; open blockers and answers given; decisions the hardened spec does
+not answer; foreign sub-issues under the run parent. Ask-the-human items
+batch here unless a hard stop requires an immediate stop.
 
 ## Hard Stops
 
 | Situation | Hard stop |
 |---|---|
-| `docs/STOP` exists in the run checkout or primary checkout, or `docs/runs/<run>/STOP` exists | Stop before dispatching the next wave; global stop halts all runs, per-run stop halts only this run and is never committed. |
+| `docs/STOP` (global) or `docs/runs/<run>/STOP` (this run) exists | Stop before the next wave; the per-run stop is never committed. |
 | No checkrun-result comment for completed work | Do not build on it as accepted. |
 | Builder touched `docs/checks/` | Automatic FAIL for that job. |
-| Foreign sub-issue under the run parent | Never dispatch it; escalate on the tracking-issue digest. |
+| Foreign sub-issue under the run parent | Never dispatch it; escalate on the digest. |
 | Merge conflict or postflight exit 3 | Decomposition failure: kill the job, re-spec. |
-| Third strike on the same issue | The orchestrator implements the remainder itself (Hard Rule 4); the frozen-check runner still grades that work. |
-| Third strike inside the fix wave | A third strike inside the fix wave is a hard stop — the closing review is already spent. |
+| Third strike | Orchestrator implements (Hard Rule 4); the runner still grades. |
+| Third strike inside the fix wave | Hard stop — the closing review is spent. |
 | Two consecutive KILLs | Stop the factory and ask the human. |
-| Monitor reports an anomaly | Orchestrator rules before any further dispatch on that job. |
-| Blocker collides with a recorded assumption | Ask the human; it is a spec-level decision surfacing late. |
-| Session context degrades | End the session; the next session grounds from the issue tracker and git. |
+| Monitor anomaly | Orchestrator rules before further dispatch on that job. |
+| Blocker collides with a recorded assumption | Ask the human; a spec-level decision surfacing late. |
+| Session context degrades | End the session; the next one grounds from tracker and git. |
 | Scope grows beyond the hardened spec | Stop the factory. |
 | High-stakes issue | Add cross-model review before CONTINUE. |
 
-## Context discipline
-
-- Delegate heavy reading to review, monitor, or builder subagents; the orchestrator
-  stays thin and never reads a full diff directly.
-- The issue tracker and git are the memory: specs, frozen checks, checkrun-result
-  comments, and job reports carry state across sessions, not the
-  conversation.
-- Compact proactively when the harness supports it.
+Context discipline: the orchestrator stays thin — delegate heavy reading,
+never read a full diff directly; tracker and git carry state across
+sessions; compact proactively when the harness supports it.

--- a/skills/architect/research.md
+++ b/skills/architect/research.md
@@ -1,24 +1,18 @@
 # Research fan-out reference
 
-Read this only when a research trigger fires (see SKILL.md step 3). The fan-out
-uses Codex as parallel web-research subagents — read-only, live search, on the
-flat-rate subscription — and the architect keeps all judgment: it verifies the
-load-bearing claims and writes the spec itself.
+Read only when a research trigger fires. The fan-out uses parallel
+read-only web-research subagents; the orchestrator keeps all judgment and
+verifies the load-bearing claims.
 
 ## Fan out
 
-Resolve the researcher model as builders, same order as `/architect`: repo
-`.architect/config`, then user `~/.architect/config`, then the `codex/best`
-default in `skills/architect/dispatch.md`.
+Resolve the researcher model as builders (repo config, user config, then
+the `codex/best` default in `dispatch.md`). Decompose the question into
+3–10 narrow, NON-OVERLAPPING questions — different angles, not the same
+angle five times: official docs, changelog/breaking changes, community
+failure reports, alternatives, security/operational constraints.
 
-Decompose the question into 3–10 narrow, NON-OVERLAPPING research questions.
-Cover different angles, not the same angle five times — typical split:
-official docs/reference, changelog/breaking changes, community failure reports,
-alternatives/comparisons, security/operational constraints.
-
-One fresh `codex exec` per question, all launched in parallel, up to 10
-CLI-launched researchers — codex/tier-down shown; the builders default is `codex/best`
-(`dispatch.md` `## Model resolution and dispatch rules`):
+One fresh `codex exec` per question, launched in parallel, up to 10:
 
 ```bash
 codex exec -C <repo-root> --sandbox read-only -c web_search="live" \
@@ -27,27 +21,23 @@ codex exec -C <repo-root> --sandbox read-only -c web_search="live" \
   - < .architect/research/<NN>-<topic>.prompt.md
 ```
 
-Write each research block to a `.prompt.md` file and pass it via stdin (`-`),
-never as a shell argument — quote-mangling shells make codex hang waiting on
-stdin otherwise.
+Write each research block to a `.prompt.md` file and pass it via stdin —
+quote-mangling shells make codex hang otherwise.
 
 - `--sandbox read-only`: researchers never write to the repo.
-- `-c web_search="live"`: web search is on by default in current Codex
-  (cached mode); `"live"` forces fresh results. Version ladder if the canary
-  complains: `--enable web_search` (0.13x, now deprecation-warned) →
-  `-c tools.web_search=true` (< 0.133). `--search` is TUI-only — exec rejects
-  it. Launch ONE canary researcher and confirm it starts cleanly before
-  fanning out — these flags have churned three times in 2026 alone.
-- If resolved builders is a claude row, or Codex is unavailable, run the
-  fan-out as read-only Claude subagents with web search, respecting the
-  built-in harness cap (currently 5) — the research block works verbatim.
-- Effort `high`, not `xhigh` — research is coverage work; xhigh buys nothing
-  here. Synthesis happens on the architect's side.
-- Scope each researcher to ≤5 subjects and put hard context rules in the
-  block (snippet over page; quote ≤2 sentences; stop the moment you can
-  answer) — a researcher that fills its context window dies without writing
-  its output file. Bisect and re-dispatch dead researchers; don't re-run as-is.
-- Optionally pin `[tools.web_search] allowed_domains` in config for
+- `-c web_search="live"` forces fresh results. Version ladder if the canary
+  complains: `--enable web_search` -> `-c tools.web_search=true` (< 0.133);
+  `--search` is TUI-only. Launch ONE canary researcher before fanning out —
+  these flags churn.
+- If builders resolve to a claude row or Codex is unavailable, run the
+  fan-out as read-only Claude subagents with web search (harness cap 5);
+  the research block works verbatim.
+- Effort `high`, not `xhigh` — research is coverage work.
+- Scope each researcher to ≤5 subjects with hard context rules in the block
+  (snippet over page; quote ≤2 sentences; stop when you can answer) — a
+  researcher that fills its context dies without writing its file. Bisect
+  and re-dispatch dead researchers.
+- Optionally pin `[tools.web_search] allowed_domains` for
   prompt-injection-sensitive repos.
 
 ## Research block template
@@ -73,18 +63,16 @@ OUTPUT FORMAT — a markdown report, ≤ ~2,500 tokens (~10 KB) total:
   an implementation decision.
 ```
 
-## Gather (architect — this is your work, not another agent's)
+## Gather (orchestrator work, not another agent's)
 
 1. Read every findings file in `.architect/research/`.
-2. Identify the **load-bearing claims** — facts the spec will depend on
-   (an API shape, a version constraint, a limit, a deprecation). Adversarially
-   verify each: cross-check against a second independent source or the live
-   dependency itself. Discard single-source low-confidence claims or mark them
-   as open questions.
-3. Write `docs/spec/<slice>.md`: problem, decision + why, requirements,
-   non-goals, verified facts **with citations**, open questions for the human.
-   You write it — researchers gather, the architect judges and decides.
-4. Commit the spec. Raw findings stay in `.architect/research/` (gitignored) —
-   only the distilled, cited spec is repo memory.
-5. The slice spec references this spec instead of restating it; the builder's
-   PHASE 0 is expected to challenge the spec's claims like anything else.
+2. Adversarially verify each load-bearing claim (API shape, version
+   constraint, limit, deprecation) against a second independent source or
+   the live dependency; discard or mark open single-source low-confidence
+   claims.
+3. Feed the verified, cited findings into the consuming stage — the spec
+   strategist's dispatch context at intake, or the amended issue/check text
+   during re-planning. Raw findings stay in `.architect/research/`
+   (gitignored); only distilled, cited claims become repo memory.
+4. Builders' PHASE 0 is expected to challenge research claims like
+   anything else.

--- a/skills/architect/tracker.md
+++ b/skills/architect/tracker.md
@@ -2,15 +2,13 @@
 
 ## Config
 
-`.architect/config` and `~/.architect/config` may set `tracker = github` or
-`tracker = markdown`. Resolution order is repo config, then user config, then
-default `github`. Unknown config keys warn and do not fail.
+`.architect/config` then `~/.architect/config` may set `tracker = github`
+or `tracker = markdown`; default `github`. Unknown keys warn, never fail.
 
 ## Markdown issue format
 
-Markdown issue files live at `docs/issues/<run>/<NNN>-<slug>.md`; `<NNN>` is
-zero-padded to 3 digits, local to the run starting at `001`, and each file is
-git-tracked.
+Files at `docs/issues/<run>/<NNN>-<slug>.md`, `<NNN>` zero-padded, local to
+the run from `001`, git-tracked:
 
 ```markdown
 ---
@@ -27,18 +25,16 @@ blocked-by: 5, 6
 - 2026-07-04T00:05Z [builder-mirror] STATUS: COMPLETE ...
 ```
 
-Frontmatter keys are exactly `issue`, `title`, `state`, `parent`,
-`blocked-by` in the first block, one per line as `key: value`, parseable by
-line-grep without a YAML library. Empty forms are `parent: none` and
-`blocked-by: none`. `## Comments` is append-only. Next issue number is max
-existing issue number in `docs/issues/<run>/` + 1. State transitions and
-comment appends are orchestrator commits.
+Frontmatter keys are exactly `issue:`, `title:`, `state:`, `parent:`,
+`blocked-by:` in the first block, one `key: value` per line, line-greppable
+without a YAML library; empty forms are `parent: none` and `blocked-by:
+none`. `## Comments` is append-only. Next issue number = max existing + 1.
+State transitions and comment appends are orchestrator commits.
 
-Run manifests live at `docs/runs/<run>/manifest.md`. The first frontmatter
-block keys are exactly `run`, `tracking-issue`, `factory-branch`, `tracker`,
-`spec`, `state`, `created`, one per line as `key: value`; `state` is
-`ACTIVE` or `FINISHED`. The pinned `tracking-issue` number is the tracking
-issue for the run.
+Run manifests live at `docs/runs/<run>/manifest.md`; first frontmatter
+block keys are exactly `run`, `tracking-issue`, `factory-branch`,
+`tracker`, `spec`, `state`, `created`; `state` is `ACTIVE` or `FINISHED`.
+The pinned `tracking-issue` is the run's tracking issue.
 
 ## TSV emission
 
@@ -47,14 +43,13 @@ Both trackers feed the same line protocol:
 | Line | Contract |
 |---|---|
 | `TRACK\t<n>` | Pinned open tracking issue number. |
-| `SUB\t<n>\t<STATE>\t<open-blockers comma-joined>\t<title>` | One sub-issue row. Blockers are filtered to blockers whose own file says OPEN. |
+| `SUB\t<n>\t<STATE>\t<open-blockers comma-joined>\t<title>` | One sub-issue row; blockers filtered to those whose own file says OPEN. |
 | `NOOPENRUN` | Manifest missing or pinned tracking issue closed. |
 
-Markdown mode emits those lines from the run manifest plus issue-file
-frontmatter exactly where github mode emits them from pinned `gh --jq`. `TRACK`
-is the manifest's `tracking-issue`. `SUB` rows are children whose `parent`
-equals `TRACK`. A missing pinned issue file is a tracker inconsistency, not
-`NOOPENRUN`.
+Markdown mode emits from the manifest plus issue-file frontmatter exactly
+where github mode emits from pinned `gh --jq`. `TRACK` is the manifest's
+`tracking-issue`; `SUB` rows are children whose `parent` equals `TRACK`. A
+missing pinned issue file is a tracker inconsistency, not `NOOPENRUN`.
 
 ## Preflight per mode
 
@@ -69,18 +64,18 @@ Hard stop text: `Required tracker preflight cannot be satisfied`.
 
 | Mode | Finish |
 |---|---|
-| `github` | Existing PR path unchanged; PR closure closes the tracking issue through GitHub. |
-| `markdown` | Append the digest to the tracking issue file, leave the factory branch ready, and record merge instructions in the digest for the human merge step unless the in-session human directs otherwise. |
+| `github` | PR path unchanged; PR closure closes the tracking issue. |
+| `markdown` | Append the digest to the tracking issue file, leave the factory branch ready, record merge instructions in the digest unless the in-session human directs otherwise. |
 
 ## Command mapping
 
-| Operation | GitHub command family | Markdown-mode orchestrator file operation |
+| Operation | GitHub command family | Markdown-mode file operation |
 |---|---|---|
-| create | `gh issue create --title <t> --body-file <f> --parent <tracking-n> --blocked-by <n,n>` | Write `docs/issues/<run>/<NNN>-<slug>.md` with frontmatter, body, and `## Comments`; commit the file. |
-| claim | `gh issue edit <n> --add-assignee "@me"` | Orchestrator assigns exactly one job before dispatch; assignee line is optional/omitted in markdown files. |
-| comment | `gh issue comment <n> --body ...` | Append one timestamped `## Comments` line; commit the append. |
-| close | `gh issue close <n>` or PR close automation | Flip `state: OPEN` to `state: CLOSED`; commit the state change. |
-| parent/blocked-by edges | Native `--parent <tracking-n>` and `--blocked-by <n,n>` flags at create time, or GitHub native parent/blocker edits after creation; never body/title-only edge text | Update `parent:` and `blocked-by:` frontmatter fields using issue numbers or `none`; commit the edge change. |
+| create | `gh issue create --title <t> --body-file <f> --parent <tracking-n> --blocked-by <n,n>` | Write `docs/issues/<run>/<NNN>-<slug>.md` with frontmatter, body, `## Comments`; commit. |
+| claim | `gh issue edit <n> --add-assignee "@me"` | Orchestrator assigns one job before dispatch; assignee line optional in files. |
+| comment | `gh issue comment <n> --body ...` | Append one timestamped `## Comments` line; commit. |
+| close | `gh issue close <n>` or PR automation | Flip `state: OPEN` to `state: CLOSED`; commit. |
+| parent/blocked-by edges | Native `--parent` / `--blocked-by` flags or native edge edits; never body/title-only edge text | Update `parent:` / `blocked-by:` frontmatter (numbers or `none`); commit. |
 
 All issue-file mutations are orchestrator commits; builders mirror through
-reports, with `MIRROR: ORCHESTRATOR` unchanged.
+reports (`MIRROR: ORCHESTRATOR`).

--- a/skills/codebase-design/SKILL.md
+++ b/skills/codebase-design/SKILL.md
@@ -38,7 +38,7 @@ file for frozen check. Consistent language is the whole point.
 
 **Factory (one line each; matches `docs/spec/skill-library.md` Target flow):**
 
-- **Run** - one factory build from spec approval to the closing PR, on its own factory branch.
+- **Run** - one factory build from intake to the closing PR, on its own factory branch.
 - **Tracking issue** - the run's parent issue: dashboard, digest, preflight record.
 - **Issue** - one vertical-slice unit of work: one builder job, one disjoint file set, one change-skeleton.
 - **Slice** - the vertical cut an issue implements; slice names the cut, issue names its tracker record - same unit, two angles.
@@ -46,7 +46,7 @@ file for frozen check. Consistent language is the whole point.
 - **Check-runner** - the deterministic script that grades a frozen check's RUN items and exits typed (0/2/5).
 - **Strategist** - the fresh high-judgment subagent that drafts specs, cuts issues, stress-tests plans, and runs full-lane reviews.
 - **Builder** - the fresh, worktree-isolated agent that implements one issue and never commits.
-- **Orchestrator** - the one session that grounds, dispatches strategist and builder work, freezes, and integrates; never writes implementation code; in the fast lane (/architect-fast) it also performs the closing review and its fixes - a recorded relaxation.
+- **Orchestrator** - the one session that grounds, dispatches strategist and builder work, freezes, and integrates; never writes implementation code; in the fast lane (/architect-fast) it also runs the closing test pass whose output feeds the builder review - a recorded relaxation.
 - **Factory branch** - the run's integration branch (`factory/<run>`) that job branches merge into.
 - **Worktree** - the isolated git checkout a builder or reviewer works in, verified against the freeze commit.
 - **Job report** - a builder's raw-evidence artifact, ending in one STATUS line.

--- a/skills/final-review/SKILL.md
+++ b/skills/final-review/SKILL.md
@@ -29,6 +29,7 @@ grades, same as any other issue.
 1. The spec (`docs/spec/<run>.md`): goal, non-goals, validation strategy.
 2. The full run diff: `git diff <pre-run-sha>..HEAD`.
 3. Every shipped issue's published interface contract block.
+4. The closing test-pass output in your dispatch block — builder-built suites plus every frozen RUN item, run by the orchestrator at the head you review.
 
 Dispatch mechanics — worktree from the factory branch head, `docs/checks/`
 read-only, you commit nothing, downstream harvest/freeze/filing/dispatch is
@@ -94,7 +95,7 @@ Severity counts and the per-axis worst finding accompany either line.
 One or more verified findings: write the review spec at
 `docs/runs/<run>/review-spec.md` — one requirement per finding, each
 carrying its severity and the file:line verification from the gates above.
-A run artifact, not a human-approved spec.
+A run artifact, not the run's hardened spec.
 
 Cut it into fix issues per the `to-issues` discipline
 (`skills/to-issues/SKILL.md`): tracer-bullet slices, structural before

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: to-issues
 description: >
-  Use when decomposing an approved spec into tracker issues: cutting
+  Use when decomposing a hardened spec into tracker issues: cutting
   tracer-bullet vertical slices through every layer, ordering structural work
   first with blocking edges, maximizing the disjoint parallel frontier,
   publishing producer/consumer interface contracts, and attaching a compact
   change-skeleton to each issue. Invoked only from an explicit architect
-  dispatch — by the strategist subagent in `/architect`, or directly by the
-  orchestrator in `/architect-fast` — after spec approval; never left to
-  description-trigger discovery.
+  dispatch — by the harden strategist subagent in `/architect`, or directly
+  by the orchestrator in `/architect-fast` — after the spec is written;
+  never left to description-trigger discovery.
 ---
 
 <!-- Adapted from mattpocock/skills (MIT). -->
 
 # To Issues
 
-Turn the approved spec into dispatch-ready issues under the tracking issue.
-Approval already covers the whole plan — this stage does not re-quiz the
-human; a hard stop or an oddity escalation is the only thing that reopens a
+Turn the hardened spec into dispatch-ready issues under the tracking issue.
+The spec already settles the whole plan — this stage does not quiz the
+human; a hard stop or an oddity escalation is the only thing that opens a
 question here.
 
 ## 1. Read before you cut

--- a/skills/to-spec/SKILL.md
+++ b/skills/to-spec/SKILL.md
@@ -35,24 +35,22 @@ through step 4.
 4. Never run the timed-ruling protocol yourself or wait on the human:
    return every open question to the orchestrator, one line each —
    `RULING NEEDED: <question> | options: <a | b> | default: <option> — <why>`
-   — and it runs the protocol (`skills/architect/SKILL.md` `### 2. Spec
-   Approval`). Rulings already present in your dispatch context are decided;
+   — and it runs the protocol (`skills/architect/SKILL.md` `## Timed-ruling
+   protocol`). Rulings already present in your dispatch context are decided;
    record each as an `## Assumptions` entry. (Direct orchestrator invocation
    only — `/architect-fast`: run the protocol yourself as that lane records.)
 5. Shape the spec on the template below and write it to
    `docs/spec/<run>.md` in your working tree. Do NOT commit it and do NOT
    create or update the tracking issue — the spec commit and the
-   tracking-issue update (spec pointer, assumptions digest, the three
-   approve-by-comment forms `APPROVE`, `APPROVE with edits: <text>`,
-   `REJECT <reason>`, or the markdown-mode equivalent in
-   `skills/architect/tracker.md` `## Command mapping`) are orchestrator
-   actions after you return. End your reply with `SPEC DRAFT: <path>` plus
-   any `RULING NEEDED:` lines.
+   tracking-issue update (spec pointer, assumptions digest, or the
+   markdown-mode equivalent in `skills/architect/tracker.md`
+   `## Command mapping`) are orchestrator actions after you return. End
+   your reply with `SPEC DRAFT: <path>` plus any `RULING NEEDED:` lines.
 
 ## Template
 
 Write the sections below in this order; the names are load-bearing for
-approval and decomposition, so keep them exact.
+hardening and decomposition, so keep them exact.
 
 - `## Goal` — what the run adds and why, from the reader's side.
 - `## Target flow` (optional) — a short numbered sequence, only when the run
@@ -75,5 +73,3 @@ approval and decomposition, so keep them exact.
   source, date fetched, fact supported.
 - `## Preflight evidence` — tool, auth, and repo-state evidence gathered
   before decomposition.
-- `## Approval record` — the exact authorization form, quoted; the three
-  forms are defined in `skills/architect/SKILL.md` `### 2. Spec Approval`.


### PR DESCRIPTION
## What

Implements the owner-directed flow respec (2026-07-07): **no human approval for spec docs anywhere**, one consolidated harden dispatch, and an end-of-run test pass feeding the closing review. Target flow diagram: the session artifact both lanes were reviewed against.

### /architect
- **Intake**: the goal feeds the spec strategist directly — the ~5-question batch is gone. The timed-ruling protocol moves to its own `## Timed-ruling protocol` section and is the only human-question mechanism (auto-default after ~5 min, recorded, veto-able).
- **Harden (new stage)**: one fresh strategist runs the adversarial attack, folds surviving findings into a revised spec, decomposes with `to-issues`, drafts `frozen-checks`, and stress-tests its own decomposition — replacing the former adversarial spec review, human approval, separate decomposition dispatch, and pre-freeze stress pass.
- **Publish and freeze**: orchestrator-owned, unchanged mechanics, no approval gate.
- **Finish**: the closing review always runs (the "run the final review?" ruling is removed). The orchestrator first executes the closing test pass — builder-built suites plus every frozen RUN item — and feeds the raw output into the `final-review` dispatch block (new review-basis item 4).
- Per-issue check-runner grading at merge time is **kept** (it gates merges), per the reviewed flow.

### /architect-fast
- Spec-approval step removed; "one human step" language retired.
- Still strategist-free by design: the orchestrator writes spec + ≤3 issues itself.
- The orchestrator no longer reviews its own run: after the closing test pass, one **fresh builder subagent** reviews the whole diff + test output, records findings as one fix issue, and fixes them in its worktree; the orchestrator merges through postflight (builders still never commit).

### Ripple updates
- `to-spec`: `## Approval record` template section and APPROVE/REJECT forms removed; timed-ruling anchor repointed.
- `adversarial-review`: contract reshaped to the three-stage harden dispatch (attack → revise+decompose → stress-test); still never commits or touches the tracker.
- `to-issues`, `frozen-checks` seams, `codebase-design` glossary (Run, Orchestrator), `integrate` precondition wording via architect-fast's standing ruling.
- README, DESIGN.md (supersedes D3/D4 with the recorded owner directive), CONTEXT.md, and both flow SVGs updated to match.

## Verification

- `tests/validate_skills.py`: **OK — 11 skills validated, v4 contracts clean** (cross-skill pointer integrity, glossary lint, line budgets).
- Budgets after edits: architect SKILL.md 204/220; five-file guard 988/989; architect-fast 133/160; final-review 110/110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)