### PR TITLE
Record Start-Process forensics: no fourth hang class

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -961,6 +961,18 @@ cleanup. Both namespaces are load-bearing in shipped text.)
   manual forensics (hot spin vs idle block) but stays out of the watchdog
   by ruling — it cannot distinguish a wedged `mkdtemp` from a legitimate
   long compile; `BLOCKED_ON_TOOL` covers the class deterministically.
+  Same-day follow-up (BenchPair #220/#221): two builders dispatched from a
+  stale pre-directive launch script (workspace-write, raw shell, no
+  wrapper) hung on a spawned `benchpair web` readiness wait. Controlled
+  repro exonerated `Start-Process` itself — a detached network-less child
+  returns in 16s under BOTH sandbox modes — and pinned the class: under
+  workspace-write the server-spawn + local-HTTP command is
+  `rejected: blocked by policy` (or the child blocks silently when the
+  network I/O is internal); under danger-full-access the identical command
+  returns SERVER=200 in 24s. Not a fourth hang class — class (3) reached
+  via a spawned server. The stale template was fixed in place; ad-hoc
+  dispatch copies the sandbox flag from `## Sandbox posture`, never from
+  an older run's launch script.
 - **Loop-hygiene pre-freeze stress-test catch record (2026-07-04):** 6
   defects before dispatch, including the host-specific finding that bare
   `python` resolves to the Windows Store stub and validator checks must run as

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -191,9 +191,14 @@ binaries (Git-for-Windows bash/grep/sed) die at startup
 (`CreateFileMapping` Win32 error 5; openai/codex#12000, #21715); (2)
 pytest's cacheprovider hangs forever in `pytest_sessionfinish ->
 tempfile.mkdtemp()` (py-spy-verified stack; TEMP/TMP/TMPDIR + `--basetemp`
-+ `-o cache_dir` redirects verified insufficient); (3) asyncio
-subprocess/network I/O blocks in `select()` (live-provider tests that pass
-in an unsandboxed shell). Researchers stay `--sandbox read-only`
++ `-o cache_dir` redirects verified insufficient); (3) network I/O under
+the token blocks or is rejected — asyncio `select()` hangs on
+live-provider calls, a spawned web server never comes up so the builder's
+readiness poll waits forever, and network-shaped commands can be
+`rejected: blocked by policy` outright. `Start-Process` itself is not a
+trigger (controlled repro 2026-07-07: detached spawn returns promptly
+under both modes; server spawn + local HTTP round trip returns 200 only
+under full access). Researchers stay `--sandbox read-only`
 (`research.md`); they write nothing.
 
 The constraints that matter are enforced downstream, not by the OS


### PR DESCRIPTION
## What

Resolves the debug report on builders still hanging after the sandbox-posture fix (BenchPair #220/#221, code-review-2026-07-07 run).

### Findings (controlled repro, both sandbox modes)
- **Q1 — is `Start-Process` a fourth hang class? No.** A detached, network-less `Start-Process -WindowStyle Hidden -PassThru` child returns in **16s under BOTH** `workspace-write` and `danger-full-access` — the parent never waits on descendants. The incident's wedge was the **child** (`benchpair web`, an asyncio network server) plus the builder's readiness wait: the server-shaped repro (spawn `http.server`, poll `127.0.0.1:8123`) is **`rejected: blocked by policy`** under workspace-write and returns **`SERVER=200` in 24s** under danger-full-access. Documented hang class (3), reached via a spawned server.
- **Q2 — why didn't the fix propagate?** `launch.sh`'s Wave-1 logs stamp 14:12–14:28; the danger-full-access directive merged ~18:00. The script predates the fix and was copied verbatim for Wave 2. Installed skill copies were verified current (18:01).
- **Q3 — did prior forensics test Start-Process?** No — ADDENDUM 1/2 tested `asyncio.create_subprocess_exec` and pytest cacheprovider only. Now tested directly; negative.
- **Q4 — intentional workspace-write?** No; oversight from an older template. The pattern also bypassed `run-job` + watchdog entirely, so nothing detected the hangs — and the postflight wrapper gate cannot protect ad-hoc runs that never call postflight.

### Changes
- `dispatch.md` `## Sandbox posture`: class (3) generalized to name the spawned-server readiness-wait shape, the policy-rejection variant, and the Start-Process exoneration.
- `DESIGN.md` §7: repro evidence appended to the 2026-07-07 incident record.
- Outside this repo (no commit here): `BenchDocs/runs/code-review-2026-07-07/jobs/launch.sh` flipped to `danger-full-access` with a dated comment; `WATCHDOG-DIAGNOSIS-PROMPT.md` gained ADDENDUM 3 (resolved) in `~/tools/architect-loop`.

## Verification
- Repro artifacts: 4 codex exec runs (2 minimal, 2 server-shaped), results quoted verbatim in ADDENDUM 3 and DESIGN.md; leftover repro processes reaped.
- `tests/validate_skills.py`: OK — 11 skills validated, v4 contracts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)