### PR TITLE
Narrow PHASE 0 to execution conflicts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,7 +151,7 @@ Why the move:
   job's lifecycle wanted a row in it, which fought the disjoint-file-set
   rule that makes parallel jobs safe. Issues give each unit of work its own
   thread; comments are the append-only log.
-- **The tracker is the human-visible dashboard.** PHASE-0 disagreements,
+- **The tracker is the human-visible dashboard.** PHASE-0 execution conflicts,
   blocker answers, verdicts, and the tracking issue digest are readable from GitHub
   without opening the repo — the audit trail is where humans already look.
 - **Precedent for the delivery-channel split.** GitHub's own Copilot coding
@@ -354,13 +354,15 @@ architect-v5 and architect-v5.1 specs, and loop-improvements research
   the bypass where an orchestrator launched raw background builders with
   no watchdog armed and two jobs hung for 60-75 minutes undetected;
   fixture-pinned in the validator.
-- **PHASE 0: disagreement is mandatory.** Before building, every job states
-  its plan and every disagreement with the spec, citing real files — or what
-  it checked before finding none. Silent compliance is a job defect.
-  Rationale: prescriptive specs are followed literally by the builder-class
-  models, so spec errors are only caught *before* execution; PHASE 0 caught
-  a live orchestrator defect during the v5.1 run (§7). Every disagreement
-  gets an explicit ACCEPT/REJECT/MODIFY ruling.
+- **PHASE 0: execution conflicts are mandatory.** Before building, every job
+  states its plan and any execution conflict with the slice's spec, checks,
+  boundaries, or live dependencies, citing real files or command output — or
+  what it checked before finding none. Silent compliance with an impossible
+  slice is a job defect. Rationale: adversarial review catches pre-freeze
+  spec and decomposition failures, but builders run in the final slice
+  worktree and are the last defense against stale maps, dependency mismatches,
+  and boundary defects; PHASE 0 caught a live orchestrator defect during the
+  v5.1 run (§7). Every conflict gets an explicit ACCEPT/REJECT/MODIFY ruling.
 - **Raw evidence only; every status claim audited against tool output.**
   Builders report tables, numbers, and command output — no "promising", no
   verdicts. Anthropic's testing found status-audit instructions "nearly

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ report raw evidence only. See [DESIGN.md](DESIGN.md) for the evidence trail and
   freeze commit. Checks freeze in git before any builder exists.
 - The run manifest pins the tracking issue, tracker mode, factory branch, and
   spec path; every issue carries a run marker.
-- Builders run in fresh worktrees. They must state disagreements before coding,
-  must not commit, and must end with one raw `STATUS:` line.
+- Builders run in fresh worktrees. They must state execution conflicts before
+  coding, must not commit, and must end with one raw `STATUS:` line.
 - Wrapped CLI jobs write `job.meta.json`, `job.heartbeat`, `job.exit.json`,
   `events.jsonl`, and `stderr.log`; exit truth outranks terminal-looking report
   text. Postflight refuses to merge CLI job work without that wrapper exit

--- a/docs/spec/architect-fast.md
+++ b/docs/spec/architect-fast.md
@@ -52,7 +52,7 @@ and what replaces it (the substitution table in Implementation decisions).
    (hard stop, human ruling): the size ceiling.
 5. Factory loop: dispatch all ready issues as fresh worktree-isolated
    builders (same agent def, preloads, model resolution, never-commit rule,
-   PHASE-0 disagreements, raw-evidence reports). The builder block template
+   PHASE-0 execution conflicts, raw-evidence reports). The builder block template
    is reused with one named substitution: its frozen-checks section becomes
    acceptance criteria quoted from the issue body, graded by builder-run
    tests and the orchestrator review. At dispatch the orchestrator records

--- a/docs/spec/judge-narrowing-and-scout.md
+++ b/docs/spec/judge-narrowing-and-scout.md
@@ -77,7 +77,7 @@ the spec, the decomposition skeletons, and every builder.
   carry a compact change-skeleton grounded in the map: ≤~30 lines per issue
   of files, signatures, data flow, and invariants — structure only, no
   bodies. The skeleton is a contract, not a line-by-line mandate; PHASE 0
-  disagreement governs conflicts with reality. Decomposition computes the
+  execution-conflict checks govern conflicts with reality. Decomposition computes the
   parallel frontier from skeleton file-ownership so disjointness is proved
   before dispatch, not discovered as a merge conflict.
 - **G5 — Human-gated closing review.** After the last build issue closes and

--- a/skills/architect-fast/SKILL.md
+++ b/skills/architect-fast/SKILL.md
@@ -31,7 +31,7 @@ Unchanged from `/architect`: the tracking issue is the coordination log;
 builders are fresh, worktree-isolated, and never commit; the orchestrator
 owns commits, merges, and closure; tier is set at decomposition, never
 moved by a failure; the timed-ruling protocol times every human question
-and no approval gate exists anywhere; disagreement is mandatory at PHASE 0;
+and no approval gate exists anywhere; execution-conflict checks are mandatory at PHASE 0;
 no silent fallback — every precondition, blocker, and substitution is
 recorded.
 
@@ -76,7 +76,7 @@ recorded.
 
 4. **Factory loop.** Dispatch every ready issue as a fresh
    worktree-isolated builder — same agent def, preloads, model resolution,
-   never-commit rule, PHASE-0 disagreements, raw-evidence reports
+   never-commit rule, PHASE-0 execution conflicts, raw-evidence reports
    (`skills/architect/dispatch.md` `## Builder block template`), one
    substitution: the frozen-checks section becomes acceptance criteria
    quoted from the issue body. At dispatch, record each job's

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -43,8 +43,9 @@ invokes a peer. Mechanics: `dispatch.md` (templates, routing), `loop.md`
    Failure never moves builder tier.
 7. **Builders never commit.** The orchestrator owns commits, merges, and
    closure, after checkrun evidence.
-8. **Disagreement is mandatory.** PHASE 0 states the plan and every
-   disagreement with file evidence, or what was checked before finding none.
+8. **Execution-conflict check is mandatory.** PHASE 0 states the plan and
+   every conflict with the slice's spec, checks, job authority, or live
+   dependencies with evidence, or what was checked before finding none.
 9. **No silent fallback.** Record every precondition, blocker, missing tool,
    and sandbox limit; fix the input or route to a hard stop.
 

--- a/skills/architect/dispatch.md
+++ b/skills/architect/dispatch.md
@@ -318,7 +318,7 @@ normal. Builder comments on its own issue are exactly four kinds, never
 one per commit:
 
 ```bash
-gh issue comment <n> --body "PHASE 0: <disagreements, or what I checked>"
+gh issue comment <n> --body "PHASE 0: <execution conflicts, or what I checked>"
 gh issue comment <n> --body "BLOCKED: <exact blocker> + <what I tried>"
 gh issue comment <n> --body "MILESTONE: <what completed so far>"
 gh issue comment <n> --body "STATUS: <the report's exact status line>"
@@ -537,12 +537,15 @@ from the worktree root and rule on its typed exit before any other step: 0
 `FFCHECK: OK` proceed, 2 `FFCHECK: DIVERGED` stop and report, 5
 `FFCHECK: ERROR` stop and report.
 
-PHASE 0 - Before any code: reply with your plan and EVERY disagreement you have
-with this spec, with reasons, citing real files in this repo. Silent compliance
-is a failure. Silent scope additions are a failure. If you have no
-disagreements, state what you checked before concluding the spec is sound.
-Verify the named APIs/formats/versions against the live dependencies before
-planning around them.
+PHASE 0 - Before any code: reply with your plan and any execution conflict
+with this slice's spec, checks, boundaries, or live dependencies. Cite real
+repo file:line evidence or command output. Include nonexistent APIs,
+dependency/version mismatches, impossible check expectations, stale paths,
+and boundary conflicts. Silent compliance is a failure. Silent scope additions
+are a failure. If you find no conflicts, state what files, APIs, and commands
+you checked before concluding the slice is executable. Do not relitigate
+product/design preferences or add scope. Verify named APIs/formats/versions
+against the live dependencies before planning around them.
 
 PHASE 1 - The files under docs/checks/ are read-only at all times - editing
 them fails the slice regardless of results.

--- a/skills/architect/research.md
+++ b/skills/architect/research.md
@@ -74,5 +74,5 @@ OUTPUT FORMAT — a markdown report, ≤ ~2,500 tokens (~10 KB) total:
    strategist's dispatch context at intake, or the amended issue/check text
    during re-planning. Raw findings stay in `.architect/research/`
    (gitignored); only distilled, cited claims become repo memory.
-4. Builders' PHASE 0 is expected to challenge research claims like
-   anything else.
+4. Builders' PHASE 0 execution-conflict check is expected to challenge
+   research claims like anything else.

--- a/skills/codebase-design/SKILL.md
+++ b/skills/codebase-design/SKILL.md
@@ -51,7 +51,7 @@ file for frozen check. Consistent language is the whole point.
 - **Worktree** - the isolated git checkout a builder or reviewer works in, verified against the freeze commit.
 - **Job report** - a builder's raw-evidence artifact, ending in one STATUS line.
 - **Verdict** - the grading record posted on an issue at close: checkrun summary plus typed exit, postflight result, slice call, decisive reason; the closing review's run-level verdict goes on the tracking issue.
-- **Ruling** - an orchestrator decision recorded post-freeze: a PHASE-0 disagreement, boundary amendment, or respawn answer.
+- **Ruling** - an orchestrator decision recorded post-freeze: a PHASE-0 execution conflict, boundary amendment, or respawn answer.
 - **Digest** - the shipped-issues, diffstat, rulings, and domain-language summary handed to the integrate subagent's docs pass.
 - **Hard stop** - an irreversible or destructive action the loop refuses without a human ruling.
 


### PR DESCRIPTION
## Summary

- Reframes builder PHASE 0 from broad "disagreements" to evidence-backed execution conflicts.
- Updates the architect builder template, hard-rule summary, fast-lane docs, README, and glossary references.
- Keeps the last-defense check for stale paths, dependency/API mismatches, impossible checks, and job-authority conflicts while discouraging product/design relitigation.

## Validation

- `C:\Users\danhm\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe tests\validate_skills.py` -> `OK - 11 skills validated, v4 contracts clean`
- `git diff --check`