### PR TITLE
Weaken sandbox to full access; gate merges on wrapper exit truth

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -331,11 +331,29 @@ architect-v5 and architect-v5.1 specs, and loop-improvements research
   it does not resume polluted context (a running builder never re-reads its
   own issue comments; see §3, Copilot precedent).
 - **Builders never commit.** The orchestrator owns commits, merges, and
-  issue closure. Codex `workspace-write` is the one backend with verified
-  sandbox `.git` write protection; Claude builders use permission-deny rules
-  plus post-flight branch/commit checks instead
-  ([Codex sandboxing](https://developers.openai.com/codex/agent-approvals-security),
-  [headless docs](https://code.claude.com/docs/en/headless)).
+  issue closure. Enforcement is the prose ban plus postflight — the
+  touch-set audit over the full freeze->job diff and the wrapper-exit-truth
+  gate — on every backend
+  ([headless docs](https://code.claude.com/docs/en/headless)).
+- **The OS sandbox is weak by directive (owner directive, 2026-07-07).**
+  Builder, strategist, and verification CLI jobs run
+  `--sandbox danger-full-access`: network, outside reads, and outside
+  writes allowed. Three verified hang classes under the Codex Windows
+  sandbox's restricted token forced this, each wedging jobs *after* the
+  real work succeeded: Cygwin `CreateFileMapping` deaths (D13), pytest's
+  cacheprovider `pytest_sessionfinish -> tempfile.mkdtemp()` hang
+  (py-spy-verified, §7 2026-07-07), and asyncio subprocess/network
+  `select()` blocks on live-provider tests that pass unsandboxed. The
+  factory's real boundaries — never-commit, MAY TOUCH, read-only checks,
+  wrapped dispatch — are all enforced by postflight audits and grading,
+  so the sandbox bought hangs, not safety. Accepted trade-off: builders
+  can reach the network and the wider filesystem; the audit trail, not
+  the OS, is the containment. Researchers stay `--sandbox read-only`.
+- **Unwrapped work cannot merge (2026-07-07).** Postflight's `job_dir`
+  gate requires the wrapper's `job.exit.json` before any merge, closing
+  the bypass where an orchestrator launched raw background builders with
+  no watchdog armed and two jobs hung for 60-75 minutes undetected;
+  fixture-pinned in the validator.
 - **PHASE 0: disagreement is mandatory.** Before building, every job states
   its plan and every disagreement with the spec, citing real files — or what
   it checked before finding none. Silent compliance is a job defect.
@@ -923,7 +941,26 @@ cleanup. Both namespaces are load-bearing in shipped text.)
   solution, in git history before the 2026-07-04 cleanup);
   out-of-workspace temp paths and `asyncio.create_subprocess_exec`-based
   tooling hang under workspace-write — prescribe in-workspace temp/cache
-  paths and sequential check execution.
+  paths and sequential check execution. Superseded 2026-07-07: the default
+  posture is now `danger-full-access` (§4); these substitutions apply only
+  to jobs opted back into a sandbox.
+- **Cacheprovider and live-network hangs; the wrapper bypass (2026-07-07).**
+  Two independent runs, three findings. (1) Four builders across two repos
+  hung *after all tests passed*, py-spy-pinned to the identical frame:
+  `pytest_sessionfinish -> cacheprovider -> tempfile.mkdtemp()` never
+  returns under the sandbox's restricted token; TEMP/TMP/TMPDIR +
+  `--basetemp` + `-o cache_dir` redirects were tried live and did NOT fix
+  it — only `-p no:cacheprovider` does (negative result preserved in
+  dispatch.md `## Sandbox posture`). (2) A third hang class: a live-provider
+  test blocked in asyncio `select()` inside `codex exec`'s sandboxed shell
+  while passing in an unsandboxed one. (3) Both runs had launched builders
+  as raw background tasks without `run-job` or a watchdog — nothing
+  structurally prevented it; hangs sat 60-75 minutes until manual checks.
+  Fixes shipped: full-access default posture, the postflight `job_dir`
+  wrapper gate, and validator pins for all three. CPU-delta was useful
+  manual forensics (hot spin vs idle block) but stays out of the watchdog
+  by ruling — it cannot distinguish a wedged `mkdtemp` from a legitimate
+  long compile; `BLOCKED_ON_TOOL` covers the class deterministically.
 - **Loop-hygiene pre-freeze stress-test catch record (2026-07-04):** 6
   defects before dispatch, including the host-specific finding that bare
   `python` resolves to the Windows Store stub and validator checks must run as

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
   must not commit, and must end with one raw `STATUS:` line.
 - Wrapped CLI jobs write `job.meta.json`, `job.heartbeat`, `job.exit.json`,
   `events.jsonl`, and `stderr.log`; exit truth outranks terminal-looking report
-  text.
+  text. Postflight refuses to merge CLI job work without that wrapper exit
+  truth — unwrapped work cannot merge.
+- The OS sandbox is deliberately weak (`danger-full-access`): builders may
+  use the network and the wider filesystem. The real boundaries are the
+  postflight touch-set audit, the never-commit ban, and read-only frozen
+  checks.
 - The watchdog reports typed evidence only. It never kills, nudges, or grades.
   Stuck jobs are reaped with `kill-job.ps1|.sh` and respawned from durable issue
   context.

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -7,6 +7,7 @@
 - Per-harness delegation
 - Check-runner dispatch
 - CLI-launched subagent dispatch
+- Sandbox posture
 - Preflight and postflight dispatch
 - Integration commands
 - Issue conventions
@@ -87,7 +88,7 @@ decomposition and never moves because a job failed (`loop.md`
 
 | | Claude Code (CLI + Desktop) | Codex (CLI + app) |
 |---|---|---|
-| Strategist | `strategist = claude/*`: Agent tool at the strategist model, `run_in_background: false` for result-bearing stages, stage skills named in the prompt. `strategist = codex/*`: background `codex exec -o <file>` job through `run-job.ps1\|.sh` — read-heavy sandbox, no Fast pins; drafts and verdict return as files (no tracker access in sandbox). | `strategist = codex/*`: `spawn_agent` with defensive framing, no Fast pins. `strategist = claude/*`: CLI-launched `claude -p` through `run-job.ps1\|.sh`, dispatch block on stdin, file-based output contract; claude CLI absent -> record and fall back per the rules above. |
+| Strategist | `strategist = claude/*`: Agent tool at the strategist model, `run_in_background: false` for result-bearing stages, stage skills named in the prompt. `strategist = codex/*`: background `codex exec -o <file>` job through `run-job.ps1\|.sh` — same full-access posture, no Fast pins; drafts and verdict return as files. | `strategist = codex/*`: `spawn_agent` with defensive framing, no Fast pins. `strategist = claude/*`: CLI-launched `claude -p` through `run-job.ps1\|.sh`, dispatch block on stdin, file-based output contract; claude CLI absent -> record and fall back per the rules above. |
 | Builder | Agent tool with `.claude/agents/architect-builder.md`; `isolation: worktree`; `background: true`; model passed per invocation. Desktop auto-creates the isolation worktree (`.claude/worktrees/agent-<id>`) — integrate from its branch. CLI spawns have run UNISOLATED despite frontmatter (D11): pass isolation per invocation if supported and verify each concurrent job's worktree (`git worktree list`) before running two at once. Never pre-create a worktree for Claude-backend jobs; `.architect/wt/<run>/<slice>-<NN>` is Codex-backend only. | `spawn_agent` with defensive framing ("Your task is: ..."); worktree created by the orchestrator via git; `/goal` semantics for persistent completion. |
 | Verification (optional, read-only) | Agent tool with `.claude/agents/architect-judge.md`, `run_in_background: false`, report file plus one greppable verdict line required; builders model per invocation. | Background `codex exec -o <file>` typed-exit path with read-only instructions; process exit wakes the loop. |
 | Monitor | Script watchdog (`watchdog.ps1` / `watchdog.sh`) under a long-lived Bash task; LLM fallback template only where task exits cannot wake the loop. | Same; the LLM fallback consumes one native subagent slot. |
@@ -150,8 +151,8 @@ all in-flight CLI jobs.
 Single Codex-backed job:
 
 ```bash
-<repo-root>/skills/architect/run-job.sh --job-dir <repo-root>/.architect/jobs/<run>/<slice>-<NN> --workdir <repo-root>/.architect/wt/<run>/<slice>-<NN> --backend codex-cli --report-path <repo-root>/docs/jobs/<run>/<slice>-01.md --stdin-file <repo-root>/.architect/jobs/<run>/<slice>-<NN>/block.md --sandbox-env -- \
-  codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox workspace-write -m gpt-5.5 -c model_reasoning_effort="xhigh" -c service_tier="fast" -c features.fast_mode=true --json -o <repo-root>/.architect/jobs/<run>/<slice>-<NN>/last-run.md \
+<repo-root>/skills/architect/run-job.sh --job-dir <repo-root>/.architect/jobs/<run>/<slice>-<NN> --workdir <repo-root>/.architect/wt/<run>/<slice>-<NN> --backend codex-cli --report-path <repo-root>/docs/jobs/<run>/<slice>-01.md --stdin-file <repo-root>/.architect/jobs/<run>/<slice>-<NN>/block.md -- \
+  codex exec -C <repo-root>/.architect/wt/<run>/<slice>-<NN> --sandbox danger-full-access -m gpt-5.5 -c model_reasoning_effort="xhigh" -c service_tier="fast" -c features.fast_mode=true --json -o <repo-root>/.architect/jobs/<run>/<slice>-<NN>/last-run.md \
   -
 ```
 
@@ -176,9 +177,38 @@ git -C <repo-root> worktree add <repo-root>/.architect/wt/<run>/<slice>-<NN> -b 
 <repo-root>/skills/architect/run-job.sh ... -- <codex-or-claude command for that worktree>
 ```
 
-A worktree's `.git` is a pointer file and the resolved git dir is
-sandbox-protected too: builders cannot commit or touch shared history;
-nothing reaches a branch until orchestrator checks pass.
+Builders still never commit — a prose ban audited by postflight; nothing
+reaches a branch until orchestrator checks pass.
+
+## Sandbox posture
+
+Builder, strategist, and verification CLI jobs run `--sandbox
+danger-full-access` by design (owner directive, 2026-07-07): network
+calls, reads, and writes outside the worktree are allowed. Three verified
+hang classes forced this — the Codex Windows sandbox's restricted token
+wedged jobs after the real work had already succeeded: (1) Cygwin-runtime
+binaries (Git-for-Windows bash/grep/sed) die at startup
+(`CreateFileMapping` Win32 error 5; openai/codex#12000, #21715); (2)
+pytest's cacheprovider hangs forever in `pytest_sessionfinish ->
+tempfile.mkdtemp()` (py-spy-verified stack; TEMP/TMP/TMPDIR + `--basetemp`
++ `-o cache_dir` redirects verified insufficient); (3) asyncio
+subprocess/network I/O blocks in `select()` (live-provider tests that pass
+in an unsandboxed shell). Researchers stay `--sandbox read-only`
+(`research.md`); they write nothing.
+
+The constraints that matter are enforced downstream, not by the OS
+sandbox: builders never commit (prose ban, postflight-audited); MAY TOUCH
+is enforced by postflight's touch-set diff over the full freeze->job
+range; a `docs/checks/` edit is an automatic FAIL; and unwrapped work
+cannot merge (postflight `job_dir` gate below).
+
+Opting a job back into a sandbox (not recommended): every pytest
+invocation needs `-p no:cacheprovider`; pass the wrapper's `--sandbox-env`
+flag to redirect TEMP/TMP/TMPDIR into the workspace; keep temp/cache paths
+in `.architect/tmp/<purpose>`; sanctioned same-pattern substitutions
+(PowerShell + native git for Cygwin deaths,
+`UV_CACHE_DIR=.architect/tmp/uv-cache`) are recorded per use; and the hang
+classes above still apply to anything this list misses.
 
 ## Preflight and postflight dispatch
 
@@ -212,9 +242,16 @@ postflight config JSON:
   "merge_message": "<text>",
   "push": false,
   "remote": "origin",
-  "worktree": ".architect/wt/<run>/<slice>-<NN>"
+  "worktree": ".architect/wt/<run>/<slice>-<NN>",
+  "job_dir": ".architect/jobs/<run>/<slice>-<NN>"
 }
 ```
+
+`job_dir` is mandatory for CLI-launched jobs: postflight requires
+`<job_dir>/job.exit.json` (wrapper exit truth) and exits
+`POSTFLIGHT: VIOLATION wrapper exit truth missing` without it — unwrapped
+work cannot merge. Omit `job_dir` only for harness-native Agent-tool jobs,
+whose exits the harness itself owns.
 
 | Script | Exit | Prefix | Meaning |
 |---|---:|---|---|
@@ -271,9 +308,9 @@ spawning; a builder never self-claims:
 gh issue edit <n> --add-assignee "@me"   # orchestrator claims, before dispatch
 ```
 
-Builders usually cannot post (Codex has no network; Claude subagents have a
-shell-strip watch item) — `MIRROR: ORCHESTRATOR` is normal. Builder
-comments on its own issue are exactly four kinds, never one per commit:
+Builders often lack tracker auth in their jobs — `MIRROR: ORCHESTRATOR` is
+normal. Builder comments on its own issue are exactly four kinds, never
+one per commit:
 
 ```bash
 gh issue comment <n> --body "PHASE 0: <disagreements, or what I checked>"
@@ -387,25 +424,8 @@ bodies and check files may carry duration *hints* (e.g. "full suite ~ 20m")
 — informative context for the monitor, never an enforced ceiling.
 
 Builder edits, orchestrator exercises: spawn-heavy checks that cannot run
-in the sandbox become orchestrator-side bounded RUN evidence; the builder
-does edits plus static/local verification only.
-
-Executor truth for sandboxed jobs: MSYS2/Cygwin-runtime binaries (Git for
-Windows `bash.exe`, `grep.exe`, `sed.exe`) die at startup under the Codex
-Windows sandbox (Cygwin shared-memory `CreateFileMapping` denied, Win32
-error 5, under the restricted token; upstream openai/codex#12000, #21715).
-Native `git.exe` and PowerShell are unaffected; POSIX sandboxes are
-unaffected. Check files therefore name the platform-native executor primary
-for sandboxed jobs: PowerShell + native git on Windows, bash on POSIX.
-
-Sanctioned substitutions, recorded per use:
-
-| Condition | Substitution |
-|---|---|
-| Git Bash CreateFileMapping error 5 in Codex Windows sandbox | PowerShell + native git, same pattern |
-| `uv` AppData cache denial (os error 5) | `UV_CACHE_DIR=.architect/tmp/uv-cache` |
-| pytest tmpdir `mkdir(mode=0o700)` WinError 5 | wrapper `--sandbox-env` TEMP/TMP/TMPDIR redirect |
-| Tracker posting unavailable in sandbox | `MIRROR: ORCHESTRATOR` in the report |
+in the job's environment become orchestrator-side bounded RUN evidence;
+the builder does edits plus static/local verification only.
 
 ## Orchestrator shell hygiene
 
@@ -434,12 +454,6 @@ harnesses where Bash is stripped.
 On Windows PowerShell 5.1, `>`, `*>`, and `Tee-Object` write UTF-16; read
 event files encoding-aware (`Get-Content`, or `iconv`) — byte-oriented grep
 can silently miss growth.
-
-Known sandbox hang sources: `asyncio.create_subprocess_exec` and anything
-built on it (Playwright launch, anyio subprocess pools) — plain
-`subprocess.run` works; out-of-workspace temp paths under workspace-write —
-prescribe `.architect/tmp/<purpose>`, `--basetemp
-.architect/tmp/<check-id>`, and in-workspace caches.
 
 ## Respawn-with-answer template
 
@@ -543,13 +557,13 @@ design; the architect commits and merges after verification. Do NOT delete lock
 files or escalate privileges if a git command fails; record the exact error and
 continue.
 
-SANDBOX EXECUTION POLICY - All temp, basetemp, and cache paths MUST be inside
-the workspace (`.architect/tmp/<purpose>`); never the system temp. Run test/check
-commands SEQUENTIALLY - never two invocations in flight at once. The spec or issue may declare duration hints for known-long commands (e.g. "full suite ~ 20m");
+EXECUTION POLICY - Run test/check commands SEQUENTIALLY - never two
+invocations in flight at once. Prefer in-workspace scratch paths
+(`.architect/tmp/<purpose>`) so forensics stay with the job. The spec or issue may declare duration hints for known-long commands (e.g. "full suite ~ 20m");
 they are context, not kill ceilings. If a command appears stalled - no output
 growth and no file mtime movement well past its duration hint - record the
 exact command and observed state in the job report and stop the job; the
-monitor and orchestrator own stall handling. A filesystem/sandbox error on a path is
+monitor and orchestrator own stall handling. A filesystem or permission error on a path is
 environmental: record the exact failure and route around it - never retry the same path.
 
 When a known-bad pattern exists, the spec must name it as forbidden with
@@ -588,8 +602,10 @@ fully handled end-to-end.
 
 ## Builder-side standing setup
 
-- Builders never commit; the orchestrator does. Workspace-write protects
-  `.git` as read-only in Codex on Windows, including worktree pointers.
+- Builders never commit; the orchestrator does. Enforcement is the prose
+  ban plus postflight — the touch-set audit over the full freeze->job
+  range and the `job_dir` wrapper gate — since the OS sandbox is
+  deliberately weak (`## Sandbox posture`).
 - Repo `AGENTS.md` carries exact build/test commands and repo gotchas only;
   the loop's PHASE rules stay in the dispatch block so they version with
   the skill.

--- a/skills/architect/postflight.ps1
+++ b/skills/architect/postflight.ps1
@@ -79,6 +79,17 @@ $push = $false
 if (@($cfg.PSObject.Properties.Name) -contains "push") { $push = [bool]$cfg.push }
 if (-not $remote) { $remote = "origin" }
 
+# Wrapper-exit-truth gate: CLI-launched jobs pass job_dir; unwrapped work
+# cannot merge (2026-07-07 bypass incident).
+$jobDir = PropString $cfg "job_dir"
+if ($jobDir) {
+    $exitFile = Join-Path (FullPath $jobDir) "job.exit.json"
+    if (-not (Test-Path -LiteralPath $exitFile -PathType Leaf)) {
+        Write-Output "POSTFLIGHT: VIOLATION wrapper exit truth missing $exitFile"
+        exit 2
+    }
+}
+
 $cur = GitRun -GitArgs @("-C", $script:RepoRoot, "rev-parse", "--abbrev-ref", "HEAD")
 if ($cur.Code -ne 0 -or @($cur.Lines).Count -lt 1) { ErrorExit "current branch unavailable" }
 $current = ([string]$cur.Lines[0]).Trim()

--- a/skills/architect/postflight.sh
+++ b/skills/architect/postflight.sh
@@ -87,6 +87,17 @@ case "$repo_root" in /*) ;; *) printf 'POSTFLIGHT: ERROR repo_root not absolute\
 tmp_dir="$repo_root/.architect/tmp/postflight"
 mkdir -p "$tmp_dir" 2>/dev/null || err "tmp unavailable"
 
+# Wrapper-exit-truth gate: CLI-launched jobs pass job_dir; unwrapped work
+# cannot merge (2026-07-07 bypass incident).
+job_dir=$(json_string job_dir)
+if [ -n "$job_dir" ]; then
+  jd=$(abs_path "$job_dir")
+  if [ ! -f "$jd/job.exit.json" ]; then
+    printf 'POSTFLIGHT: VIOLATION wrapper exit truth missing %s\n' "$jd/job.exit.json"
+    exit 2
+  fi
+fi
+
 current=$(git_repo rev-parse --abbrev-ref HEAD 2>/dev/null) || err "current branch unavailable"
 # Refuse to run off the configured factory branch before touch audit or merge.
 if [ "$current" != "$factory_branch" ]; then printf 'POSTFLIGHT: ERROR off factory branch current=%s expected=%s\n' "$current" "$factory_branch"; exit 5; fi

--- a/tests/validate_skills.py
+++ b/tests/validate_skills.py
@@ -1672,6 +1672,7 @@ def write_postflight_config(
     freeze: str,
     job_branch: str,
     worktree: str | None,
+    job_dir: str | None = None,
 ) -> None:
     cfg: dict[str, object] = {
         "repo_root": str(repo_root),
@@ -1684,6 +1685,8 @@ def write_postflight_config(
     }
     if worktree is not None:
         cfg["worktree"] = worktree
+    if job_dir is not None:
+        cfg["job_dir"] = job_dir
     write_fixture_file(path, json.dumps(cfg, indent=2))
 
 
@@ -1749,6 +1752,82 @@ def check_postflight_lane_fixture() -> None:
         needle = "POSTFLIGHT: ERROR job branch has no commits beyond freeze"
         if needle not in stdout:
             errors.append(f"postflight fixture noop: missing {needle!r}\nstdout:\n{stdout}")
+
+    # Wrapper-exit-truth gate (2026-07-07 bypass incident): a config naming a
+    # job_dir without job.exit.json must refuse to merge; with exit truth
+    # present the gate passes and the normal flow continues.
+    gate_repo = base / "gate" / "repo"
+    gate_elsewhere = base / "gate-elsewhere"
+    gate_elsewhere.mkdir(parents=True)
+    gate_freeze = configure_fixture_repo(gate_repo)
+    if gate_freeze is None:
+        return
+    git_fixture(gate_repo, "branch", "job", gate_freeze)
+    unwrapped_dir = base / "gate" / "job-dir-unwrapped"
+    unwrapped_dir.mkdir(parents=True)
+    gate_config = base / "configs" / "gate-unwrapped.json"
+    write_postflight_config(
+        gate_config, gate_repo, gate_freeze, "job", None, job_dir=str(unwrapped_dir)
+    )
+    gate = run_postflight_fixture(gate_config, gate_elsewhere)
+    if gate is not None:
+        stdout = gate.stdout.replace("\r\n", "\n")
+        if gate.returncode != 2:
+            errors.append(
+                "postflight fixture wrapper gate: expected exit 2 "
+                f"got {gate.returncode}\nstdout:\n{stdout}\nstderr:\n{gate.stderr}"
+            )
+        if "POSTFLIGHT: VIOLATION wrapper exit truth missing" not in stdout:
+            errors.append(
+                f"postflight fixture wrapper gate: missing violation line\nstdout:\n{stdout}"
+            )
+
+    wrapped_dir = base / "gate" / "job-dir-wrapped"
+    write_fixture_file(wrapped_dir / "job.exit.json", '{"exit_code": 0}\n')
+    passthrough_config = base / "configs" / "gate-wrapped.json"
+    write_postflight_config(
+        passthrough_config, gate_repo, gate_freeze, "job", None, job_dir=str(wrapped_dir)
+    )
+    passthrough = run_postflight_fixture(passthrough_config, gate_elsewhere)
+    if passthrough is not None:
+        stdout = passthrough.stdout.replace("\r\n", "\n")
+        if passthrough.returncode != 5 or "no commits beyond freeze" not in stdout:
+            errors.append(
+                "postflight fixture wrapper gate passthrough: expected exit 5 "
+                f"'no commits beyond freeze' got {passthrough.returncode}\nstdout:\n{stdout}"
+            )
+
+
+def check_sandbox_posture() -> None:
+    """Owner directive 2026-07-07: the OS sandbox stays weak; boundaries are
+    enforced by postflight (touch-set audit + wrapper gate), not the sandbox.
+    Guards the load-bearing strings so a later edit cannot silently
+    re-strengthen the sandbox or lose the recorded pytest route-around."""
+    dispatch = read_text(SKILLS / "architect" / "dispatch.md")
+    builder_blocks = [
+        block
+        for block in re.findall(r"```bash\n(.*?)```", dispatch, re.DOTALL)
+        if "codex exec" in block and "--json" in block
+    ]
+    for i, block in enumerate(builder_blocks, start=1):
+        if "--sandbox danger-full-access" not in block:
+            errors.append(
+                f"skills/architect/dispatch.md: codex dispatch example {i} must use "
+                "--sandbox danger-full-access (sandbox posture, owner directive "
+                "2026-07-07: restricted-token hang classes)"
+            )
+    if "-p no:cacheprovider" not in dispatch:
+        errors.append(
+            "skills/architect/dispatch.md: missing -p no:cacheprovider pytest "
+            "route-around for sandboxed jobs (cacheprovider mkdtemp hang, "
+            "py-spy-verified 2026-07-07; temp/basetemp/cache_dir redirects "
+            "verified insufficient)"
+        )
+    if '"job_dir"' not in dispatch:
+        errors.append(
+            "skills/architect/dispatch.md: postflight config example missing "
+            "job_dir (wrapper-exit-truth merge gate)"
+        )
 
 
 def check_runner_cases() -> list[tuple[str, list[str], dict[str, Path]]]:
@@ -2700,6 +2779,7 @@ def main() -> int:
     check_status_contract()
     check_status_run_pinning_fixture()
     check_postflight_lane_fixture()
+    check_sandbox_posture()
     check_sweep_deferred_fixture()
     check_check_runner_fixture()
     check_ground_contract()


### PR DESCRIPTION
## What

Solves the stall classes at their root per owner directive: the Codex Windows sandbox's restricted token was wedging builders *after their work already succeeded*, and nothing structurally stopped an orchestrator from launching unwrapped, unwatched builders.

### Sandbox posture
- Builder, strategist, and verification CLI jobs now dispatch `--sandbox danger-full-access` — network calls, outside reads/writes allowed. Researchers stay `--sandbox read-only`.
- All three verified hang classes disappear with the restricted token: Cygwin `CreateFileMapping` deaths (D13), pytest cacheprovider `pytest_sessionfinish → tempfile.mkdtemp()` (py-spy-pinned; TEMP/TMP/TMPDIR + `--basetemp` + `-o cache_dir` redirects **verified insufficient** — negative result preserved), and asyncio `select()` blocks on live-provider tests.
- The old sanctioned-substitutions machinery collapses into one `## Sandbox posture` section: hang classes, the `-p no:cacheprovider` route-around for anyone opting back into a sandbox, and where the real boundaries live — postflight touch-set audit, never-commit ban, read-only frozen checks.

### Wrapper-exit-truth merge gate
- Postflight config gains `job_dir` (mandatory for CLI jobs); without `<job_dir>/job.exit.json` it exits `POSTFLIGHT: VIOLATION wrapper exit truth missing`. Unwrapped work cannot merge — the machinery-bypass found in both incident runs is now self-defeating instead of prose-only.

### Tests
- `check_sandbox_posture`: pins `--sandbox danger-full-access` in every codex dispatch example, the `-p no:cacheprovider` note, and the `job_dir` config example.
- Postflight lane fixture: gate-refuses case (job_dir, no exit truth → exit 2 + violation line) and gate-passthrough case (exit truth present → flow continues to the normal typed exits).
- Per ruling: **no CPU-delta stall rule** — recorded in DESIGN.md as manual forensics only; `WATCHDOG: BLOCKED_ON_TOOL` (already fixture-pinned) covers the hang signature deterministically.

## Verification
- `tests/validate_skills.py`: OK — 11 skills validated, v4 contracts clean (includes the two new gate fixture cases live-running postflight.ps1).
- `bash -n postflight.sh`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)